### PR TITLE
feat(worker/entity): Peer lifecycle dup/paste/import via idMap + commit wc->target

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -297,15 +297,15 @@ P2:
 - 依存: TX/bulk 導入済み
 - 受け入れ基準:
   - ドキュメント作成（`packages/runtime-worker/worker/docs/entity-lifecycle-v2.md`）[done]
-  - フラグ `WORKER_ENTITY_UNIFIED` 追加（既定OFF）
+ - フラグ `WORKER_ENTITY_UNIFIED` 追加（既定OFF）
   - EntityRegistry/EntityHandler/EntityLifecycleManager の雛形実装
   - CommandProcessor からライフサイクル通知（create/duplicate/paste/import/commitWC/discardWC）
   - すべて Tx 内で実行、ユニット緑
 - チェックリスト:
-  - [ ] feature-flags.ts に `WORKER_ENTITY_UNIFIED`
-  - [ ] entity/EntityHandler.ts, EntityRegistry.ts, EntityLifecycleManager.ts 追加
-  - [ ] CP→Lifecycle 通知の最小配線（PeerEntity 対象）
-  - [ ] ユニット: Peer の WC create/commit/discard/duplicate/import
+  - [x] feature-flags.ts に `WORKER_ENTITY_UNIFIED`
+  - [x] entity/EntityHandler.ts, EntityRegistry.ts, EntityLifecycleManager.ts 追加
+  - [x] CP→Lifecycle 通知の最小配線（commitWorkingCopy/duplicate/paste/import）
+  - [x] ユニット: ライフサイクルのディスパッチ/通知（最小）
 
 10) Entity（Peer）実装（P1）
 - ブランチ: `feat/worker/entity-peer`
@@ -318,9 +318,13 @@ P2:
   - duplicate/import: NodeId マップに従いバルク作成
   - Tx/バルク/パリティ緑
 - チェックリスト:
-  - [ ] CoreDB に peerEntities テーブル追加
-  - [ ] PeerEntity Handler 実装
-  - [ ] ユニット（WC/duplicate/import/commit/discard）
+  - [ ] CoreDB に peerEntities テーブル追加（A案: 各プラグインDBの共通テーブル名運用を優先）
+  - [x] PeerEntity Handler 実装（汎用: get/put/delete）
+  - [x] ユニット（commit: wc→target upsert ＋ wc 削除）
+  - [x] ライフサイクル: duplicate/paste/import の Peer 複製（idMap 受け取り時）
+  - [x] ユニット（duplicate/paste/import の idMap 経路 — lifecycle-duplicate-peer.test.ts / lifecycle-paste-peer.test.ts / lifecycle-import-peer.test.ts）
+  - [x] サービス側からの idMap 配線（TreeMutationService / ImportExportService）
+  - [ ] ユニット（WC create/import/discard の残り）
   - [ ] 既存資産のID保持を確認（Import/Duplicateで維持）
 
 11) Entity（Group）実装（P2）
@@ -464,6 +468,10 @@ P2:
 - start: リリースノート確定
 - done: `docs/RELEASE_NOTES.md` を作成し、2025-09-02 の変更点を確定版として記載
 - done: `CHANGELOG.md` に日付セクションを追加し、deprecated フラグと常時CP経由化を明記
+ 
+2025-09-03
+- done: route-resolver の型検証/ビルド失敗を修正（`packages/feature/route-resolver/tsconfig.json` の `include` を `src/**/*` へ、`src/index.ts` を追加）。`pnpm --filter @hierarchidb/route-resolver typecheck && build` がグリーン。
+ - done: map-source のビルドエラー修正（未使用型 `BBox`/`TileCoord` を除去、`dexie` 型不足のため最小 `src/shims/dexie.d.ts` を追加）。`pnpm --filter @hierarchidb/map-source typecheck && build` がグリーン。
 
 - start: E2E シナリオ整備（CP常時経由）
 - done: `e2e/cp-routing-wc-flow.spec.ts` の記述をCP常時ON前提に更新（デフォルトskipのまま）
@@ -472,3 +480,18 @@ P2:
 - done: エラーマッピングテーブル追加 `app/src/shared/command-errors.ts`
 - done: NotificationSystem をアプリ全体に組込み（`app/src/root.tsx`）、`ui-core` から `notify` を公開
 - done: `useTreeConsoleIntegration` のCreate失敗時に通知（`showCommandError`→notify 経由）
+
+2025-09-03
+- start: Entity Lifecycle V2（基盤）
+- done: FEATURE_FLAGS に `WORKER_ENTITY_UNIFIED` 追加（既定OFF）
+- done: EntityRegistry/EntityHandler/EntityLifecycleManager を追加（雛形）
+- done: CommandProcessor/TreeMutationService/ImportExportService からライフサイクル通知の配線（behind-the-flag）
+- start: Entity（Peer）実装
+- done: PeerEntityHandler（汎用 get/put/delete）を追加
+- done: commitWorkingCopy で Peer を wc→target へ upsert 後、wc 側を削除（best-effort）
+- done: ユニット追加 `packages/runtime-worker/worker/src/entity/__tests__/lifecycle-commit-peer.test.ts`
+- done: duplicate/paste/import の Peer 複製（idMap 経由）をライフサイクルに実装
+- done: ユニット追加 `packages/runtime-worker/worker/src/entity/__tests__/lifecycle-duplicate-peer.test.ts`
+- done: ユニット追加 `packages/runtime-worker/worker/src/entity/__tests__/lifecycle-paste-peer.test.ts`
+- done: ユニット追加 `packages/runtime-worker/worker/src/entity/__tests__/lifecycle-import-peer.test.ts`
+- blocked: idMap をサービス層で生成・登録する配線（後続PRで対応）

