### PR TITLE
vibe-kanbanが期待する内容でのCleanup Scriptをプロジェクト全体に適用 (vibe-kanban)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "e2e": "turbo run e2e",
     "lint": "turbo run lint",
     "format": "turbo run format",
-    "clean": "turbo run clean && rm -rf node_modules",
+    "clean": "npx turbo run clean",
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "storybook:ui-core": "pnpm --filter @hierarchidb/ui-core storybook",


### PR DESCRIPTION
現状では次のようなエラーになり、タスクが正常に完了しなかったことになっている。

> hierarchidb@2.0.0 clean /private/var/folders/hw/tl0yhp05667b7zc_dr12kn_00000gn/T/vibe-kanban/worktrees/vk-a6b6-package-js
> turbo run clean && rm -rf node_modules

sh: turbo: command not found
 ELIFECYCLE  Command failed.
 WARN   Local package.json exists, but node_modules missing, did you mean to install?

vibe-kanbanでは終了時には何が期待されているのかを確認したいので教えてほしい。
node_moduleを削除するべきではないということ？

また、それはそれとして、turboのパスが通るように修正する必要がある。