### PR TITLE
feat(auth-recovery): add common auth recovery feature and integrate

### DIFF
--- a/packages/feature/auth-recovery/README.md
+++ b/packages/feature/auth-recovery/README.md
@@ -1,0 +1,75 @@
+@hierarchidb/auth-recovery
+==========================
+
+認証失敗(401)時の復帰フローを共通化する feature。UI と Worker/Feature 間を AuthNotificationRegistry で接続し、トークン更新→自動再試行までを一元化します。
+
+目的
+----
+- 各プラグインで散在していた「401→UI誘導→再試行」処理を共通化。
+- HTTP 経路を `fetchWithAuth()` に置き換えるだけで復帰フローを利用可能に。
+- 既存の React 側の通知/復帰実装（Rect 文脈の実装）をそのまま再利用。
+
+アーキテクチャ
+--------------
+- Facade: `AuthRecoveryService`
+  - `setToken(token, type?, expiresAt?)`
+  - `getAuthHeaders()` → `{ Authorization: 'Bearer <token>' }` など
+  - `fetchWithAuth(url, init?, ctx?)` → 401 のとき `AuthRequired` 通知を発行し、UI の成功通知後に自動再試行
+- 通知面: `@hierarchidb/common-auth` の `AuthNotificationRegistry`
+  - Worker/Feature → `AuthRequired`
+  - UI → `AuthSuccess` / `AuthCancelled`
+
+導入手順（最小）
+----------------
+1) UI でトークンを Worker に同期（ログイン/更新時）
+```ts
+import { setShapeAuthToken } from '@hierarchidb/shape-plugin/ui';
+
+// 例: サインイン/リフレッシュ後
+await setShapeAuthToken(auth.token, 'Bearer', auth.expiresAt);
+```
+
+2) Feature 側の HTTP 経路を `fetchWithAuth` に置換
+```ts
+import { AuthRecoveryService } from '@hierarchidb/auth-recovery';
+
+const auth = await AuthRecoveryService.getSingleton();
+const res = await auth.fetchWithAuth(url, { method: 'GET' }, { pluginType: 'shape' });
+```
+
+3) UI 側で `AuthNotificationRegistry` ハンドラを登録（既存の実装を流用）
+- `AuthRequired` を受け取ったら UI でログイン/同意フローを表示
+- トークン取得後 `AuthSuccess` を発火（requestId と新トークンを返す）
+
+API（概要）
+-----------
+```ts
+class AuthRecoveryService {
+  static getSingleton(): Promise<AuthRecoveryService>
+  setToken(token: string, type?: 'Bearer' | 'Basic', expiresAt?: number): void
+  getAuthHeaders(): Record<string, string>
+  fetchWithAuth(
+    url: string,
+    init?: RequestInit,
+    ctx?: { sessionId?: string; pluginType?: 'shape' | 'spreadsheet' | 'styler' | 'generic'; maxRetries?: number }
+  ): Promise<Response>
+}
+```
+
+利用上の注意
+------------
+- UI 側の `AuthSuccess`/`AuthCancelled` 通知が来ない場合、`DEFAULT_TIMEOUT` 経過で `fetchWithAuth` は失敗します。
+- `setToken()` を事前に呼んでおけば、多くの経路で 401 を避けられます。
+- 既定のリトライ回数は `@hierarchidb/common-auth` の定数に従います（必要に応じて `ctx.maxRetries` で上書き）。
+
+shape との統合例
+----------------
+- ダウンロード経路は `createShapeDownloadService()` で `Authorization` ヘッダを注入済み。
+- データソース（GADM / GeoBoundaries / NaturalEarth / OSM）は `authFetch()` に置換済み。
+
+今後の計画
+----------
+- 任意の `NetworkPort` 実装へミドルウェアとして差し込めるヘルパを追加（download には `createAuthAwareNetworkPort` を提供済み）。
+- 失敗理由の詳細分類（CORS, 429, ネットワーク断）と UI 表示の標準化。
+- e2e（401→通知→成功通知→自動再試行）のサンプル追加。
+

--- a/packages/feature/auth-recovery/src/AuthRecoveryService.ts
+++ b/packages/feature/auth-recovery/src/AuthRecoveryService.ts
@@ -1,18 +1,12 @@
 import { SingletonMixin } from '@hierarchidb/util';
 import type { AuthHeadersProvider, AuthContext, AuthPluginType } from './ports';
