### PR TITLE
feat(folder-plugin): Dexie-backed Group/Relations stores

### DIFF
--- a/packages/node-type/folder-plugin/src/worker/folderEntitiesDB.ts
+++ b/packages/node-type/folder-plugin/src/worker/folderEntitiesDB.ts
@@ -1,0 +1,32 @@
+import Dexie, { type Table } from 'dexie';
+import type { NodeId } from '@hierarchidb/common-type';
+
+export type FolderGroupRow = {
+  nodeId: NodeId;
+  id: string; // stable item id
+  data?: unknown;
+  updatedAt?: number;
+};
+
+export type FolderRelationRow = {
+  srcNodeId: NodeId;
+  dstNodeId: NodeId;
+  type: string;
+  meta?: unknown;
+  updatedAt?: number;
+};
+
+export class FolderEntitiesDB extends Dexie {
+  groupEntities!: Table<FolderGroupRow, [NodeId, string]>;
+  relations!: Table<FolderRelationRow, [NodeId, string, NodeId]>;
+
+  constructor(name = 'folder-plugin-entities') {
+    super(name);
+    this.version(1).stores({
+      // composite unique keys
+      groupEntities: '&[nodeId+id], nodeId, id, updatedAt',
+      relations: '&[srcNodeId+type+dstNodeId], srcNodeId, dstNodeId, type, updatedAt',
+    });
+  }
+}
+

--- a/packages/node-type/folder-plugin/src/worker/folderGroupStore.dexie.ts
+++ b/packages/node-type/folder-plugin/src/worker/folderGroupStore.dexie.ts
@@ -1,0 +1,24 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { GroupItemBase, GroupStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { FolderEntitiesDB, FolderGroupRow } from './folderEntitiesDB';
+
+type Item = GroupItemBase<{ value?: unknown }>
+
+export function createFolderGroupStoreDexie(db: FolderEntitiesDB): GroupStore<Item> {
+  return {
+    async list(nodeId: NodeId) {
+      return (await db.groupEntities.where('nodeId').equals(nodeId).toArray()) as any;
+    },
+    async bulkUpsert(nodeId: NodeId, items: Item[]) {
+      const rows: FolderGroupRow[] = items.map((it) => ({ ...it, nodeId, updatedAt: Date.now() }));
+      await db.groupEntities.bulkPut(rows);
+    },
+    async bulkDelete(nodeId: NodeId, itemIds: string[]) {
+      // delete one by one using composite key
+      await db.transaction('rw', db.groupEntities, async () => {
+        for (const id of itemIds) await db.groupEntities.delete([nodeId, id] as any);
+      });
+    },
+  };
+}
+

--- a/packages/node-type/folder-plugin/src/worker/folderRelationStore.dexie.ts
+++ b/packages/node-type/folder-plugin/src/worker/folderRelationStore.dexie.ts
@@ -1,0 +1,23 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { RelationBase, RelationStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { FolderEntitiesDB, FolderRelationRow } from './folderEntitiesDB';
+
+type Rel = RelationBase<{ weight?: number }>;
+
+export function createFolderRelationStoreDexie(db: FolderEntitiesDB): RelationStore<Rel> {
+  return {
+    async listByNode(nodeId: NodeId) {
+      return (await db.relations.where('srcNodeId').equals(nodeId).toArray()) as any;
+    },
+    async bulkUpsert(rels: Rel[]) {
+      const rows: FolderRelationRow[] = rels.map((r) => ({ ...r, updatedAt: Date.now() }));
+      await db.relations.bulkPut(rows);
+    },
+    async bulkDelete(rels: Rel[]) {
+      await db.transaction('rw', db.relations, async () => {
+        for (const r of rels) await db.relations.delete([r.srcNodeId, r.type, r.dstNodeId] as any);
+      });
+    },
+  };
+}
+

--- a/packages/node-type/folder-plugin/src/worker/index.ts
+++ b/packages/node-type/folder-plugin/src/worker/index.ts
@@ -65,19 +65,42 @@ try {
   // and keep this safe in non-worker contexts.
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  import('@hierarchidb/runtime-worker/entity/store-registry').then(({ storeRegistry }) => {
-    // Peer store
-    import('./folderPeerStore').then(({ folderPeerStore }) => {
-      if (!storeRegistry.getPeer('folder')) storeRegistry.registerPeer('folder', folderPeerStore);
-    }).catch(() => {});
-    // Group store
-    import('./folderGroupStore').then(({ folderGroupStore }) => {
+  import('@hierarchidb/runtime-worker/entity/store-registry').then(async ({ storeRegistry }) => {
+    // Prefer Dexie-backed stores when indexedDB is available; otherwise fallback to in‑memory dev stores
+    const hasIndexedDB = typeof indexedDB !== 'undefined' && !!indexedDB.open;
+    if (hasIndexedDB) {
+      try {
+        const { FolderEntitiesDB } = await import('./folderEntitiesDB');
+        const db = new FolderEntitiesDB();
+        await db.open();
+        // Group
+        if (!storeRegistry.getGroup('folder')) {
+          const { createFolderGroupStoreDexie } = await import('./folderGroupStore.dexie');
+          storeRegistry.registerGroup('folder', createFolderGroupStoreDexie(db));
+        }
+        // Relations
+        if (!storeRegistry.getRelations('folder')) {
+          const { createFolderRelationStoreDexie } = await import('./folderRelationStore.dexie');
+          storeRegistry.registerRelations('folder', createFolderRelationStoreDexie(db));
+        }
+      } catch {
+        // fallback to dev stores
+        const { folderGroupStore } = await import('./folderGroupStore');
+        if (!storeRegistry.getGroup('folder')) storeRegistry.registerGroup('folder', folderGroupStore);
+        const { folderRelationStore } = await import('./folderRelationStore');
+        if (!storeRegistry.getRelations('folder')) storeRegistry.registerRelations('folder', folderRelationStore);
+      }
+    } else {
+      const { folderGroupStore } = await import('./folderGroupStore');
       if (!storeRegistry.getGroup('folder')) storeRegistry.registerGroup('folder', folderGroupStore);
-    }).catch(() => {});
-    // Relations store
-    import('./folderRelationStore').then(({ folderRelationStore }) => {
+      const { folderRelationStore } = await import('./folderRelationStore');
       if (!storeRegistry.getRelations('folder')) storeRegistry.registerRelations('folder', folderRelationStore);
-    }).catch(() => {});
+    }
+    // Peer (dev mem; Dexie版は別途導入予定)
+    try {
+      const { folderPeerStore } = await import('./folderPeerStore');
+      if (!storeRegistry.getPeer('folder')) storeRegistry.registerPeer('folder', folderPeerStore);
+    } catch {}
   }).catch(() => {});
 } catch {
   // ignore


### PR DESCRIPTION
Adds production Dexie-backed GroupStore and RelationStore for the folder plugin, with auto-registration when indexedDB is available. Falls back to dev memory stores otherwise.\n\n- DB: folder-plugin-entities (tables: groupEntities, relations)\n- GroupStore: list/bulkUpsert/bulkDelete\n- RelationStore: listByNode/bulkUpsert/bulkDelete\n\nNo behavior change when WORKER_ENTITY_UNIFIED=0.