### PR TITLE
feat(coredb): duplicateSubtreeWithMap (subtree idMap)

### DIFF
--- a/packages/runtime-worker/worker/src/services/CoreDB.ts
+++ b/packages/runtime-worker/worker/src/services/CoreDB.ts
@@ -606,6 +606,17 @@ export class CoreDB extends Dexie {
    * Duplicate a subtree with correct depth calculation
    */
   async duplicateSubtree(sourceRootId: NodeId, targetParentId: NodeId): Promise<NodeId> {
+    const { newRootId } = await this.duplicateSubtreeWithMap(sourceRootId, targetParentId);
+    return newRootId;
+  }
+
+  /**
+   * Duplicate a subtree and return the full old→new id mapping as well as the new root id.
+   */
+  async duplicateSubtreeWithMap(
+    sourceRootId: NodeId,
+    targetParentId: NodeId
+  ): Promise<{ newRootId: NodeId; idMap: Map<NodeId, NodeId> }> {
     const sourceRoot = await this.nodes.get(sourceRootId);
     if (!sourceRoot) {
       throw new Error(`Source root ${sourceRootId} not found`);
@@ -674,9 +685,8 @@ export class CoreDB extends Dexie {
       duplicatedNodes.push(duplicatedNode);
     }
 
-    // Create all nodes
     await this.bulkCreateNodes(duplicatedNodes);
-    return newRootId;
+    return { newRootId, idMap: idMapping };
   }
 
   // Legacy restoreFromTrash removed. Use CommandProcessor.recoverFromTrash with holder-based model.

--- a/packages/runtime-worker/worker/src/services/__tests__/coredb-duplicate-subtree-with-map.test.ts
+++ b/packages/runtime-worker/worker/src/services/__tests__/coredb-duplicate-subtree-with-map.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import type { NodeId, NodeType, TreeNode } from '@hierarchidb/common-type';
+import { CoreDB } from '~/services/CoreDB';
+
+function node(id: string, parentId: string, name: string, depth = 1, type: NodeType = 'folder' as any): TreeNode {
+  return {
+    id: id as any,
+    parentId: parentId as any,
+    nodeType: type,
+    name,
+    depth,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    version: 1,
+  } as any;
+}
+
+describe('CoreDB.duplicateSubtreeWithMap', () => {
+  it('duplicates subtree and returns idMap', async () => {
+    const map = new Map<string, TreeNode>();
+    // Tree: p -> a -> b
+    const p = 'p';
+    const a = 'a';
+    const b = 'b';
+    map.set(p, node(p, 'root', 'P', 0));
+    map.set(a, node(a, p, 'A', 1));
+    map.set(b, node(b, a, 'B', 2));
+
+    const created: TreeNode[] = [];
+    const fake: any = {
+      nodes: {
+        async get(id: NodeId) { return map.get(id as any); },
+      },
+      async listChildren(parentId: NodeId) {
+        return Array.from(map.values()).filter((n) => n.parentId === parentId) as any;
+      },
+      async bulkCreateNodes(nodes: TreeNode[]) { created.push(...nodes); },
+    };
+
+    const { idMap, newRootId } = await CoreDB.prototype.duplicateSubtreeWithMap.call(fake, a as any, p as any);
+    expect(newRootId).toBe(idMap.get(a as any));
+    // mapping should contain a and b
+    expect(idMap.get(a as any)).toBeDefined();
+    expect(idMap.get(b as any)).toBeDefined();
+    // created should contain 2 nodes with remapped parent of b to new a
+    const newA = created.find((n) => n.id === idMap.get(a as any));
+    const newB = created.find((n) => n.id === idMap.get(b as any));
+    expect(newA?.parentId).toBe(p);
+    expect(newB?.parentId).toBe(newA?.id);
+  });
+});
+


### PR DESCRIPTION
Adds CoreDB.duplicateSubtreeWithMap to return full subtree old→new id mapping along with the new root id.\n\n- duplicateSubtree now delegates to duplicateSubtreeWithMap.\n- Unit test: coredb-duplicate-subtree-with-map.test.ts (stubs nodes.get/listChildren/bulkCreateNodes).\n- Used by TreeMutationService.duplicateNodesCommand when available to drive idMap-based entity duplication.\n\nBehind existing flags at higher levels; CoreDB behavior remains consistent.