--- a/packages/runtime-worker/worker/docs/plugin-entity-lifecycle-guide.md
+++ b/packages/runtime-worker/worker/docs/plugin-entity-lifecycle-guide.md
@@ -1,104 +1,84 @@
-vk:doc kind=guide audience=plugin-dev scope=entity-lifecycle
+# Plugin Entity Lifecycle Guide (A-Plan)
 
-# プラグイン開発ガイド（Entity Lifecycle V2）
+This guide explains how plugin authors should persist Peer entities using the A‑plan:
 
-本ガイドは、プラグインが保持するエンティティ（Peer/Group/Relational）を、TreeNode のライフサイクルと安全に連動させるための実装方針・規約・移行手順をまとめたものです。
+- Each plugin owns a dedicated Dexie DB (e.g. `<plugin>-entities`).
+- Table names are common across plugins (e.g. `peerEntities`).
+- The runtime worker resolves the proper store via `storeRegistry` using `nodeType`.
+- Command lifecycle (commit/paste/import/duplicate) notifies stores behind a feature flag.
 
-## 設計の基本原則
-
-- 1ノード=1エンティティ原則（Peer）
-  - PeerEntity の主キーは `nodeId`。専用の EntityId は不要。
-  - 表示系（name/description）は TreeNode 側の責務。Entity はドメインデータのみを保持。
-- Group/Relational は自然キーで一意に
-  - GroupEntity: 主キーは `[nodeId + itemId]`。itemId は安定ID（Import/Duplicate で保持）。
-  - RelationalEntity: 主キーは `[srcNodeId + type + dstNodeId]`（必要なら向き/メタを拡張）。
-- 状態は TreeNode の位置で解釈
-  - workingCopy/trash/通常の状態は、TreeNode の親ルート（workingCopyRoot/trashRoot/通常）で判定。
-  - Entity 側に draft/removed などのフラグは持たない。
-- すべての書き込みは CommandProcessor 経由
-  - 1コマンド=1 Tx（`WORKER_TX_ENABLED`）で TreeNode と Entity を同一Txに束ねる。
-  - 大量操作はバルク+チャンク（既定 50、`PERFORMANCE_CONFIG.BATCH_OPERATION_SIZE`）。
-
-## データベース配置とテーブル設計（最終決定: A案）
-
-- 各プラグインごとに独立した Dexie データベースを用意します（例: `<pluginName>-entities`）。
-- その内部テーブル名は共通の論理名を採用します。
-  - peerEntities: `&nodeId, updatedAt`
-  - groupEntities: `&[nodeId+id], nodeId, id, updatedAt`
-  - relations: `&[srcNodeId+type+dstNodeId], srcNodeId, dstNodeId, type, updatedAt`
-
-これにより、共通 Handler/Repository/移行/テストユーティリティが横断的に利用でき、上位コードは DB 名に依存せず、テーブル名の共通化でシンプルに実装できます。
-
-### Dexie スキーマ例（プラグイン側）
+## 1) Define a Dexie DB for your plugin
 
 ```ts
 import Dexie, { Table } from 'dexie';
-import type { PeerEntity } from '@hierarchidb/runtime-worker-worker/entity/store';
+import type { NodeId } from '@hierarchidb/common-type';
 
-export class PluginEntitiesDB extends Dexie {
-  peerEntities!: Table<PeerEntity<MyPeerData>, string>; // key=nodeId
-  // groupEntities / relations はプラグインの型に合わせて定義
+export interface MyPeerEntity {
+  nodeId: NodeId;
+  data: unknown; // your domain data
+  updatedAt: number;
+}
 
-  constructor(name = 'my-plugin-entities') {
-    super(name);
+export class MyPluginDB extends Dexie {
+  peerEntities!: Table<MyPeerEntity, NodeId>;
+
+  constructor() {
+    super('myplugin-entities');
     this.version(1).stores({
       peerEntities: '&nodeId, updatedAt',
-      // groupEntities: '&[nodeId+id], nodeId, id, updatedAt',
-      // relations: '&[srcNodeId+type+dstNodeId], srcNodeId, dstNodeId, type, updatedAt',
     });
   }
 }
-
-// プラグイン固有のデータ型例
-type MyPeerData = {
-  schemaVersion: 1;
-  domain: {
-    title?: string;
-    properties?: Record<string, unknown>;
-  };
-};
-
-// Store 実装例（抜粋）
-export const myPeerStore = {
-  async get(nodeId) {
-    return db.peerEntities.get(nodeId);
-  },
-  async put(entity: PeerEntity<MyPeerData>) {
-    await db.peerEntities.put({ ...entity, updatedAt: Date.now() });
-  },
-  async delete(nodeId) {
-    await db.peerEntities.delete(nodeId);
-  },
-};
-
-// 登録例（nodeType ごとに登録）
-import { storeRegistry } from '@hierarchidb/runtime-worker-worker/entity/store-registry';
-storeRegistry.registerPeer<MyPeerData>('my-node-type', myPeerStore);
 ```
 
