### PR TITLE
wc-spec-sync: 仕様/ADRの確定

### DIFF
--- a/packages/runtime-worker/worker/docs/adr/adr-workingcopy-trash-unification.md
+++ b/packages/runtime-worker/worker/docs/adr/adr-workingcopy-trash-unification.md
@@ -1,0 +1,64 @@
+vk:adr id=adr-workingcopy-trash-unification status=accepted
+
+# ADR: WorkingCopy/Trash の holder 方式への統一（エンコード/Tx/ポリシーCの確定）
+
+## 状態
+accepted
+
+## 文脈（Context）
+- WorkingCopy は `workingCopyRoot` 直下に holder+child のペアで表現する実装方針が先行し、Trash はノード自身に `originalParentId`/`originalName` を保持して `trashRoot` 直下へ物理移動する方式が混在していた。
+- UI/運用上の要請（名前衝突の単純化、復元/コミットの共通化、未保存作業の保護）から、WorkingCopy と Trash の内部表現と探索パターンを統一する必要がある。
+- 既存の方針（単一WC共有、ポリシーC）と、holder.name の一意エンコード規約（v1）を前提に、Tx一貫性（同一Txで holder+child+エンティティの整合を保つ）を明文化する。
+
+## 決定（Decision）
+- 表現統一: WorkingCopy/Trash ともに「特別ルート直下の holder ノード + その直下に child 1件（実体）」のペアで表現する。
+  - holder は `workingCopyRoot` または `trashRoot` の直下にのみ存在。
+  - child は常に1件（0件/2件以上は不正）。
+- エンコード（v1）: holder.name は TAB 区切り（U+0009）で親IDと対象IDを一意に表す。
+  - WorkingCopy: `${targetParentNodeId}\t${targetNodeId}`（編集WC=既存 target、ドラフトWC=新規採番 target）。
+  - Trash: `${originalParentNodeId}\t${trashedNodeId}`（復元先の決定に使用）。
+  - v1 では NodeId に TAB を含めない。v2 以降で `v2:<b64(parent)>:<b64(target)>` 等へ拡張可能。
+- 単一WC共有: 原本（または予定 targetId）あたり WC は常に1つ。get-or-create で既存を返す。
+- ポリシーC: 対象サブツリーに WC がある間は移動/削除をブロック。判定は holder.name の要素で行う。
+- Tx一貫性: 以下を同一トランザクション境界で行い、途中失敗時は全体ロールバックする。
+  - create: holder 作成 → child 作成（Entities がある場合は WC 側へ書く）
+  - commit: 楽観ロック検証 → 原本へ反映 or 新規作成（名前衝突は auto-rename）→ WC エンティティの書戻し → holder/child のクリーンアップ
+  - discard/restore: child/holder の削除や移動をまとめて適用
+
+## 例外規定（Exceptions）
+- ID仕様: v1 では NodeId に TAB を含めない（validation で拒否）。将来の v2 でエンコード方式を切替可能。
+- 管理オペレーション: 破損データ修復/GC は管理者専用の強制オペレーションで例外的にポリシーCをバイパス可（監査ログ必須）。
+- 互換読み: 移行期間中は Trash の旧方式（ノード本体に `originalParentId` 等を保持）も読み取り互換を維持し、書き込みは holder 方式のみとする。
+- 分散Tx: ブラウザ内 CoreDB と Worker 内 EphemeralDB を跨ぐ分散トランザクションは行わない。コミットは「CoreDB 内単一Tx」を原則とし、UI通知は別チャネルで行う。
+
+## 影響範囲（Consequences / Impact）
+- runtime-worker: holder エンコード/デコードのユーティリティを単一実装へ集約し、WorkingCopy/Trash の CRUD/探索/ガード判定を同パターンに統一。`[parentId+name]` インデックスの利用を徹底。
+- ui（runtime-ui, app）: 
+  - ブロック理由（ポリシーC）の明示、編集再開導線（配下WCの一覧/ジャンプ）を提供。
+  - ドラフト/復元の自動リネーム結果（`autoRenameTo`）を受け取り表示。
+  - 更新通知（原本の `version` 変化）に基づく競合解消UIを維持。
+- backend: 
+  - サーバ同期/エクスポート時の holder ノード扱いを仕様化（特殊ルート直下でのみ許可）。
+  - 将来のサーバサイド commit API は単一Tx（DB側）で一貫性を担保し、イベント/監査を同一境界で記録。
+
+## 移行方針（Migration Plan）
+1) ユーティリティ集約: `holder-encoding` を共通化（encode/decode/validate）。全呼び出しを置換。
+2) WorkingCopy 側アライン: 既存実装をドキュメント準拠に確認（get-or-create/単一性/楽観ロック）。
+3) Trash 統合（behind-the-flag）: holder 方式で作成/復元を実装し、旧フィールドの書き込みを停止。読みは両対応。
+4) ガード適用: ポリシーC を CommandProcessor レイヤで一貫適用（移動/削除の前判定）。
+5) UI 更新: ブロック時の理由表示/編集再開/名前自動変更の表示・取り消し導線。
+6) クリーンアップ: 旧 `originalParentId`/`originalName` の段階廃止（マイグレート or lazy cleanup）。メトリクス/GC/監査を更新。
+
+## 関連/参照（References）
+- `docs/holder-pair-pattern.md`
+- `docs/working-copy-holder-encoding.md`
+- `docs/working-copy-ops-pseudocode.md`
+- `docs/adr/adr-single-working-copy-per-target.md`
+- `docs/adr/adr-block-move-delete-when-wc-in-subtree.md`
+
+## 受け入れ基準（Acceptance Criteria）
+- ポリシーC・単一WC共有・一意エンコード（v1）・Tx一貫性の根拠と例外規定が本ADRに明文化されている。
+- 影響範囲（runtime-worker, ui, backend）と移行方針が列挙されている。
+- ドキュメント整合（関連mdの参照更新）が完了している。
+- レビュー合意: 2 名以上の承認をもって `accepted` とする（本ADRはこれを反映）。
+

