### PR TITLE
Viteプラグインでpackage.json読み込み機構の実装 (vibe-kanban)

### DIFF
--- a/app/src/routes/tags.($uuid).tsx
+++ b/app/src/routes/tags.($uuid).tsx
@@ -110,8 +110,8 @@ export default function TagsPage() {
     return (
       <Grid container spacing={2}>
         {allTags.map((tag) => (
-          <Gridkey={tag.id}>
-            //  xs={12} md={4} sm={6}
+          <Grid key={tag.id}>
+            {/*  xs={12} md={4} sm={6} */}
             <Card>
               <CardContent>
                 <Box display="flex" alignItems="center" gap={1} mb={2}>

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -6,6 +6,7 @@ import dts from 'vite-plugin-dts';
 import * as path from 'path';
 import { faviconPlugin } from './vite-plugin-favicon';
 import { comlink } from 'vite-plugin-comlink';
+import { vitePluginPackageReader } from '../scripts/vite-plugin-package-reader';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode, isSsrBuild }) => {
@@ -19,6 +20,10 @@ export default defineConfig(({ mode, isSsrBuild }) => {
   // プラグインのリストを作成
   const plugins = [
     // tildeResolver(),
+    vitePluginPackageReader({
+      rootDir: path.resolve(__dirname, '..'),
+      pluginPattern: /@hierarchidb\/node-type-.*-plugin$/
+    }),
     dts(),
     faviconPlugin(), // Add favicon plugin to serve favicon at root
     comlink(), // Add Comlink plugin for Worker support

--- a/scripts/vite-plugin-package-reader.ts
+++ b/scripts/vite-plugin-package-reader.ts
@@ -1,0 +1,158 @@
+import { Plugin } from 'vite';
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface PackageJsonContent {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  hierarchidb?: {
+    plugin?: any;
+  };
+}
+
+export interface PackageReaderOptions {
+  rootDir?: string;
+  pluginPattern?: RegExp;
+}
+
+export class PackageJsonReader {
+  private cache = new Map<string, PackageJsonContent>();
+  private rootDir: string;
+  private pluginPattern: RegExp;
+
+  constructor(options: PackageReaderOptions = {}) {
+    this.rootDir = options.rootDir || process.cwd();
+    this.pluginPattern = options.pluginPattern || /@hierarchidb\/node-type-.*-plugin$/;
+  }
+
+  /**
+   * アプリケーションのpackage.jsonを読み込む
+   */
+  async readAppPackageJson(): Promise<PackageJsonContent> {
+    const appPackageJsonPath = path.join(this.rootDir, 'app', 'package.json');
+    const content = await this.readPackageJson(appPackageJsonPath);
+    if (!content) {
+      throw new Error(`Failed to read app package.json from ${appPackageJsonPath}`);
+    }
+    return content;
+  }
+
+  /**
+   * プラグインパッケージを検出する
+   */
+  detectPluginPackages(dependencies: Record<string, string>): string[] {
+    const pluginPackages = Object.keys(dependencies)
+      .filter(name => this.pluginPattern.test(name))
+      .sort((a, b) => {
+        // folder-pluginを優先
+        if (a.includes('folder-plugin')) return -1;
+        if (b.includes('folder-plugin')) return 1;
+        return a.localeCompare(b);
+      });
+    
+    return pluginPackages;
+  }
+
+  /**
+   * プラグインのpackage.jsonを読み込む
+   */
+  async readPluginPackageJson(packageName: string): Promise<PackageJsonContent | null> {
+    // キャッシュチェック
+    if (this.cache.has(packageName)) {
+      return this.cache.get(packageName)!;
+    }
+
+    // node_modulesから探す
+    let packageJsonPath = path.join(this.rootDir, 'app', 'node_modules', packageName, 'package.json');
+    let content = await this.readPackageJson(packageJsonPath);
+
+    // モノレポ構造の場合
+    if (!content) {
+      const pluginType = packageName.replace('@hierarchidb/node-type-', '').replace('-plugin', '');
+      packageJsonPath = path.join(this.rootDir, 'packages', 'node-type', pluginType, 'package.json');
+      content = await this.readPackageJson(packageJsonPath);
+    }
+
+    if (content) {
+      this.cache.set(packageName, content);
+    } else {
+      console.warn(`[PackageReader] Could not find package.json for ${packageName}`);
+    }
+
+    return content;
+  }
+
+  /**
+   * すべてのプラグインpackage.jsonを読み込む
+   */
+  async readAllPluginPackages(): Promise<Map<string, PackageJsonContent>> {
+    console.log('[PackageReader] Reading plugin package.json files...');
+    
+    const appPackageJson = await this.readAppPackageJson();
+    const dependencies = appPackageJson.dependencies || {};
+    const pluginPackages = this.detectPluginPackages(dependencies);
+    
+    console.log(`[PackageReader] Found ${pluginPackages.length} plugin packages`);
+    
+    const results = new Map<string, PackageJsonContent>();
+    
+    for (const packageName of pluginPackages) {
+      const content = await this.readPluginPackageJson(packageName);
+      if (content) {
+        results.set(packageName, content);
+        console.log(`[PackageReader] Loaded ${packageName} v${content.version}`);
+      }
+    }
+    
+    return results;
+  }
+
+  /**
+   * package.jsonファイルを読み込む
+   */
+  private async readPackageJson(filePath: string): Promise<PackageJsonContent | null> {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return JSON.parse(content) as PackageJsonContent;
+    } catch (error) {
+      if ((error as any).code !== 'ENOENT') {
+        console.error(`[PackageReader] Error reading ${filePath}:`, error);
+      }
+      return null;
+    }
+  }
+
+  /**
+   * キャッシュを取得する
+   */
+  getCache(): Map<string, PackageJsonContent> {
+    return new Map(this.cache);
+  }
+}
+
+/**
+ * Viteプラグイン
+ */
+export function vitePluginPackageReader(options?: PackageReaderOptions): Plugin {
+  const reader = new PackageJsonReader(options);
+  let pluginPackages: Map<string, PackageJsonContent>;
+
+  return {
+    name: 'vite-plugin-package-reader',
+    
+    async buildStart() {
+      pluginPackages = await reader.readAllPluginPackages();
+    },
+    
+    // APIを公開
+    api: {
+      getReader(): PackageJsonReader {
+        return reader;
+      },
+      getPluginPackages(): Map<string, PackageJsonContent> {
+        return pluginPackages || new Map();
+      }
+    }
+  };
+}


### PR DESCRIPTION
ファイル: docs/tasks/task-1-package-json-reader.md

  # タスク1: Viteプラグインでpackage.json読み込み機構の実装

  ## 作業目標
  ビルド時にプラグインパッケージのpackage.jsonファイルを読み込む機構を実装する。この機構により、アプリケーションが依存するプラグインを自動的に検出し、その設定情報を取得できるようにする。

  ## 背景
  HierarchiDBのプラグインシステムでは、各プラグインはnpmパッケージとして配布される。これらのプラグインを手動で登録するのではなく、package.jsonのdependenciesから自動的に検出して読み込む必要がある
  。

  ## 実装要件

  ### 1. 作成するファイル
  `scripts/vite-plugin-package-reader.ts`を新規作成する。

  ### 2. 実装する機能

  #### PackageJsonReaderクラス
  以下の機能を持つクラスを実装する：

  1. **アプリケーションpackage.jsonの読み込み**
     - `app/package.json`を読み込む
     - dependenciesセクションを解析する

  2. **プラグインパッケージの検出**
     - パターン`@hierarchidb/node-type-*-plugin`に一致するパッケージを検出する
     - folder-pluginを優先的に処理するようソートする

  3. **プラグインpackage.jsonの読み込み**
     - 各プラグインのpackage.jsonを探索する
     - node_modulesディレクトリを最初に確認する
     - モノレポ構造の場合は`packages/node-type/`配下も確認する
     - 読み込んだ内容をキャッシュする

  #### Viteプラグイン関数
  以下の仕様でViteプラグインを実装する：

  1. **プラグイン名**: `vite-plugin-package-reader`
  2. **buildStartフック**: ビルド開始時にすべてのプラグインpackage.jsonを読み込む
  3. **APIの公開**: 他のViteプラグインから参照できるよう、以下のAPIを提供する
     - `getReader()`: PackageJsonReaderインスタンスを返す
     - `getPluginPackages()`: 読み込んだpackage.jsonのMapを返す

  ### 3. 実装コード

  ```typescript
  import { Plugin } from 'vite';
  import fs from 'fs/promises';
  import path from 'path';

  export interface PackageJsonContent {
    name: string;
    version: string;
    dependencies?: Record<string, string>;
    hierarchidb?: {
      plugin?: any;
    };
  }

  export interface PackageReaderOptions {
    rootDir?: string;
    pluginPattern?: RegExp;
  }

  export class PackageJsonReader {
    private cache = new Map<string, PackageJsonContent>();
    private rootDir: string;
    private pluginPattern: RegExp;

    constructor(options: PackageReaderOptions = {}) {
      this.rootDir = options.rootDir || process.cwd();
      this.pluginPattern = options.pluginPattern || /@hierarchidb\/node-type-.*-plugin$/;
    }

    // 実装内容...（詳細は仕様書参照）
  }

  export function vitePluginPackageReader(options?: PackageReaderOptions): Plugin {
    // 実装内容...（詳細は仕様書参照）
  }

設定手順

  1. Vite設定ファイルの更新

  app/vite.config.tsに以下の変更を加える：

  import { vitePluginPackageReader } from '../scripts/vite-plugin-package-reader';

  export default defineConfig({
    plugins: [
      vitePluginPackageReader({
        rootDir: process.cwd(),
        pluginPattern: /@hierarchidb\/node-type-.*-plugin$/
      }),
      // 既存のプラグイン設定は維持
    ],
  });

  動作確認項目

  必須確認事項

  1. ビルド実行時にコンソールに[PackageReader] Reading plugin package.json files...が表示される
  2. 検出されたプラグイン数が正しく表示される
  3. folder-pluginが最初に処理される

  エラー処理の確認

  1. 存在しないpackage.jsonへのアクセス時に警告が表示される
  2. 不正なJSON形式の場合にエラーがキャッチされる

  出力仕様

  PackageJsonContent型

  読み込まれたpackage.jsonは以下の型で保持される：
  - name: パッケージ名
  - version: バージョン番号
  - dependencies: 依存パッケージのマップ（オプション）
  - hierarchidb.plugin: プラグイン設定情報（オプション）

  読み込み結果

  Map<string, PackageJsonContent>形式で、キーはパッケージ名、値はpackage.json内容となる。

  注意事項

  1. ファイルシステムアクセス
    - このコードはNode.js環境（ビルド時）でのみ動作する
    - ブラウザ環境では実行されない
  2. キャッシュ管理
    - 同一ビルドセッション内では読み込み結果がキャッシュされる
    - ビルドを再実行すると新たに読み込まれる
  3. パス解決
    - モノレポとスタンドアロンの両方の構造に対応する必要がある
    - 相対パスは常にrootDirからの相対として解決される

  次のタスクへの引き継ぎ

  このタスクで作成したPackageJsonReaderクラスとその読み込み結果は、タスク2「package.jsonからPluginDefinition生成」で利用される。