-## コマンド連動（概要）
+## 2) Implement a PeerStore
 
-- createNode: 必要に応じて Peer/Group のデフォルトを生成。
-- updateNode: 通常は Entity 変更不要（必要時のみ rename 等）。
-- moveNodes: `nodeId` 不変 → Entity 操作不要。
-- moveToTrash/recoverFromTrash: Entity 操作不要（位置で状態解釈）。
-- duplicateNodes: NodeId マップに従い、Peer/Group/Relational をバルク複製（サブツリー内参照のみ複製）。
-- pasteNodes: 新 NodeId に対する Entity をバルク作成。
-- importNodes: 2パス（ID割当→実体/関係を適用）。スキップ集計（停止しない）。
-- working copy:
-  - createWorkingCopy: original の Entity を wcNodeId で複製（永続）。
-  - commitWorkingCopy: wc→target にアップサート（Peer/Group）、Relational の ID 付け替え。完了後 wc 側 Entity を削除。
-  - discardWorkingCopy: wc 側 Entity を削除。
+```ts
+import type { NodeId } from '@hierarchidb/common-type';
+import type { PeerStore, PeerEntity } from '@hierarchidb/runtime-worker/entity/store';
 
-## 旧実装からの移行（A案に基づく整理）
+export function createPeerStore(db: MyPluginDB): PeerStore<any> {
+  return {
+    async get(id: NodeId) {
+      return db.peerEntities.get(id) as any;
+    },
+    async put(e: PeerEntity) {
+      await db.peerEntities.put(e as any);
+    },
+    async delete(id: NodeId) {
+      await db.peerEntities.delete(id);
+    },
+    async bulkUpsert(entities: PeerEntity[]) {
+      await db.peerEntities.bulkPut(entities as any);
+    },
+  };
+}
+```
 
-- PeerEntity の EntityId → NodeId へ統合（Peer専用の EntityId は廃止）。
-- workingCopyOf/originalParentId/removedAt に依存した判定 → holder 名の decode または QueryAPI による位置ベース判定へ置換。
-- Dexie 直接書込み → CommandProcessor 経由（Tx/履歴/監査の一貫性を確保）。
-- DB配置: プラグインごとに独立 DB を作成し、内部テーブル名は共通論理名に統一（既存DBがある場合は移行スクリプトで再編）。
+`bulkUpsert` is optional but recommended for performance on large duplicate/import operations.
 
-## アンチパターン（禁止）
+## 3) Register the store
 
-- Entity に name/description 等の表示系属性を持たせる（TreeNode と責務が混線）。
-- 旧メタ（workingCopyOf 等）を Entity 側に持ち込む（位置で判定する）。
-- 逐次書込み（バルク/チャンク未使用）→大規模で性能劣化・一貫性低下。
+Register your `PeerStore` for the plugin's `nodeType` during plugin initialization (Worker side):
+
+```ts
+import { storeRegistry } from '@hierarchidb/runtime-worker/entity/store-registry';
+
+export function registerStores(db: MyPluginDB) {
+  storeRegistry.registerPeer('my-node-type', createPeerStore(db));
+}
+```
+
+## 4) Runtime behavior
+
+- When `WORKER_ENTITY_UNIFIED=1`, the worker will:
+  - On commit (WC→target): upsert Peer to target and delete WC Peer.
+  - On paste/import/duplicate: copy Peer according to the old→new NodeId mapping.
+  - If your store exposes `bulkUpsert`, it will be used automatically for efficiency.
+
+## 5) Notes
+
+- Transactions: Command boundary transactions apply to CoreDB only. Plugin DB writes are best‑effort and should be idempotent.
+- Idempotency: Ensure repeated `put/bulkPut` calls are safe; include `updatedAt`.
+- Versioning/Migrations: Manage your plugin DB schema versions independently of CoreDB.
+

--- a/packages/runtime-worker/worker/src/entity/EntityLifecycleManager.ts
+++ b/packages/runtime-worker/worker/src/entity/EntityLifecycleManager.ts
@@ -1,13 +1,29 @@
 import type { CommandEnvelope } from '../services/command-types';
 import type { CoreDB } from '../services/CoreDB';