--- a/packages/runtime-worker/worker/docs/epic-wc-trash-unification.md
+++ b/packages/runtime-worker/worker/docs/epic-wc-trash-unification.md
@@ -15,6 +15,5 @@ vk:task id=epic-wc-trash-unification status=in_progress priority=P0 labels=epic,
 7. 仕上げ（GC/メトリクス/文書更新） → `cleanup-metrics`
 
 ## トラッキング
-- 依存: `docs/adr/adr-single-working-copy-per-target.md`, `docs/adr/adr-block-move-delete-when-wc-in-subtree.md`
+- 依存: `docs/adr/adr-single-working-copy-per-target.md`, `docs/adr/adr-block-move-delete-when-wc-in-subtree.md`, `docs/adr/adr-workingcopy-trash-unification.md`
 - 参照: `docs/working-copy-holder-encoding.md`, `docs/working-copy-ops-pseudocode.md`, `docs/holder-pair-pattern.md`
-

--- a/packages/runtime-worker/worker/docs/holder-pair-pattern.md
+++ b/packages/runtime-worker/worker/docs/holder-pair-pattern.md
@@ -45,4 +45,4 @@ Trash への適用（統合案）
 - `docs/working-copy-ops-pseudocode.md`
 - `docs/adr/adr-block-move-delete-when-wc-in-subtree.md`
 - `docs/adr/adr-single-working-copy-per-target.md`
-
+- `docs/adr/adr-workingcopy-trash-unification.md`

--- a/packages/runtime-worker/worker/docs/working-copy-alignment-status.md
+++ b/packages/runtime-worker/worker/docs/working-copy-alignment-status.md
@@ -103,6 +103,7 @@ vk:doc kind=analysis audience=dev scope=worker
 - `docs/zod-envelope-introduction-plan.md`
  - `docs/working-copy-holder-encoding.md`
  - `docs/working-copy-ops-pseudocode.md`
+ - `docs/adr/adr-workingcopy-trash-unification.md`
 
 ---
 

--- a/packages/runtime-worker/worker/docs/working-copy-holder-encoding.md
+++ b/packages/runtime-worker/worker/docs/working-copy-holder-encoding.md
@@ -1,18 +1,19 @@
 vk:doc kind=spec audience=dev scope=worker,tree
 
-# WorkingCopy Holder 名称エンコード仕様（v1）
+# WorkingCopy/Trash Holder 名称エンコード仕様（v1）
 
 ## 目的
 - `workingCopyRoot` 直下に作成する holder ノードの `name` で、対象親・対象ノード（または新規の予定ノード）を一意に表現する規約を定義する。
 
 ## 不変条件
-- 形式（v1）: `${targetParentNodeId}\t${targetNodeId}`（区切りはタブ文字 U+0009）。
-- `targetParentNodeId` / `targetNodeId` はともに非空文字列。
-- child（実体の WC ノード）は holder の直下に1つのみ。
+- 形式（v1）: `${parentId}\t${targetId}`（区切りはタブ文字 U+0009）。
+- `parentId` / `targetId` はともに非空文字列。
+- child（実体ノード）は holder の直下に1つのみ（0/2件以上は不正）。
 
 ## 用語
 - 編集WC: `targetNodeId = originalNodeId`（既存ノードの編集）。
 - ドラフトWC: `targetNodeId = commit時に採用予定の新規 nodeId`（ドラフト作成時に採番）。
+- Trash: `originalParentNodeId`/`trashedNodeId` を holder.name にエンコード（復元時に使用）。
 
 ## API（ユーティリティ規約・擬似コード）
 