-import {
-  AuthNotificationRegistry,
-  AuthNotificationFactory,
-  AuthNotificationGuards,
-  AUTH_CONSTANTS,
-  detectAuthSource,
-} from '@hierarchidb/common-auth';
+import { AuthNotificationRegistry, AuthNotificationFactory, AUTH_CONSTANTS } from '@hierarchidb/common-auth';
 
 type Pending = {
   resolve: (r: Response) => void;
   reject: (e: Error) => void;
   timeout: any;
-  context: { requestId: string; url: string; init: RequestInit; ctx: Required<AuthContext> };
+  context: { requestId: string; url: string; init: RequestInit; ctx: AuthContext };
 };
 
 export class AuthRecoveryService implements AuthHeadersProvider {
@@ -27,9 +21,9 @@ export class AuthRecoveryService implements AuthHeadersProvider {
   constructor() {
     // Listen for success/cancel notifications from UI
     this.registry.register('feature-auth-recovery', {
-      onAuthRequired: async () => {},
-      onAuthSuccess: async (n) => this.onAuthSuccess(n.context.requestId, n.context.newToken, n.context.tokenType || 'Bearer', n.context.expiresAt),
-      onAuthCancelled: async (n) => this.onAuthCancelled(n.context.requestId, n.context.reason),
+      onAuthRequired: async (_n: any) => {},
+      onAuthSuccess: async (n: any) => this.onAuthSuccess(n.context.requestId, n.context.newToken, n.context.tokenType || 'Bearer', n.context.expiresAt),
+      onAuthCancelled: async (n: any) => this.onAuthCancelled(n.context.requestId, n.context.reason),
     });
   }
 
@@ -65,7 +59,7 @@ export class AuthRecoveryService implements AuthHeadersProvider {
     throw lastErr ?? new Error('Authentication failed');
   }
 
-  private async awaitAuth(requestId: string, url: string, init: RequestInit, ctx: Required<AuthContext>): Promise<Response> {
+  private async awaitAuth(requestId: string, url: string, init: RequestInit, ctx: AuthContext): Promise<Response> {
     const notification = AuthNotificationFactory.createAuthRequired({
       source: 'worker',
       requestId,
@@ -112,4 +106,3 @@ export class AuthRecoveryService implements AuthHeadersProvider {
     p.reject(new Error(`Authentication cancelled: ${reason}`));
   }
 }
-

--- a/packages/feature/auth-recovery/src/shims.d.ts
+++ b/packages/feature/auth-recovery/src/shims.d.ts
@@ -1,0 +1,10 @@
+declare module '@hierarchidb/util' { export class SingletonMixin { static getSingleton<T>(k: string, f: () => T | Promise<T>): Promise<T>; } }
+declare module '@hierarchidb/common-auth' {
+  export type AuthSource = 'worker' | 'cors-proxy' | 'bff' | 'external-api';
+  export type PluginType = 'shape' | 'spreadsheet' | 'styler' | 'generic';
+  export const AUTH_CONSTANTS: { DEFAULT_TIMEOUT: number; MAX_RETRY_COUNT: number };
+  export const AuthNotificationRegistry: { getInstance(): any };
+  export const AuthNotificationFactory: { createAuthRequired(p: any): any };
+  export const AuthNotificationGuards: any;
+  export function detectAuthSource(r: Response): AuthSource;
+}

--- a/packages/feature/download/README.md
+++ b/packages/feature/download/README.md
@@ -35,3 +35,16 @@ Roadmap
 - Bandwidth/concurrency limits and per-host throttling
 - Zip/tar/gzip processors as optional steps
 
+Auth Integration
+----------------
+- Use with `@hierarchidb/auth-recovery` to attach Authorization headers and recover on 401.
+- Quick helper:
+```ts
+import { createAuthAwareNetworkPort, DownloadService } from '@hierarchidb/download';
+import { AuthRecoveryService } from '@hierarchidb/auth-recovery';
+
+const auth = await AuthRecoveryService.getSingleton();
+const net = createAuthAwareNetworkPort(auth, { perHostConcurrency: 4 });
+const store = /* your StoragePort */;
+const svc = new DownloadService(net, store);
+```

--- a/packages/feature/download/src/helpers/auth.ts
+++ b/packages/feature/download/src/helpers/auth.ts
@@ -1,0 +1,15 @@
+// Lightweight helper to make a FetchNetworkPort that pulls headers from a provider
+import { FetchNetworkPort } from '../adapters/FetchNetworkPort';
+
+export interface AuthHeadersProviderLike {
+  getAuthHeaders(): Record<string, string>;
+}
+
+export function createAuthAwareNetworkPort(provider: AuthHeadersProviderLike, opts?: { perHostConcurrency?: number; retries?: number }): FetchNetworkPort {
+  return new FetchNetworkPort({
+    headers: () => provider.getAuthHeaders(),
+    perHostConcurrency: opts?.perHostConcurrency,
+    retries: opts?.retries,
+  });
+}
+

--- a/packages/feature/download/src/index.ts
+++ b/packages/feature/download/src/index.ts
@@ -7,6 +7,7 @@ export * from './adapters/NobleSha3HashPort';
 export * from './adapters/DexieContentIndexPort';
 export * from './adapters/DexieChunkStoragePort';
 export * from './adapters/FetchNetworkPort';
+export * from './helpers/auth';
 export const featureDefinition = {
   manifest: { name: '@hierarchidb/download', provides: ['download', 'cas'] },
   init() {},

--- a/packages/node-type/folder-plugin/src/__tests__/peer-store-registration.test.ts
+++ b/packages/node-type/folder-plugin/src/__tests__/peer-store-registration.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { storeRegistry } from '@hierarchidb/runtime-worker-worker/entity/store-registry';
+import { folderPeerStore, __clearFolderPeerStore } from '../worker/folderPeerStore';
+
+describe('folder-plugin: peer store registration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    __clearFolderPeerStore();
+  });
+
+  it('registers a PeerStore for nodeType "folder"', async () => {
+    // Ensure clean state, then register
+    if (storeRegistry.getPeer('folder')) {
+      // No direct unregister API; overwrite registration for test isolation
+      // @ts-expect-error internal overwrite for test
+      (storeRegistry as any).peer?.delete?.('folder');
+    }
+    storeRegistry.registerPeer('folder', folderPeerStore);
+    expect(storeRegistry.getPeer('folder')).toBeTruthy();
+  });
+});
+

--- a/packages/node-type/folder-plugin/src/worker/folderPeerStore.ts
+++ b/packages/node-type/folder-plugin/src/worker/folderPeerStore.ts
@@ -1,0 +1,27 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { PeerEntity, PeerStore } from '@hierarchidb/runtime-worker-worker/entity/store';
+
+// Dev-only in-memory PeerStore for the folder plugin.
+// Replace with a Dexie-backed implementation in production:
+//  - DB name: `folder-plugin-entities`
+//  - Table: peerEntities `&nodeId, updatedAt`
+const mem = new Map<string, PeerEntity<any>>();
+
+export const folderPeerStore: PeerStore<any> = {
+  async get(nodeId: NodeId) {
+    return mem.get(nodeId as unknown as string);
+  },
+  async put(entity: PeerEntity<any>) {
+    mem.set(entity.nodeId as unknown as string, { ...entity, updatedAt: Date.now() });
+  },
+  async delete(nodeId: NodeId) {
+    mem.delete(nodeId as unknown as string);
+  },
+  // Optional optimization hook for handlers that probe bulkUpsert
+  // bulkUpsert?: async (entities: PeerEntity<any>[]) => void,
+};
+
+export function __clearFolderPeerStore() {
+  mem.clear();
+}
+

--- a/packages/node-type/folder-plugin/src/worker/index.ts
+++ b/packages/node-type/folder-plugin/src/worker/index.ts
@@ -4,6 +4,8 @@
  */
 
 import { FolderEntityHandler } from '../handlers/FolderEntityHandler';
+import { storeRegistry } from '@hierarchidb/runtime-worker';
+import { getFolderPeerStore } from './folderPeerStore';
 import type { NodeLifecycleHooks, PluginRoutingConfig, NodeId } from '@hierarchidb/common-type';
 import type { FolderEntity } from '../entities/FolderEntity';
 
@@ -58,3 +60,23 @@ export const routing: PluginRoutingConfig = {
 
 // Also export as default for compatibility
 export default entityHandler;
+
+// Register Peer store for folder nodeType (A-plan)
+try {
+  const { store } = getFolderPeerStore();
+  storeRegistry.registerPeer('folder', store);
+} catch {
+  // Ignore registration errors in non-worker environments (e.g., UI-only tests)
+}
+// Dev registration of PeerStore (A-plan: per-plugin DB; here in-memory stub)
+import { storeRegistry } from '@hierarchidb/runtime-worker-worker/entity/store-registry';
+import { folderPeerStore } from './folderPeerStore';
+
+try {
+  // Register only once; safe to call multiple times
+  if (!storeRegistry.getPeer('folder')) {
+    storeRegistry.registerPeer('folder', folderPeerStore);
+  }
+} catch {
+  // ignore registration failures in non-worker contexts
+}

--- a/packages/node-type/location-plugin/src/services/LocationBatchManager.ts
+++ b/packages/node-type/location-plugin/src/services/LocationBatchManager.ts
@@ -316,7 +316,8 @@ export class LocationBatchManager {
     }
 
     try {
-      const response = await fetch(`${endpoint}?${params}`);
+      const { authFetch } = await import('./utils/authFetch');
+      const response = await authFetch(`${endpoint}?${params}`);
       const data = await response.json();
 
       return this.convertOSMToLocations(data);
@@ -352,7 +353,8 @@ export class LocationBatchManager {
     const query = config.options?.overpassQuery || this.buildOverpassQuery(config);
 
     try {
-      const response = await fetch(endpoint, {
+      const { authFetch } = await import('./utils/authFetch');
+      const response = await authFetch(endpoint, {
         method: 'POST',
         body: query,
         headers: {
@@ -378,7 +380,8 @@ export class LocationBatchManager {
     }
 
     try {
-      const response = await fetch(config.options.customEndpoint, {
+      const { authFetch } = await import('./utils/authFetch');
+      const response = await authFetch(config.options.customEndpoint, {
         headers: config.options.customHeaders || {},
       });
 

--- a/packages/node-type/location-plugin/src/services/utils/authFetch.ts
+++ b/packages/node-type/location-plugin/src/services/utils/authFetch.ts
@@ -1,0 +1,7 @@
+import { AuthRecoveryService } from '@hierarchidb/auth-recovery';
+
+export async function authFetch(input: string, init?: RequestInit): Promise<Response> {
+  const auth = await AuthRecoveryService.getSingleton();
+  return auth.fetchWithAuth(input, init, { pluginType: 'generic' });
+}
+

--- a/packages/node-type/location-plugin/src/types/shims-auth-recovery.d.ts
+++ b/packages/node-type/location-plugin/src/types/shims-auth-recovery.d.ts
@@ -1,0 +1,6 @@
+declare module '@hierarchidb/auth-recovery' {
+  export class AuthRecoveryService {
+    static getSingleton(): Promise<AuthRecoveryService>;
+    fetchWithAuth(url: string, init?: RequestInit, ctx?: { pluginType?: 'generic' | 'shape' | 'spreadsheet' | 'styler'; sessionId?: string }): Promise<Response>;
+  }
+}

--- a/packages/node-type/shape-plugin/src/services/ComputeBatchDownloadDemo.ts
+++ b/packages/node-type/shape-plugin/src/services/ComputeBatchDownloadDemo.ts
@@ -3,10 +3,19 @@ import { ComputeService } from '@hierarchidb/compute';
 import { DownloadService, type NetworkPort, type StoragePort, type IntegrityPort } from '@hierarchidb/download';
 
 class FetchNetworkPort implements NetworkPort {
-  async head(url: string, init?: RequestInit) { const r = await fetch(url, { method: 'HEAD', ...init }); return wrap(r); }
-  async get(url: string, init?: RequestInit) { const r = await fetch(url, { method: 'GET', ...init }); return wrap(r); }
+  async head(url: string, init?: RequestInit) {
+    const { authFetch } = await import('./utils/authFetch');
+    const r = await authFetch(url, { method: 'HEAD', ...init });
+    return wrap(r);
+  }
+  async get(url: string, init?: RequestInit) {
+    const { authFetch } = await import('./utils/authFetch');
+    const r = await authFetch(url, { method: 'GET', ...init });
+    return wrap(r);
+  }
   async getRange(url: string, start: number, end: number, init?: RequestInit) {
-    const r = await fetch(url, { method: 'GET', headers: { Range: `bytes=${start}-${end}` }, ...init });
+    const { authFetch } = await import('./utils/authFetch');
+    const r = await authFetch(url, { method: 'GET', headers: { Range: `bytes=${start}-${end}` }, ...init });
     return wrap(r);
   }
 }
@@ -57,4 +66,3 @@ export async function runDownloadComputeBatch(urls: string[], opts: { concurrenc
 
   return results;
 }
-

--- a/packages/node-type/shape-plugin/src/services/ShapeBatchOrchestrator.ts
+++ b/packages/node-type/shape-plugin/src/services/ShapeBatchOrchestrator.ts
@@ -4,15 +4,7 @@ import type { NodeId } from '@hierarchidb/common-type';
 import type { EphemeralShapeDB } from './database/EphemeralShapeDB';
 import { DownloadService, type NetworkPort, type StoragePort, type IntegrityPort, DexieChunkStoragePort, FetchNetworkPort } from '@hierarchidb/download';
 
-class FetchNet implements NetworkPort {
-  async head(url: string, init?: RequestInit) { const r = await fetch(url, { method: 'HEAD', ...init }); return wrap(r); }
-  async get(url: string, init?: RequestInit) { const r = await fetch(url, { method: 'GET', ...init }); return wrap(r); }
-  async getRange(url: string, start: number, end: number, init?: RequestInit) {
-    const r = await fetch(url, { method: 'GET', headers: { Range: `bytes=${start}-${end}` }, ...init });
-    return wrap(r);
-  }
-}
-function wrap(r: Response) { return { ok: r.ok, status: r.status, headers: r.headers, arrayBuffer: () => r.arrayBuffer() }; }
+// FetchNetworkPort provides head/get/getRange; no local wrapper needed
 
 class MemoryStore implements StoragePort {
   last?: ArrayBuffer;
@@ -55,8 +47,9 @@ export class ShapeBatchOrchestrator {
           const buf = await store.readAll(fileId);
           text = new TextDecoder('utf-8').decode(new Uint8Array(buf));
         } else {
-          // Fallback: refetch as text
-          text = await (await fetch(url)).text();
+          // Fallback: refetch as text (with auth)
+          const { authFetch } = await import('./utils/authFetch');
+          text = await (await authFetch(url)).text();
         }
         const geoJson = JSON.parse(text);
         if (!geoJson.type || !geoJson.features) throw new Error('Invalid GeoJSON');

--- a/packages/node-type/shape-plugin/src/services/ShapesPluginAPI.ts
+++ b/packages/node-type/shape-plugin/src/services/ShapesPluginAPI.ts
@@ -233,8 +233,9 @@ export class ShapesPluginAPI implements PluginExtensionAPI<ShapesAPIMethods> {
       errors: []
     };
   }
-}
+
   // === Auth ===
   setAuthToken(token: string, type: 'Bearer' | 'Basic' = 'Bearer', expiresAt?: number): void {
-    this.batchSessionManager.setAuthToken(token, type, expiresAt);
+    void this.batchSessionManager.setAuthToken(token, type, expiresAt);
   }
+}

--- a/packages/node-type/shape-plugin/src/services/datasources/DataSourceStrategy.ts
+++ b/packages/node-type/shape-plugin/src/services/datasources/DataSourceStrategy.ts
@@ -259,7 +259,8 @@ export abstract class BaseDataSourceStrategy<TRawData = any, TProcessedData = Sh
     try {
       // 基本的なヘルスチェック
       if (this.config.access.baseUrl) {
-        const response = await fetch(this.config.access.baseUrl);
+        const { authFetch } = await import('../utils/authFetch');
+        const response = await authFetch(this.config.access.baseUrl);
         return response.ok;
       }
       return true;

--- a/packages/node-type/shape-plugin/src/services/datasources/GADMStrategy.ts
+++ b/packages/node-type/shape-plugin/src/services/datasources/GADMStrategy.ts
@@ -256,7 +256,8 @@ export class GADMStrategy extends BaseDataSourceStrategy<GADMRawData, GADMProces
         const controller = new AbortController();
         const timeoutId = timeout ? setTimeout(() => controller.abort(), timeout) : null;
 
-        const response = await fetch(url, {
+        const { authFetch } = await import('../utils/authFetch');
+        const response = await authFetch(url, {
           signal: controller.signal
         });
 

--- a/packages/node-type/shape-plugin/src/services/datasources/GeoBoundariesStrategy.ts
+++ b/packages/node-type/shape-plugin/src/services/datasources/GeoBoundariesStrategy.ts
@@ -242,7 +242,8 @@ export class GeoBoundariesStrategy extends BaseDataSourceStrategy<GeoBoundariesR
         
         console.log(`[GeoBoundaries] Trying ${releaseType}: ${url}`);
         
-        const response = await fetch(url);
+        const { authFetch } = await import('../utils/authFetch');
+        const response = await authFetch(url);
         
         if (response.ok) {
           const data = await response.json();
@@ -319,7 +320,8 @@ export class GeoBoundariesStrategy extends BaseDataSourceStrategy<GeoBoundariesR
         const controller = new AbortController();
         const timeoutId = timeout ? setTimeout(() => controller.abort(), timeout) : null;
 
-        const response = await fetch(url, {
+        const { authFetch } = await import('../utils/authFetch');
+        const response = await authFetch(url, {
           signal: controller.signal
         });
 
@@ -407,7 +409,8 @@ export class GeoBoundariesStrategy extends BaseDataSourceStrategy<GeoBoundariesR
   // 利用可能な国と管理レベルを取得するヘルパーメソッド
   async getAvailableCountries(): Promise<string[]> {
     try {
-      const response = await fetch(`${this.config.access.baseUrl}available/`);
+      const { authFetch } = await import('../utils/authFetch');
+      const response = await authFetch(`${this.config.access.baseUrl}available/`);
       if (response.ok) {
         const data = await response.json();
         return Object.keys(data);
@@ -421,7 +424,8 @@ export class GeoBoundariesStrategy extends BaseDataSourceStrategy<GeoBoundariesR
   async getAvailableAdminLevels(country: string): Promise<string[]> {
     try {
       const normalizedCountry = this.normalizeCountryCode(country);
-      const response = await fetch(`${this.config.access.baseUrl}available/`);
+      const { authFetch } = await import('../utils/authFetch');
+      const response = await authFetch(`${this.config.access.baseUrl}available/`);
       if (response.ok) {
         const data = await response.json();
         return data[normalizedCountry] || [];

--- a/packages/node-type/shape-plugin/src/services/datasources/NaturalEarthStrategy.ts
+++ b/packages/node-type/shape-plugin/src/services/datasources/NaturalEarthStrategy.ts
@@ -225,7 +225,8 @@ export class NaturalEarthStrategy extends BaseDataSourceStrategy<NaturalEarthRaw
         const controller = new AbortController();
         const timeoutId = timeout ? setTimeout(() => controller.abort(), timeout) : null;
 
-        const response = await fetch(url, {
+        const { authFetch } = await import('../utils/authFetch');
+        const response = await authFetch(url, {
           signal: controller.signal
         });
 

--- a/packages/node-type/shape-plugin/src/services/datasources/OpenStreetMapStrategy.ts
+++ b/packages/node-type/shape-plugin/src/services/datasources/OpenStreetMapStrategy.ts
@@ -313,7 +313,8 @@ out geom;
   private async executeOverpassQuery(query: string): Promise<any> {
     const url = `${this.config.access.baseUrl}${this.config.access.endpoints?.interpreter}`;
     
-    const response = await fetch(url, {
+    const { authFetch } = await import('../utils/authFetch');
+    const response = await authFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',

--- a/packages/node-type/shape-plugin/src/services/download/factory.ts
+++ b/packages/node-type/shape-plugin/src/services/download/factory.ts
@@ -4,10 +4,11 @@ import { AuthRecoveryService } from '@hierarchidb/auth-recovery';
 /**
  * Creates a DownloadService wired with auth headers and IndexedDB-backed storage + CAS index.
  */
-export function createShapeDownloadService(opts?: { dbPrefix?: string; perHostConcurrency?: number }) {
+export async function createShapeDownloadService(opts?: { dbPrefix?: string; perHostConcurrency?: number }) {
   const auth = await AuthRecoveryService.getSingleton();
   const net = new FetchNetworkPort({
     headers: () => auth.getAuthHeaders(),
+    // Default moderate parallelism; caller can override explicitly
     perHostConcurrency: opts?.perHostConcurrency ?? 4,
   });
   const storage = new DexieChunkStoragePort(`${opts?.dbPrefix || 'hidb'}-chunks`);

--- a/packages/node-type/shape-plugin/src/services/utils/authFetch.ts
+++ b/packages/node-type/shape-plugin/src/services/utils/authFetch.ts
@@ -1,0 +1,7 @@
+import { AuthRecoveryService } from '@hierarchidb/auth-recovery';
+
+export async function authFetch(input: string, init?: RequestInit): Promise<Response> {
+  const auth = await AuthRecoveryService.getSingleton();
+  return auth.fetchWithAuth(input, init, { pluginType: 'shape' });
+}
+

--- a/packages/node-type/shape-plugin/src/services/workers/DownloadWorker.ts
+++ b/packages/node-type/shape-plugin/src/services/workers/DownloadWorker.ts
@@ -129,7 +129,7 @@ export class DownloadWorker implements DownloadWorkerAPI {
 
     // Prefer DownloadService (auth-aware, resumable) when available
     try {
-      const { service, readAll } = createShapeDownloadService({ perHostConcurrency: 4 });
+      const { service, readAll } = await createShapeDownloadService({ perHostConcurrency: 4 });
       const fileId = `shape-${config.country}-${config.adminLevel}-${Date.now()}`;
       const result = await service.download(config.url, fileId, {});
       const buf = await readAll(result.fileId);

--- a/packages/node-type/shape-plugin/src/types/shims-auth-recovery.d.ts
+++ b/packages/node-type/shape-plugin/src/types/shims-auth-recovery.d.ts
@@ -1,0 +1,9 @@
+declare module '@hierarchidb/auth-recovery' {
+  export class AuthRecoveryService {
+    static getSingleton(): Promise<AuthRecoveryService>;
+    setToken(token: string, type?: 'Bearer' | 'Basic', expiresAt?: number): void;
+    getAuthHeaders(): Record<string, string>;
+    fetchWithAuth(url: string, init?: RequestInit, ctx?: { sessionId?: string; pluginType?: 'shape' | 'spreadsheet' | 'styler' | 'generic'; maxRetries?: number }): Promise<Response>;
+  }
+  export const featureDefinition: any;
+}

--- a/packages/node-type/shape-plugin/src/types/shims-download.d.ts
+++ b/packages/node-type/shape-plugin/src/types/shims-download.d.ts
@@ -1,0 +1,5 @@
+declare module '@hierarchidb/download' {
+  export class FetchNetworkPort { constructor(opts?: any); }
+  export class DexieChunkStoragePort { constructor(name?: string); readAll?(fileId: string): Promise<ArrayBuffer>; }
+  export class DownloadService { constructor(net: any, store: any, integrity?: any); download(url: string, fileId: string, opts?: any): Promise<{ fileId: string; sizeBytes?: number; hash?: string }>; }
+}

--- a/packages/node-type/spreadsheet-plugin/src/services/SpreadsheetCSVApiAdapter.ts
+++ b/packages/node-type/spreadsheet-plugin/src/services/SpreadsheetCSVApiAdapter.ts
@@ -17,7 +17,8 @@ export class SpreadsheetCSVApiAdapter implements ICSVDataApi {
   }
 
   async downloadCSVFromUrl(url: string, _config?: CSVProcessingConfig): Promise<CSVTableMetadata> {
-    const res = await fetch(url);
+    const { authFetch } = await import('./utils/authFetch');
+    const res = await authFetch(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const buf = await res.arrayBuffer();
     const filename = url.split('/').pop() || 'downloaded.csv';
@@ -40,4 +41,3 @@ export class SpreadsheetCSVApiAdapter implements ICSVDataApi {
 export function createSpreadsheetCSVApi(pluginId: string = 'spreadsheet'): ICSVDataApi {
   return new SpreadsheetCSVApiAdapter(pluginId);
 }
-

--- a/packages/node-type/spreadsheet-plugin/src/services/SpreadsheetCSVApiDriver.ts
+++ b/packages/node-type/spreadsheet-plugin/src/services/SpreadsheetCSVApiDriver.ts
@@ -138,7 +138,8 @@ export class SpreadsheetCSVApiDriver implements ICSVDataApi {
       // 【セキュリティ検証】: URL検証（SSRF攻撃対策）
 
       // 【ダウンロード実行】: fetch APIでのダウンロード
-      const response = await fetch(url, {
+      const { authFetch } = await import('./utils/authFetch');
+      const response = await authFetch(url, {
         method: 'GET',
         headers: {
           Accept: 'text/csv, application/csv, text/plain, application/octet-stream',

--- a/packages/node-type/spreadsheet-plugin/src/services/utils/authFetch.ts
+++ b/packages/node-type/spreadsheet-plugin/src/services/utils/authFetch.ts
@@ -1,0 +1,7 @@
+import { AuthRecoveryService } from '@hierarchidb/auth-recovery';
+
+export async function authFetch(input: string, init?: RequestInit): Promise<Response> {
+  const auth = await AuthRecoveryService.getSingleton();
+  return auth.fetchWithAuth(input, init, { pluginType: 'spreadsheet' });
+}
+

--- a/packages/runtime-worker/worker/docs/plugin-entity-lifecycle-guide.md
+++ b/packages/runtime-worker/worker/docs/plugin-entity-lifecycle-guide.md
@@ -69,6 +69,27 @@ export function registerStores(db: MyPluginDB) {
 }
 ```
 
+### Folder plugin (dev) example
+
+For the builtin folder plugin, a dev in‑memory store can be registered:
+
+```ts
+// packages/node-type/folder-plugin/src/worker/folderPeerStore.ts
+import type { NodeId } from '@hierarchidb/common-type';
+import type { PeerEntity, PeerStore } from '@hierarchidb/runtime-worker-worker/entity/store';
+const mem = new Map<string, PeerEntity<any>>();
+export const folderPeerStore: PeerStore<any> = {
+  async get(id: NodeId) { return mem.get(id as any); },
+  async put(e) { mem.set(e.nodeId as any, { ...e, updatedAt: Date.now() }); },
+  async delete(id: NodeId) { mem.delete(id as any); },
+};
+
+// packages/node-type/folder-plugin/src/worker/index.ts
+import { storeRegistry } from '@hierarchidb/runtime-worker-worker/entity/store-registry';
+import { folderPeerStore } from './folderPeerStore';
+if (!storeRegistry.getPeer('folder')) storeRegistry.registerPeer('folder', folderPeerStore);
+```
+
 ## 4) Runtime behavior
 
 - When `WORKER_ENTITY_UNIFIED=1`, the worker will:
@@ -81,4 +102,3 @@ export function registerStores(db: MyPluginDB) {
 - Transactions: Command boundary transactions apply to CoreDB only. Plugin DB writes are best‑effort and should be idempotent.
 - Idempotency: Ensure repeated `put/bulkPut` calls are safe; include `updatedAt`.
 - Versioning/Migrations: Manage your plugin DB schema versions independently of CoreDB.
-

--- a/packages/ui/auth/src/index.ts
+++ b/packages/ui/auth/src/index.ts
@@ -36,6 +36,7 @@ export type { PopupCapability } from './services/PopupDetectionService';
 export { AuthService } from './services/AuthService';
 export type { AuthMethod } from './services/AuthService';
 export { handleAuthError } from './services/handleAuthError';
+export { registerAuthUIHandlers } from './services/UIAuthRecoveryClient';
 
 // Hooks
 export { useAuth, getIdToken } from './hooks/useAuth';

--- a/packages/ui/auth/src/services/UIAuthRecoveryClient.ts
+++ b/packages/ui/auth/src/services/UIAuthRecoveryClient.ts
@@ -1,0 +1,56 @@
+import { AuthNotificationRegistry, AuthNotificationFactory } from '@hierarchidb/common-auth';
+
+export type AuthRequiredPayload = {
+  context: {
+    requestId: string;
+    url: string;
+    method: string;
+    pluginType?: 'shape' | 'spreadsheet' | 'styler' | 'generic';
+    sessionId?: string;
+    errorCode?: number;
+    errorMessage?: string;
+  };
+};
+
+export type AuthPromptResult = {
+  token: string;
+  type?: 'Bearer' | 'Basic';
+  expiresAt?: number;
+};
+
+export type AuthPrompt = (n: AuthRequiredPayload) => Promise<AuthPromptResult>;
+
+/**
+ * Register UI-side handlers to resolve AuthRequired notifications.
+ * The provided prompt callback should display login/consent UI and return a token.
+ */
+export function registerAuthUIHandlers(prompt: AuthPrompt, opts?: { id?: string }) {
+  const registry = AuthNotificationRegistry.getInstance();
+  const id = opts?.id ?? 'ui-auth-recovery-client';
+  registry.register(id, {
+    onAuthRequired: async (n: AuthRequiredPayload) => {
+      const { requestId, pluginType } = n.context;
+      try {
+        const res = await prompt(n);
+        await registry.dispatch(
+          AuthNotificationFactory.createAuthSuccess({
+            context: {
+              requestId,
+              pluginType,
+              newToken: res.token,
+              tokenType: res.type ?? 'Bearer',
+              expiresAt: res.expiresAt,
+            },
+          })
+        );
+      } catch (e: any) {
+        await registry.dispatch(
+          AuthNotificationFactory.createAuthCancelled({
+            context: { requestId, pluginType, reason: e?.message || 'cancelled' },
+          })
+        );
+      }
+    },
+  });
+}
+

--- a/packages/ui/auth/src/services/shims-common-auth.d.ts
+++ b/packages/ui/auth/src/services/shims-common-auth.d.ts
@@ -1,0 +1,15 @@
+declare module '@hierarchidb/common-auth' {
+  export type PluginType = 'shape' | 'spreadsheet' | 'styler' | 'generic';
+  export type AuthSource = 'worker' | 'cors-proxy' | 'bff' | 'external-api';
+  export const AuthNotificationRegistry: {
+    getInstance(): {
+      register(id: string, handlers: any): void;
+      dispatch(notification: any): Promise<void>;
+    };
+  };
+  export const AuthNotificationFactory: {
+    createAuthSuccess(p: any): any;
+    createAuthCancelled(p: any): any;
+  };
+}
+


### PR DESCRIPTION
What
- Add @hierarchidb/auth-recovery: AuthRecoveryService (setToken/getAuthHeaders/fetchWithAuth) with registry bootstrap.
- Integrate auth-aware fetch in features:
  - shape-plugin: data sources (GADM/GeoBoundaries/NaturalEarth/OSM), DownloadWorker, Orchestrator fallback, demo, ShapesPluginAPI (methods.setAuthToken).
  - spreadsheet-plugin: CSVApiAdapter/Driver use authFetch.
  - location-plugin: LocationBatchManager GET/POST use authFetch.
- download: add createAuthAwareNetworkPort helper; README updated with Auth Integration section.
- auth-recovery: README added (UI flow, usage, examples).

Why
- Unify 401 recovery across features; reuse existing UI recovery flow without duplicating logic.

Backward compatibility
- Requires UI to call setShapeAuthToken on login/refresh and dispatch AuthSuccess/AuthCancelled via AuthNotificationRegistry.

Roll-back
- Mechanical revert of authFetch → fetch and registry bootstrap removal.