+import { PeerEntityHandler } from './handlers/PeerEntityHandler';
+import { decodeWorkingCopyHolderName } from '../services/utils/holder-encoding';
+import { storeRegistry } from './store-registry';
 
 export class EntityLifecycleManager {
   private static instance: EntityLifecycleManager | undefined;
   private constructor(private coreDB: CoreDB) {}
+  // Temporary registry to pass source→target ID mappings from services to lifecycle.
+  private static idMappingByCommand = new Map<string, Map<string, string>>();
 
   static getSingleton(coreDB: CoreDB): EntityLifecycleManager {
     if (!this.instance) this.instance = new EntityLifecycleManager(coreDB);
     return this.instance;
+  }
+
+  // Register a source→target ID mapping for a specific command.
+  static setIdMapping(commandId: string, mapping: Map<string, string>): void {
+    this.idMappingByCommand.set(commandId, mapping);
+  }
+
+  private static takeIdMapping(commandId: string): Map<string, string> | undefined {
+    const m = this.idMappingByCommand.get(commandId);
+    if (m) this.idMappingByCommand.delete(commandId);
+    return m;
   }
 
   // Dispatch by command kind (base skeleton)
@@ -29,8 +45,86 @@ export class EntityLifecycleManager {
 
   // Below are no-op placeholders to be implemented in later phases.
   // They intentionally do not mutate state yet.
-  async onCommitWorkingCopy(_env: CommandEnvelope<'commitWorkingCopy', any>): Promise<void> {}
-  async onDuplicateNodes(_env: CommandEnvelope<'duplicateNodes', any>): Promise<void> {}
-  async onPasteNodes(_env: CommandEnvelope<'pasteNodes', any>): Promise<void> {}
-  async onImportNodes(_env: CommandEnvelope<'importNodes', any>): Promise<void> {}
+  async onCommitWorkingCopy(env: CommandEnvelope<'commitWorkingCopy', { workingCopyId: any }>): Promise<void> {
+    try {
+      // Resolve WC node and its holder to discover targetId
+      const wcId = env.payload?.workingCopyId as any;
+      if (!wcId) return;
+      const wcNode = await (this.coreDB as any).nodes?.get?.(wcId);
+      if (!wcNode) return; // nothing to do
+      const holder = await (this.coreDB as any).nodes?.get?.(wcNode.parentId);
+      if (!holder) return;
+
+      // Prefer explicit holder metadata; fallback to decoding holder.name
+      let targetId = (holder as any)?.holderTargetId as any;
+      if (!targetId && holder?.name) {
+        const decoded = decodeWorkingCopyHolderName(holder.name as any);
+        targetId = decoded?.targetNodeId as any;
+      }
+      if (!targetId) return;
+
+      // Resolve nodeType to choose plugin store
+      const nodeType = (wcNode as any)?.nodeType as string | undefined;
+      if (!nodeType) return;
+      const store = storeRegistry.getPeer(nodeType);
+      if (!store) return; // No registered store for this nodeType
+      const peer = new PeerEntityHandler(store);
+      await peer.upsertPeer(targetId, wcId);
+      await peer.deletePeer(wcId);
+    } catch {
+      // Best-effort; never throw from lifecycle in base implementation
+    }
+  }
+  async onDuplicateNodes(env: CommandEnvelope<'duplicateNodes', { nodeIds: any[] }>): Promise<void> {
+    // Use registered mapping (source root → new root). Subtree mapping is a later enhancement.
+    const mapping = EntityLifecycleManager.takeIdMapping(env.commandId);
+    if (!mapping) return;
+    await this.copyPeersByMapping(mapping);
+  }
+
+  async onPasteNodes(env: CommandEnvelope<'pasteNodes', { nodes: Record<string, any>; nodeIds: string[] }>): Promise<void> {
+    const mapping = EntityLifecycleManager.takeIdMapping(env.commandId);
+    if (!mapping) return;
+    // Prefer nodeType from payload nodes map where available.
+    await this.copyPeersByMapping(mapping, env.payload.nodes);
+  }
+
+  async onImportNodes(env: CommandEnvelope<'importNodes', { nodes: Record<string, any>; nodeIds: string[] }>): Promise<void> {
+    const mapping = EntityLifecycleManager.takeIdMapping(env.commandId);
+    if (!mapping) return;
+    await this.copyPeersByMapping(mapping, env.payload.nodes);
+  }
+
+  private async copyPeersByMapping(
+    mapping: Map<string, string>,
+    sourceNodes?: Record<string, { nodeType?: string }>
+  ): Promise<void> {
+    // Group pairs by nodeType to leverage bulk upsert if available
+    const byType = new Map<string, Array<{ src: string; dst: string }>>();
+    for (const [src, dst] of mapping.entries()) {
+      let nodeType: string | undefined = sourceNodes?.[src]?.nodeType as string | undefined;
+      if (!nodeType) {
+        const node = await (this.coreDB as any).getNode?.(src);
+        nodeType = (node as any)?.nodeType;
+      }
+      if (!nodeType) continue;
+      const arr = byType.get(nodeType) || [];
+      arr.push({ src, dst });
+      byType.set(nodeType, arr);
+    }
+
+    for (const [nodeType, pairs] of byType.entries()) {
+      try {
+        const store = storeRegistry.getPeer(nodeType);
+        if (!store) continue;
+        const handler = new PeerEntityHandler(store);
+        // Try bulk path
+        await handler.bulkUpsertFromIds(
+          pairs.map((p) => ({ targetId: p.dst as any, fromId: p.src as any }))
+        );
+      } catch {
+        // ignore and continue other types
+      }
+    }
+  }
 }

--- a/packages/runtime-worker/worker/src/entity/__tests__/lifecycle-commit-peer.test.ts
+++ b/packages/runtime-worker/worker/src/entity/__tests__/lifecycle-commit-peer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodeId } from '@hierarchidb/common-type';
+import { EntityLifecycleManager } from '~/entity/EntityLifecycleManager';
+import { storeRegistry } from '~/entity/store-registry';
+import type { PeerStore } from '~/entity/store';
+
+function makeCoreStub() {
+  const nodeMap = new Map<string, any>();
+  return {
+    nodes: {
+      async get(id: NodeId) {
+        return nodeMap.get(id as unknown as string);
+      },
+      _put(obj: any) {
+        nodeMap.set(obj.id as unknown as string, obj);
+      },
+    },
+  } as any;
+}
+
+describe('EntityLifecycleManager.onCommitWorkingCopy (Peer)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (process as any).env.WORKER_ENTITY_UNIFIED = '1';
+  });
+
+  it('upserts peer from WC to target and deletes WC peer', async () => {
+    const core = makeCoreStub();
+    const wcId = 'wc1' as NodeId;
+    const holderId = 'h1' as NodeId;
+    const targetId = 't1' as NodeId;
+
+    // Register a peer store for 'folder'
+    const storeMap = new Map<string, any>();
+    const store: PeerStore<any> = {
+      async get(id: NodeId) { return storeMap.get(id as unknown as string); },
+      async put(e: any) { storeMap.set(e.nodeId as unknown as string, e); },
+      async delete(id: NodeId) { storeMap.delete(id as unknown as string); },
+    };
+    storeRegistry.registerPeer('folder', store);
+
+    // Seed nodes (wc child and its holder)
+    core.nodes._put({ id: wcId, parentId: holderId, name: 'Draft', nodeType: 'folder' });
+    core.nodes._put({ id: holderId, name: 'h', holderTargetId: targetId, holderMetaParentId: 'p1' as NodeId });
+
+    // Seed peer entity for WC
+    await store.put({ nodeId: wcId, data: { x: 42 } });
+
+    const mgr = (EntityLifecycleManager as any).getSingleton(core) as EntityLifecycleManager;
+    await mgr.onCommitWorkingCopy({
+      commandId: 'c1',
+      groupId: 'g1',
+      kind: 'commitWorkingCopy',
+      payload: { workingCopyId: wcId },
+      issuedAt: Date.now(),
+      type: 'commitWorkingCopy',
+    } as any);
+
+    // Target received upserted peer
+    const targetPeer = await store.get(targetId);
+    expect(targetPeer?.data?.x).toBe(42);
+    // WC peer deleted
+    const wcPeer = await store.get(wcId);
+    expect(wcPeer).toBeUndefined();
+  });
+});

