### PR TITLE
package.jsonからPluginDefinition生成 (vibe-kanban)

### DIFF
--- a/scripts/plugin-definition-builder.ts
+++ b/scripts/plugin-definition-builder.ts
@@ -1,0 +1,258 @@
+import type { 
+  PluginDefinition, 
+  NodeTypeIconDefinition,
+  CategoryDefinition,
+  PluginDatabaseConfig,
+  PluginUIConfig,
+  PluginAPIConfig,
+  PluginValidationConfig,
+  DatabaseSchema
+} from '../packages/common/types/src/plugin-definition';
+import type { NodeType } from '../packages/common/types/src/id-types';
+
+export interface PackageJsonContent {
+  name: string;
+  version: string;
+  hierarchidb?: {
+    plugin?: {
+      nodeType: string;
+      name?: string;
+      displayName?: string;
+      description?: string;
+      icon?: {
+        mui?: string;
+        emoji?: string;
+        color?: string;
+        svg?: string;
+        description?: string;
+      };
+      category?: {
+        treeId?: string;
+        menuGroup?: 'basic' | 'container' | 'document' | 'advanced';
+        createOrder?: number;
+      };
+      priority?: number;
+      database?: {
+        dbName?: string;
+        tableName?: string;
+        schema?: {
+          fields?: Array<{
+            name: string;
+            type: string;
+            indexed?: boolean;
+          }>;
+        };
+        version?: number;
+      };
+      ui?: {
+        dialogComponentPath?: string;
+        panelComponentPath?: string;
+        formComponentPath?: string;
+        iconComponentPath?: string;
+      };
+      api?: {
+        workerExtensions?: Record<string, unknown>;
+        clientExtensions?: Record<string, unknown>;
+      };
+      validation?: {
+        namePattern?: string;
+        maxChildren?: number;
+        allowedChildTypes?: string[];
+      };
+      extends?: string;
+      dependencies?: string[];
+    };
+  };
+}
+
+export class PluginDefinitionBuilder {
+  buildDefinition(packageName: string, packageJson: PackageJsonContent): PluginDefinition | null {
+    try {
+      const pluginConfig = packageJson.hierarchidb?.plugin;
+      
+      if (!pluginConfig) {
+        console.error(`Package ${packageName} does not have hierarchidb.plugin configuration`);
+        return null;
+      }
+      
+      if (!pluginConfig.nodeType) {
+        throw new Error(`Package ${packageName} has hierarchidb.plugin but missing required nodeType field`);
+      }
+      
+      const nodeType = this.validateNodeType(pluginConfig.nodeType);
+      
+      const definition: PluginDefinition = {
+        nodeType,
+        name: pluginConfig.name || packageName,
+        displayName: pluginConfig.displayName || pluginConfig.name || packageName,
+        description: pluginConfig.description,
+        version: packageJson.version,
+        
+        icon: this.buildIconDefinition(pluginConfig.icon),
+        category: this.buildCategoryDefinition(pluginConfig.category, pluginConfig.priority),
+        database: this.buildDatabaseConfig(pluginConfig, nodeType),
+        
+        ui: this.buildUIConfig(pluginConfig.ui),
+        api: this.buildAPIConfig(pluginConfig.api),
+        validation: this.buildValidationConfig(pluginConfig.validation),
+        
+        extends: pluginConfig.extends,
+        dependencies: this.buildDependencies(pluginConfig, nodeType),
+        priority: pluginConfig.priority || 1000
+      };
+      
+      return definition;
+      
+    } catch (error) {
+      console.error(`Failed to build PluginDefinition for ${packageName}:`, error);
+      return null;
+    }
+  }
+  
+  buildDefinitions(packages: Map<string, PackageJsonContent>): Map<NodeType, PluginDefinition> {
+    const definitions = new Map<NodeType, PluginDefinition>();
+    
+    packages.forEach((packageJson, packageName) => {
+      const definition = this.buildDefinition(packageName, packageJson);
+      
+      if (definition) {
+        definitions.set(definition.nodeType, definition);
+        console.log(`Generated plugin definition for ${packageName} (${definition.nodeType})`);
+      }
+    });
+    
+    console.log(`Generated ${definitions.size} plugin definitions`);
+    return definitions;
+  }
+  
+  private validateNodeType(nodeType: string): NodeType {
+    if (!nodeType || typeof nodeType !== 'string') {
+      throw new Error('Invalid nodeType: must be a non-empty string');
+    }
+    
+    return nodeType as NodeType;
+  }
+  
+  private buildIconDefinition(iconConfig: any): NodeTypeIconDefinition {
+    if (!iconConfig) {
+      return {
+        muiIconName: 'Extension',
+        emoji: '📦',
+        color: '#666666'
+      };
+    }
+    
+    return {
+      muiIconName: iconConfig.mui || 'Extension',
+      emoji: iconConfig.emoji || '📦',
+      color: iconConfig.color || '#666666',
+      svg: iconConfig.svg,
+      description: iconConfig.description
+    };
+  }
+  
+  private buildCategoryDefinition(
+    categoryConfig: any, 
+    priority?: number
+  ): CategoryDefinition {
+    const category: CategoryDefinition = {
+      treeId: (categoryConfig?.treeId || '*') as any,
+      menuGroup: categoryConfig?.menuGroup || 'basic',
+      createOrder: categoryConfig?.createOrder || priority || 1000
+    };
+    
+    return category;
+  }
+  
+  private buildDatabaseConfig(pluginConfig: any, nodeType: NodeType): PluginDatabaseConfig {
+    const dbConfig = pluginConfig.database || {};
+    const tableName = dbConfig.tableName || `${nodeType}s`.replace('-plugin', '');
+    
+    const schema: DatabaseSchema = {};
+    schema[tableName] = this.buildDatabaseSchema(dbConfig.schema);
+    
+    return {
+      dbName: dbConfig.dbName || 'CoreDB',
+      schema,
+      version: dbConfig.version || 1
+    };
+  }
+  
+  private buildDatabaseSchema(schemaConfig: any): string {
+    const indexedFields: string[] = ['&id', 'nodeId'];
+    
+    if (schemaConfig?.fields) {
+      for (const field of schemaConfig.fields) {
+        if (field.name === 'name') {
+          if (!indexedFields.includes('name')) {
+            indexedFields.push('name');
+          }
+        } else if (field.indexed) {
+          if (!indexedFields.includes(field.name)) {
+            indexedFields.push(field.name);
+          }
+        }
+      }
+    }
+    
+    const standardFields = ['createdAt', 'updatedAt', 'version'];
+    for (const field of standardFields) {
+      if (!indexedFields.includes(field)) {
+        indexedFields.push(field);
+      }
+    }
+    
+    return indexedFields.join(', ');
+  }
+  
+  private buildDependencies(pluginConfig: any, nodeType: NodeType): string[] {
+    const dependencies = pluginConfig.dependencies || [];
+    
+    // folder以外のプラグインには自動的にfolder依存を追加
+    if (nodeType !== ('folder' as NodeType) && 
+        nodeType !== ('folder-plugin' as NodeType) &&
+        !dependencies.includes('folder') &&
+        !dependencies.includes('folder-plugin')) {
+      dependencies.push('folder');
+    }
+    
+    return dependencies;
+  }
+  
+  private buildUIConfig(uiConfig: any): PluginUIConfig | undefined {
+    if (!uiConfig) {
+      return undefined;
+    }
+    
+    return {
+      dialogComponentPath: uiConfig.dialogComponentPath,
+      panelComponentPath: uiConfig.panelComponentPath,
+      formComponentPath: uiConfig.formComponentPath,
+      iconComponentPath: uiConfig.iconComponentPath
+    };
+  }
+  
+  private buildAPIConfig(apiConfig: any): PluginAPIConfig | undefined {
+    if (!apiConfig) {
+      return undefined;
+    }
+    
+    return {
+      workerExtensions: apiConfig.workerExtensions,
+      clientExtensions: apiConfig.clientExtensions
+    };
+  }
+  
+  private buildValidationConfig(validationConfig: any): PluginValidationConfig | undefined {
+    if (!validationConfig) {
+      return undefined;
+    }
+    
+    return {
+      namePattern: validationConfig.namePattern ? new RegExp(validationConfig.namePattern) : undefined,
+      maxChildren: validationConfig.maxChildren,
+      allowedChildTypes: validationConfig.allowedChildTypes?.map((type: string) => type as NodeType),
+      customValidators: validationConfig.customValidators
+    };
+  }
+}