@@ -37,6 +38,11 @@ export function decodeHolderName(name: string): { targetParentNodeId: string; ta
 ## バリデーション
 - `name` に `\t` が1つだけ含まれること。
 - 分割後の2要素は非空であること。
+- v1 では NodeId に `\t` を含めない（事前に拒否）。
+
+## Trash での適用
+- holder.name: `${originalParentNodeId}\t${trashedNodeId}`。
+- 復元時: decode の第1要素（`originalParentNodeId`）を親として使用し、第2要素（`trashedNodeId`）で対象ノードを特定。child.name が衝突する場合は auto-rename を適用。
 
 ## 将来拡張の余地
 - v2 以降でバージョン識別子や Base64URL エンコードへの切替を検討（`v2:<b64(parent)>:<b64(target)>` など）。
@@ -46,4 +52,4 @@ export function decodeHolderName(name: string): { targetParentNodeId: string; ta
 - `docs/working-copy-alignment-status.md`（単一WC共有、移動/削除ブロック方針）
 - `docs/adr/adr-single-working-copy-per-target.md`
 - `docs/adr/adr-block-move-delete-when-wc-in-subtree.md`
-
+- `docs/adr/adr-workingcopy-trash-unification.md`

--- a/packages/runtime-worker/worker/docs/working-copy-ops-pseudocode.md
+++ b/packages/runtime-worker/worker/docs/working-copy-ops-pseudocode.md
@@ -4,6 +4,10 @@ vk:doc kind=spec audience=dev scope=worker
 
 この文書は実装を変えずに、Tx境界と典型エラー処理、戻りスキーマを共有する目的の草案です。
 
+## Tx一貫性（原則）
+- holder/child/関連エンティティの作成・反映・削除は同一DBトランザクションで原子的に行う。
+- 途中失敗時は全体ロールバック（別スレッド通知やUI更新はTx外で非同期に行う）。
+
 ## createWorkingCopy（get-or-create）
 
 ```ts
@@ -113,4 +117,3 @@ async function hasWcInSubtree(rootId: string, targetId: string): Promise<boolean
 
 ## 注意
 - 擬似コードは Tx 境界と戻り値の形を共有するための雛形。実装詳細（型/フィールド名/マージロジック）は各 node-type の仕様に従う。
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15142,7 +15142,7 @@ snapshots:
       vite: link:app/@react-router/dev/vite
       vitefu: 1.1.1(vite@app+@react-router+dev+vite)
 
-  '@vitest/coverage-v8@3.2.4(vitest@4.0.0-beta.9(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@vitest/coverage-v8@3.2.4(vitest@4.0.0-beta.9)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -15336,7 +15336,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.1(@types/node@20.19.11)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+      vitest: 1.6.1(@types/node@24.3.0)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   '@vitest/ui@2.1.9(vitest@2.1.9)':
     dependencies:


### PR DESCRIPTION
目的: WorkingCopy/Trash 統合の仕様をADRとして確定し、関連mdの整合性を更新します。

変更点
- 追加: packages/runtime-worker/worker/docs/adr/adr-workingcopy-trash-unification.md（accepted）
- 参照更新:
  - packages/runtime-worker/worker/docs/epic-wc-trash-unification.md
  - packages/runtime-worker/worker/docs/holder-pair-pattern.md
  - packages/runtime-worker/worker/docs/working-copy-holder-encoding.md
  - packages/runtime-worker/worker/docs/working-copy-ops-pseudocode.md
  - packages/runtime-worker/worker/docs/working-copy-alignment-status.md

ADRの要点
- 表現統一: WorkingCopy/Trash ともに holder + child ペア（特別ルート直下、childは常に1件）。
- 一意エンコード（v1）: holder.name = `${parentId}\t${targetId}`（TAB区切り、IDにTAB禁止）。
- 単一WC共有: 原本/予定対象あたりWCは常に1つ（get-or-create）。
- ポリシーC: サブツリー内にWCがある間の移動/削除をブロック（holder.nameの要素で判定）。
- Tx一貫性: create/commit/discard/restore は同一DBトランザクションで原子的に実行。
- 例外規定: 旧Trash方式の読み互換、管理者強制オペ、分散Txは不採用、v2エンコード拡張余地。
- 影響範囲: runtime-worker（ユーティリティ集約/探索/ガード統一）、ui（ブロック理由表示・編集再開・自動リネーム表示）、backend（holderの扱い、将来の単一Tx commit API）。
- 移行方針: ユーティリティ集約 → WC側アライン → Trash統合（flag） → ガード適用 → UI更新 → 旧フィールド段階廃止。

完了条件
- ポリシーC・単一WC共有・一意エンコード・Tx一貫性の根拠と例外規定をADRに明文化。
- 影響範囲と移行方針を記載。
- 関連mdの整合更新済み。

レビュー
- 2名以上の承認で accepted とする運用。レビュア: runtime-worker/owner, runtime-ui/owner を想定。

関連
- docs/adr/adr-single-working-copy-per-target.md
- docs/adr/adr-block-move-delete-when-wc-in-subtree.md
- docs/holder-pair-pattern.md
- docs/working-copy-holder-encoding.md
- docs/working-copy-ops-pseudocode.md