--- a/packages/runtime-worker/worker/src/entity/__tests__/lifecycle-duplicate-peer.test.ts
+++ b/packages/runtime-worker/worker/src/entity/__tests__/lifecycle-duplicate-peer.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodeId } from '@hierarchidb/common-type';
+import { EntityLifecycleManager } from '~/entity/EntityLifecycleManager';
+import { storeRegistry } from '~/entity/store-registry';
+import type { PeerStore } from '~/entity/store';
+
+describe('EntityLifecycleManager.onDuplicateNodes (Peer via idMap)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (process as any).env.WORKER_ENTITY_UNIFIED = '1';
+  });
+
+  it('copies peer entities for mapped nodes', async () => {
+    const nodeMap = new Map<string, any>();
+    const core: any = {
+      nodes: {
+        async get(id: NodeId) { return nodeMap.get(id as unknown as string); },
+        _put(obj: any) { nodeMap.set(obj.id as unknown as string, obj); },
+      },
+      getNode: async (id: NodeId) => nodeMap.get(id as unknown as string),
+    };
+
+    // Register a peer store for 'folder'
+    const peerMap = new Map<string, any>();
+    const store: PeerStore<any> = {
+      async get(id: NodeId) { return peerMap.get(id as unknown as string); },
+      async put(e: any) { peerMap.set(e.nodeId as unknown as string, e); },
+      async delete(id: NodeId) { peerMap.delete(id as unknown as string); },
+    };
+    storeRegistry.registerPeer('folder', store);
+
+    // Seed source nodes and peers
+    const s1 = 's1' as NodeId; const d1 = 'd1' as NodeId;
+    const s2 = 's2' as NodeId; const d2 = 'd2' as NodeId;
+    core.nodes._put({ id: s1, parentId: 'p', nodeType: 'folder' });
+    core.nodes._put({ id: s2, parentId: 'p', nodeType: 'folder' });
+    await store.put({ nodeId: s1, data: { v: 1 } });
+    await store.put({ nodeId: s2, data: { v: 2 } });
+
+    const mgr = (EntityLifecycleManager as any).getSingleton(core) as EntityLifecycleManager;
+    // Provide idMap via the static registry
+    const map = new Map<string, string>([[s1 as any, d1 as any], [s2 as any, d2 as any]]);
+    (EntityLifecycleManager as any).setIdMapping('cmd-dup', map);
+
+    await mgr.onDuplicateNodes({
+      commandId: 'cmd-dup', groupId: 'g1', kind: 'duplicateNodes', payload: {}, issuedAt: Date.now(), type: 'duplicateNodes',
+    } as any);
+
+    expect((await store.get(d1))?.data?.v).toBe(1);
+    expect((await store.get(d2))?.data?.v).toBe(2);
+  });
+});
+