--- a/scripts/test-plugin-definition-builder.ts
+++ b/scripts/test-plugin-definition-builder.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import { PluginDefinitionBuilder, type PackageJsonContent } from './plugin-definition-builder';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// テスト用のPackageJsonReaderの実装
+class MockPackageJsonReader {
+  async readAllPluginPackageJsons(): Promise<Map<string, PackageJsonContent>> {
+    const packages = new Map<string, PackageJsonContent>();
+    
+    // 実際のプラグインパッケージを読み込む
+    const pluginPackages = [
+      'folder-plugin',
+      'shape-plugin',
+      'location-plugin',
+      'basemap-plugin',
+      'project-plugin',
+      'route-plugin',
+      'propertyresolver-plugin',
+      'stylemap-plugin'
+    ];
+    
+    for (const pkg of pluginPackages) {
+      const packagePath = path.join(
+        process.cwd(),
+        '..',
+        'packages',
+        'node-type',
+        pkg,
+        'package.json'
+      );
+      
+      if (fs.existsSync(packagePath)) {
+        try {
+          const content = fs.readFileSync(packagePath, 'utf-8');
+          const packageJson = JSON.parse(content) as PackageJsonContent;
+          packages.set(`@hierarchidb/node-type-${pkg}`, packageJson);
+        } catch (error) {
+          console.error(`Failed to read ${packagePath}:`, error);
+        }
+      }
+    }
+    
+    return packages;
+  }
+}
+
+async function runTest() {
+  console.log('=== PluginDefinitionBuilder Test ===\n');
+  
+  // PackageJsonReaderのモック実装を使用
+  const reader = new MockPackageJsonReader();
+  const packages = await reader.readAllPluginPackageJsons();
+  
+  console.log(`Found ${packages.size} plugin packages\n`);
+  
+  // PluginDefinitionBuilderを使用
+  const builder = new PluginDefinitionBuilder();
+  const definitions = builder.buildDefinitions(packages);
+  
+  console.log(`\n=== Generated Plugin Definitions ===\n`);
+  
+  // 各プラグイン定義の詳細を表示
+  for (const [nodeType, definition] of definitions.entries()) {
+    console.log(`\n[${nodeType}]`);
+    console.log(`  Name: ${definition.name}`);
+    console.log(`  Display Name: ${definition.displayName}`);
+    console.log(`  Version: ${definition.version}`);
+    console.log(`  Priority: ${definition.priority}`);
+    
+    if (definition.icon) {
+      console.log(`  Icon:`);
+      console.log(`    - MUI: ${definition.icon.muiIconName}`);
+      console.log(`    - Emoji: ${definition.icon.emoji}`);
+      console.log(`    - Color: ${definition.icon.color}`);
+    }
+    
+    console.log(`  Category:`);
+    console.log(`    - TreeId: ${definition.category.treeId}`);
+    console.log(`    - Menu Group: ${definition.category.menuGroup}`);
+    console.log(`    - Create Order: ${definition.category.createOrder}`);
+    
+    console.log(`  Database:`);
+    console.log(`    - DB Name: ${definition.database.dbName}`);
+    console.log(`    - Schema: ${JSON.stringify(definition.database.schema)}`);
+    console.log(`    - Version: ${definition.database.version}`);
+    
+    console.log(`  Dependencies: ${definition.dependencies.join(', ') || '(none)'}`);
+    
+    if (definition.extends) {
+      console.log(`  Extends: ${definition.extends}`);
+    }
+    
+    if (definition.validation) {
+      console.log(`  Validation:`);
+      if (definition.validation.namePattern) {
+        console.log(`    - Name Pattern: ${definition.validation.namePattern}`);
+      }
+      if (definition.validation.maxChildren !== undefined) {
+        console.log(`    - Max Children: ${definition.validation.maxChildren}`);
+      }
+      if (definition.validation.allowedChildTypes) {
+        console.log(`    - Allowed Child Types: ${definition.validation.allowedChildTypes.join(', ')}`);
+      }
+    }
+  }
+  
+  // 検証結果
+  console.log('\n=== Validation Results ===\n');
+  
+  // 1. すべてのプラグインがPluginDefinitionに変換されたか
+  const convertedCount = definitions.size;
+  const expectedCount = packages.size;
+  console.log(`✓ Converted ${convertedCount}/${expectedCount} plugins`);
+  
+  // 2. folder以外のプラグインにfolder依存が追加されているか
+  let folderDependencyCheck = true;
+  for (const [nodeType, definition] of definitions.entries()) {
+    if (nodeType !== 'folder' as any && nodeType !== 'folder-plugin' as any) {
+      if (!definition.dependencies.includes('folder') && !definition.dependencies.includes('folder-plugin')) {
+        console.log(`✗ ${nodeType} is missing folder dependency`);
+        folderDependencyCheck = false;
+      }
+    }
+  }
+  if (folderDependencyCheck) {
+    console.log('✓ All non-folder plugins have folder dependency');
+  }
+  
+  // 3. 必須フィールドに既定値が設定されているか
+  let defaultValuesCheck = true;
+  for (const [nodeType, definition] of definitions.entries()) {
+    if (!definition.name || !definition.displayName || !definition.version) {
+      console.log(`✗ ${nodeType} is missing required fields`);
+      defaultValuesCheck = false;
+    }
+    if (!definition.icon || !definition.category || !definition.database) {
+      console.log(`✗ ${nodeType} is missing default configuration`);
+      defaultValuesCheck = false;
+    }
+  }
+  if (defaultValuesCheck) {
+    console.log('✓ All plugins have required fields and default values');
+  }
+  
+  // 4. データベーススキーマが正しく生成されているか
+  let schemaCheck = true;
+  for (const [nodeType, definition] of definitions.entries()) {
+    const schema = Object.values(definition.database.schema)[0];
+    if (!schema || !schema.includes('&id') || !schema.includes('nodeId')) {
+      console.log(`✗ ${nodeType} has invalid database schema: ${schema}`);
+      schemaCheck = false;
+    }
+  }
+  if (schemaCheck) {
+    console.log('✓ All plugins have valid database schemas');
+  }
+  
+  console.log('\n=== Test Complete ===');
+  
+  // 詳細なテスト結果を返す
+  return {
+    totalPackages: packages.size,
+    convertedCount: definitions.size,
+    hasAllDependencies: folderDependencyCheck,
+    hasAllDefaults: defaultValuesCheck,
+    hasValidSchemas: schemaCheck
+  };
+}
+
+runTest().catch(console.error);