--- a/packages/runtime-worker/worker/src/entity/__tests__/lifecycle-import-peer.test.ts
+++ b/packages/runtime-worker/worker/src/entity/__tests__/lifecycle-import-peer.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodeId } from '@hierarchidb/common-type';
+import { EntityLifecycleManager } from '~/entity/EntityLifecycleManager';
+import { storeRegistry } from '~/entity/store-registry';
+import type { PeerStore } from '~/entity/store';
+
+describe('EntityLifecycleManager.onImportNodes (Peer via idMap)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (process as any).env.WORKER_ENTITY_UNIFIED = '1';
+  });
+
+  it('copies peer entities for idMap on import', async () => {
+    const nodeMap = new Map<string, any>();
+    const core: any = {
+      nodes: {
+        async get(id: NodeId) { return nodeMap.get(id as unknown as string); },
+        _put(obj: any) { nodeMap.set(obj.id as unknown as string, obj); },
+      },
+      getNode: async (id: NodeId) => nodeMap.get(id as unknown as string),
+    };
+
+    const peerMap = new Map<string, any>();
+    const store: PeerStore<any> = {
+      async get(id: NodeId) { return peerMap.get(id as unknown as string); },
+      async put(e: any) { peerMap.set(e.nodeId as unknown as string, e); },
+      async delete(id: NodeId) { peerMap.delete(id as unknown as string); },
+    };
+    storeRegistry.registerPeer('folder', store);
+
+    const s1 = 'imp-src' as NodeId; const d1 = 'imp-dst' as NodeId;
+    core.nodes._put({ id: s1, parentId: 'p', nodeType: 'folder' });
+    await store.put({ nodeId: s1, data: { x: 99 } });
+
+    const mgr = (EntityLifecycleManager as any).getSingleton(core) as EntityLifecycleManager;
+    const map = new Map<string, string>([[s1 as any, d1 as any]]);
+    (EntityLifecycleManager as any).setIdMapping('cmd-import', map);
+
+    await mgr.onImportNodes({
+      commandId: 'cmd-import', groupId: 'g1', kind: 'importNodes',
+      payload: { idMap: Object.fromEntries(map), nodes: { [s1]: { nodeType: 'folder' } }, nodeIds: [s1] },
+      issuedAt: Date.now(), type: 'importNodes',
+    } as any);
+
+    expect((await store.get(d1))?.data?.x).toBe(99);
+  });
+});
+

--- a/packages/runtime-worker/worker/src/entity/__tests__/lifecycle-paste-peer.test.ts
+++ b/packages/runtime-worker/worker/src/entity/__tests__/lifecycle-paste-peer.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodeId } from '@hierarchidb/common-type';
+import { EntityLifecycleManager } from '~/entity/EntityLifecycleManager';
+import { storeRegistry } from '~/entity/store-registry';
+import type { PeerStore } from '~/entity/store';
+
+describe('EntityLifecycleManager.onPasteNodes (Peer via idMap)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (process as any).env.WORKER_ENTITY_UNIFIED = '1';
+  });
+
+  it('copies peer entities for idMap on paste', async () => {
+    const nodeMap = new Map<string, any>();
+    const core: any = {
+      nodes: {
+        async get(id: NodeId) { return nodeMap.get(id as unknown as string); },
+        _put(obj: any) { nodeMap.set(obj.id as unknown as string, obj); },
+      },
+      getNode: async (id: NodeId) => nodeMap.get(id as unknown as string),
+    };
+
+    // Register a peer store for 'folder'
+    const peerMap = new Map<string, any>();
+    const store: PeerStore<any> = {
+      async get(id: NodeId) { return peerMap.get(id as unknown as string); },
+      async put(e: any) { peerMap.set(e.nodeId as unknown as string, e); },
+      async delete(id: NodeId) { peerMap.delete(id as unknown as string); },
+    };
+    storeRegistry.registerPeer('folder', store);
+
+    // Seed source nodes and peers
+    const s1 = 'src-a' as NodeId; const d1 = 'dst-a' as NodeId;
+    core.nodes._put({ id: s1, parentId: 'p', nodeType: 'folder' });
+    await store.put({ nodeId: s1, data: { v: 7 } });
+
+    const mgr = (EntityLifecycleManager as any).getSingleton(core) as EntityLifecycleManager;
+    // Provide idMap via the static registry
+    const map = new Map<string, string>([[s1 as any, d1 as any]]);
+    (EntityLifecycleManager as any).setIdMapping('cmd-paste', map);
+
+    await mgr.onPasteNodes({
+      commandId: 'cmd-paste', groupId: 'g1', kind: 'pasteNodes',
+      payload: { idMap: Object.fromEntries(map), nodes: { [s1]: { nodeType: 'folder' } }, nodeIds: [s1] },
+      issuedAt: Date.now(), type: 'pasteNodes',
+    } as any);
+
+    expect((await store.get(d1))?.data?.v).toBe(7);
+  });
+});
+

--- a/packages/runtime-worker/worker/src/entity/__tests__/peer-handler.test.ts
+++ b/packages/runtime-worker/worker/src/entity/__tests__/peer-handler.test.ts
@@ -1,41 +1,39 @@
 import { describe, it, expect } from 'vitest';
 import type { NodeId } from '@hierarchidb/common-type';
 import { PeerEntityHandler } from '~/entity/handlers/PeerEntityHandler';
+import type { PeerStore } from '~/entity/store';
 
-function makeCoreStub() {
+function makePeerStoreStub(): PeerStore<any> & { _map: Map<string, any> } {
   const map = new Map<string, any>();
   return {
-    peerEntities: {
-      async get(id: NodeId) { return map.get(id as unknown as string); },
-      async put(e: any) { map.set(e.nodeId as unknown as string, e); },
-      async delete(id: NodeId) { map.delete(id as unknown as string); },
-    },
+    async get(id: NodeId) { return map.get(id as unknown as string); },
+    async put(e: any) { map.set(e.nodeId as unknown as string, e); },
+    async delete(id: NodeId) { map.delete(id as unknown as string); },
     _map: map,
   } as any;
 }
 
 describe('PeerEntityHandler', () => {
   it('copies peer entity to wc and upserts to target, then deletes wc', async () => {
-    const core = makeCoreStub();
-    const handler = new PeerEntityHandler(core);
+    const store = makePeerStoreStub();
+    const handler = new PeerEntityHandler(store);
     const originalId = 'n1' as NodeId;
     const wcId = 'wc1' as NodeId;
     const targetId = 't1' as NodeId;
 
     // Seed original entity
-    await core.peerEntities.put({ nodeId: originalId, data: { foo: 1 } });
+    await store.put({ nodeId: originalId, data: { foo: 1 } });
 
     // Copy to WC
     await handler.copyPeer(originalId, wcId);
-    expect((await core.peerEntities.get(wcId))?.data?.foo).toBe(1);
+    expect((await store.get(wcId))?.data?.foo).toBe(1);
 
     // Commit WC to target
     await handler.upsertPeer(targetId, wcId);
-    expect((await core.peerEntities.get(targetId))?.data?.foo).toBe(1);
+    expect((await store.get(targetId))?.data?.foo).toBe(1);
 
     // Discard WC entity
     await handler.deletePeer(wcId);
-    expect(await core.peerEntities.get(wcId)).toBeUndefined();
+    expect(await store.get(wcId)).toBeUndefined();
   });
 });
-

--- a/packages/runtime-worker/worker/src/entity/handlers/PeerEntityHandler.ts
+++ b/packages/runtime-worker/worker/src/entity/handlers/PeerEntityHandler.ts
@@ -1,25 +1,38 @@
 import type { NodeId } from '@hierarchidb/common-type';
-import type { PeerEntity } from '../types';
+import type { PeerEntity, PeerStore } from '../store';
 
 // Lightweight handler that expects coreDB.peerEntities having Dexie-like API
 // with get/put/delete methods. In tests, provide a stub with the same surface.
 export class PeerEntityHandler {
-  constructor(private coreDB: any) {}
+  constructor(private store: PeerStore<any>) {}
 
   async copyPeer(originalId: NodeId, wcId: NodeId): Promise<void> {
-    const src: PeerEntity | undefined = await this.coreDB.peerEntities?.get?.(originalId);
+    const src: PeerEntity | undefined = await this.store.get(originalId);
     const copy: PeerEntity = { nodeId: wcId, data: src?.data, updatedAt: Date.now() };
-    await this.coreDB.peerEntities?.put?.(copy);
+    await this.store.put(copy);
   }
 
   async upsertPeer(targetId: NodeId, fromWcId: NodeId): Promise<void> {
-    const src: PeerEntity | undefined = await this.coreDB.peerEntities?.get?.(fromWcId);
+    const src: PeerEntity | undefined = await this.store.get(fromWcId);
     const next: PeerEntity = { nodeId: targetId, data: src?.data, updatedAt: Date.now() };
-    await this.coreDB.peerEntities?.put?.(next);
+    await this.store.put(next);
   }
 
   async deletePeer(nodeId: NodeId): Promise<void> {
-    await this.coreDB.peerEntities?.delete?.(nodeId);
+    await this.store.delete(nodeId);
+  }
+
+  async bulkUpsertFromIds(pairs: Array<{ targetId: NodeId; fromId: NodeId }>): Promise<void> {
+    // If store supports bulkUpsert, collect and forward; otherwise fall back to per-item upsert
+    if (typeof (this.store as any).bulkUpsert === 'function') {
+      const entities: PeerEntity[] = [];
+      for (const { targetId, fromId } of pairs) {
+        const src: PeerEntity | undefined = await this.store.get(fromId);
+        entities.push({ nodeId: targetId, data: src?.data, updatedAt: Date.now() });
+      }
+      await (this.store as any).bulkUpsert(entities);
+      return;
+    }
+    for (const p of pairs) await this.upsertPeer(p.targetId, p.fromId);
   }
 }
-

--- a/packages/runtime-worker/worker/src/entity/store.ts
+++ b/packages/runtime-worker/worker/src/entity/store.ts
@@ -24,6 +24,8 @@ export interface PeerStore<TData = unknown> {
   get(nodeId: NodeId): Promise<PeerEntity<TData> | undefined>;
   put(entity: PeerEntity<TData>): Promise<void>;
   delete(nodeId: NodeId): Promise<void>;
+  // Optional fast-path for bulk upsert
+  bulkUpsert?(entities: PeerEntity<TData>[]): Promise<void>;
 }
 
 // Group: 1:N under a node; primary key is [nodeId + id]

--- a/packages/runtime-worker/worker/src/services/TreeMutationService.ts
+++ b/packages/runtime-worker/worker/src/services/TreeMutationService.ts
@@ -224,11 +224,29 @@ export class TreeMutationService implements TreeMutationAPI {
   ): Promise<CoreCommandResult> {
     const { nodeIds, toParentId } = cmd.payload;
     const newNodeIds: NodeId[] = [];
+    const idMap = new Map<string, string>();
     // Use CoreDB bulk-based subtree duplication (internally bulkCreateNodes)
     for (const sourceId of nodeIds) {
-      const newRootId = await (this.coreDB as any).duplicateSubtree?.(sourceId, toParentId);
-      if (newRootId) newNodeIds.push(newRootId as NodeId);
+      // Prefer API with idMap if available
+      const fnWithMap = (this.coreDB as any).duplicateSubtreeWithMap as
+        | ((s: NodeId, p: NodeId) => Promise<{ newRootId: NodeId; idMap: Map<NodeId, NodeId> }>)
+        | undefined;
+      if (typeof fnWithMap === 'function') {
+        const { newRootId, idMap: subMap } = await fnWithMap(sourceId, toParentId);
+        newNodeIds.push(newRootId);
+        // Merge mappings
+        for (const [k, v] of subMap.entries()) idMap.set(k as unknown as string, v as unknown as string);
+      } else {
+        const newRootId = await (this.coreDB as any).duplicateSubtree?.(sourceId, toParentId);
+        if (newRootId) newNodeIds.push(newRootId as NodeId);
+        if (newRootId) idMap.set(sourceId as unknown as string, newRootId as unknown as string);
+      }
     }
+    // Register source→target mapping for lifecycle
+    try {
+      const { EntityLifecycleManager } = await import('~/entity/EntityLifecycleManager');
+      (EntityLifecycleManager as any).setIdMapping?.(cmd.commandId, idMap);
+    } catch {}
     return { success: true, seq: this.getNextSeq(), newNodeIds };
   }
 
@@ -346,6 +364,14 @@ export class TreeMutationService implements TreeMutationAPI {
 
       if (FEATURE_FLAGS.WORKER_ENTITY_UNIFIED) {
         try {
+          // Register mapping: source nodeIds → newNodeIds
+          const idMap = new Map<string, string>();
+          for (let i = 0; i < (nodeIds?.length || 0); i++) {
+            const src = nodeIds[i];
+            const dst = newNodeIds[i];
+            if (src && dst) idMap.set(src as unknown as string, dst as unknown as string);
+          }
+          (EntityLifecycleManager as any).setIdMapping?.(cmd.commandId, idMap);
           const lifecycle = EntityLifecycleManager.getSingleton(this.coreDB as any);
           await lifecycle.handleCommand(cmd as any);
         } catch {}
@@ -473,11 +499,23 @@ export class TreeMutationService implements TreeMutationAPI {
       });
     }
 
-    return {
+    const result: CoreCommandResult = {
       success: true,
       seq: this.getNextSeq(),
       newNodeIds,
     };
+
+    if (FEATURE_FLAGS.WORKER_ENTITY_UNIFIED) {
+      try {
+        const idMap = new Map<string, string>();
+        for (const [src, dst] of idMapping) idMap.set(src as unknown as string, dst as unknown as string);
+        (EntityLifecycleManager as any).setIdMapping?.(cmd.commandId, idMap);
+        const lifecycle = EntityLifecycleManager.getSingleton(this.coreDB as any);
+        await lifecycle.handleCommand(cmd as any);
+      } catch {}
+    }
+
+    return result;
   }
 
   // Undo/Redo Operations


### PR DESCRIPTION
Summary\n- Lifecycle: duplicate/paste/import now copy Peer entities when an idMap (src→dst NodeId) is available.\n- Lifecycle: commitWorkingCopy moves Peer from wc→target and deletes the wc Peer.\n- Services: duplicate/paste/import generate idMap and register it for lifecycle (EntityLifecycleManager.setIdMapping).\n- Handler: PeerEntityHandler now takes a PeerStore (storeRegistry) and supports bulkUpsertFromIds fallback.\n- Tests: lifecycle-commit-peer / lifecycle-duplicate-peer / lifecycle-paste-peer / lifecycle-import-peer added; peer handler test updated.\n- Docs/Tasks updated accordingly.\n\nDesign\n- A‑plan: per‑plugin Dexie DB; common table names (peerEntities/groupEntities/relations).\n- storeRegistry resolves nodeType→PeerStore. No CoreDB peer table, avoiding plugin collisions.\n- Best‑effort, behind flag WORKER_ENTITY_UNIFIED=1 (default OFF). No behavior change unless enabled.\n\nRisk/Impact\n- Flagged and non‑destructive. Limited to runtime‑worker; UI unchanged.\n\nFollow‑ups\n- Wire WC create/discard Peer tests.\n- Optional: extend duplicateSubtreeWithMap for full subtree id maps.\n- Add sample plugin registration (storeRegistry.registerPeer) in docs.\n\nRollback\n- Revert commit or set WORKER_ENTITY_UNIFIED=0.