### PR DESCRIPTION
### ファイル: `docs/tasks/task-2-plugin-definition-builder.md`

  ```markdown
  # タスク2: package.jsonからPluginDefinition生成

  ## 作業目標
  タスク1で読み込んだpackage.jsonの内容から、HierarchiDBのPluginDefinition型に準拠したオブジェクトを生成する機構を実装する。

  ## 背景
  各プラグインのpackage.jsonには`hierarchidb.plugin`フィールドにプラグイン設定が記述されている。この設定を正規化し、型安全なPluginDefinitionオブジェクトに変換する必要がある。

  ## 前提条件
  - タスク1のPackageJsonReaderが実装済みであること
  - `@hierarchidb/common-type`パッケージのPluginDefinition型が利用可能であること

  ## 実装要件

  ### 1. 作成するファイル
  `scripts/plugin-definition-builder.ts`を新規作成する。

  ### 2. 実装するクラス

  #### PluginDefinitionBuilderクラス
  以下のメソッドを実装する：

  ##### buildDefinition(packageName, packageJson)
  単一のpackage.jsonからPluginDefinitionを生成する。

  **処理内容：**
  1. hierarchidb.pluginフィールドの存在確認
  2. 必須フィールドの検証
  3. 各フィールドの変換と既定値の設定
  4. folder依存の自動追加（folder以外のプラグインの場合）

  ##### buildDefinitions(packages)
  複数のpackage.jsonからPluginDefinitionマップを生成する。

  **処理内容：**
  1. 各パッケージに対してbuildDefinitionを実行
  2. nodeTypeをキーとしたMapを構築
  3. 変換失敗したパッケージはスキップ

  ### 3. フィールド変換仕様

  #### 必須フィールド
  - `nodeType`: そのまま使用（検証必須）
  - `name`: pluginConfig.name || packageName
  - `displayName`: pluginConfig.displayName || pluginConfig.name
  - `version`: packageJson.version

  #### アイコン設定
  ```javascript
  icon: {
    muiIconName: iconConfig.mui || 'Extension',
    emoji: iconConfig.emoji || '📦',
    color: iconConfig.color || '#666666'
  }

  カテゴリ設定

  category: {
    treeId: categoryConfig?.treeId || '*',
    menuGroup: categoryConfig?.menuGroup || 'basic',
    createOrder: categoryConfig?.createOrder || priority || 1000
  }

  データベース設定

  database: {
    dbName: dbConfig.dbName || 'CoreDB',
    tableName: dbConfig.tableName || `${nodeType}s`,
    schema: // 後述のスキーマ生成ロジック,
    version: dbConfig.version || 1
  }

  依存関係

  - folder以外のプラグインには自動的に'folder'を依存に追加
  - 既存の依存関係は保持

  4. スキーマ生成ロジック

  入力（schema.fields配列）

  {
    "fields": [
      { "name": "name", "type": "string", "indexed": true },
      { "name": "description", "type": "string" }
    ]
  }

  出力（Dexieスキーマ文字列）

  "&id, nodeId, name, createdAt, updatedAt, version"

  生成規則：
  1. &idとnodeIdは必須
  2. nameフィールドがある場合は追加
  3. indexedがtrueのフィールドを追加
  4. 標準フィールド（createdAt, updatedAt, version）を追加

  5. エラー処理

  必須フィールド不足

  - nodeTypeが未定義の場合はエラーをスロー
  - その他の必須フィールドは既定値で補完

  変換失敗

  - エラーをconsole.errorに記録
  - nullを返して処理を継続

  実装コード構造

  import type { PluginDefinition, NodeType } from '@hierarchidb/common-type';
  import type { PackageJsonContent } from './vite-plugin-package-reader';

  export class PluginDefinitionBuilder {
    buildDefinition(packageName: string, packageJson: PackageJsonContent): PluginDefinition | null {
      // 実装
    }

    buildDefinitions(packages: Map<string, PackageJsonContent>): Map<NodeType, PluginDefinition> {
      // 実装
    }

    private validateNodeType(nodeType: string): NodeType {
      // 実装
    }

    private buildIconDefinition(iconConfig: any) {
      // 実装
    }

    private buildCategoryDefinition(categoryConfig: any, priority?: number) {
      // 実装
    }

    private buildDatabaseConfig(pluginConfig: any) {
      // 実装
    }

    private buildDatabaseSchema(schemaConfig: any): string {
      // 実装
    }

    private buildDependencies(pluginConfig: any): string[] {
      // 実装
    }

    private buildValidationConfig(validationConfig: any) {
      // 実装
    }
  }

  使用方法

  // タスク1の成果物を利用
  const reader = new PackageJsonReader();
  const packages = await reader.readAllPluginPackageJsons();

  // PluginDefinitionを生成
  const builder = new PluginDefinitionBuilder();
  const definitions = builder.buildDefinitions(packages);

  // 結果の確認
  console.log(`Generated ${definitions.size} plugin definitions`);

  動作確認項目

  必須確認事項

  1. すべてのプラグインパッケージがPluginDefinitionに変換される
  2. folder-plugin以外にfolder依存が自動追加される
  3. 必須フィールドに既定値が設定される

  型安全性の確認

  1. 生成されたオブジェクトがPluginDefinition型に準拠している
  2. TypeScriptコンパイルエラーが発生しない

  エラー処理の確認

  1. hierarchidb.pluginが存在しないパッケージがスキップされる
  2. 不正なnodeTypeでエラーが発生する

  次のタスクへの引き継ぎ

  このタスクで生成したMap<NodeType, PluginDefinition>は、タスク3「依存関係解析と初期化順序決定」で使用される。
