### PR TITLE
feat(shape-plugin): Dexie-backed Peer/Group/Relations stores

### DIFF
--- a/packages/node-type/shape-plugin/src/worker/index.ts
+++ b/packages/node-type/shape-plugin/src/worker/index.ts
@@ -10,3 +10,32 @@ export * from './handlers';
 
 // Plugin definition
 export * from './plugin';
+
+// Dexie-backed entity stores registration (Peer/Group/Relations)
+try {
+  const hasIndexedDB = typeof indexedDB !== 'undefined' && !!indexedDB.open;
+  // dynamic import to avoid SSR/Node issues
+  import('@hierarchidb/runtime-worker/entity/store-registry').then(async ({ storeRegistry }) => {
+    if (hasIndexedDB) {
+      try {
+        const { ShapeEntitiesDB } = await import('./shapeEntitiesDB');
+        const db = new ShapeEntitiesDB();
+        await db.open();
+        if (!storeRegistry.getPeer('shape')) {
+          const { createShapePeerStoreDexie } = await import('./shapePeerStore.dexie');
+          storeRegistry.registerPeer('shape', createShapePeerStoreDexie(db));
+        }
+        if (!storeRegistry.getGroup('shape')) {
+          const { createShapeGroupStoreDexie } = await import('./shapeGroupStore.dexie');
+          storeRegistry.registerGroup('shape', createShapeGroupStoreDexie(db));
+        }
+        if (!storeRegistry.getRelations('shape')) {
+          const { createShapeRelationStoreDexie } = await import('./shapeRelationStore.dexie');
+          storeRegistry.registerRelations('shape', createShapeRelationStoreDexie(db));
+        }
+      } catch {
+        // If Dexie fails, no-op; dev stores can be registered elsewhere if needed
+      }
+    }
+  }).catch(() => {});
+} catch {}

--- a/packages/node-type/shape-plugin/src/worker/shapeEntitiesDB.ts
+++ b/packages/node-type/shape-plugin/src/worker/shapeEntitiesDB.ts
@@ -1,0 +1,22 @@
+import Dexie, { type Table } from 'dexie';
+import type { NodeId } from '@hierarchidb/common-type';
+
+export type ShapePeerRow = { nodeId: NodeId; data?: unknown; updatedAt?: number };
+export type ShapeGroupRow = { nodeId: NodeId; id: string; data?: unknown; updatedAt?: number };
+export type ShapeRelationRow = { srcNodeId: NodeId; dstNodeId: NodeId; type: string; meta?: unknown; updatedAt?: number };
+
+export class ShapeEntitiesDB extends Dexie {
+  peerEntities!: Table<ShapePeerRow, NodeId>;
+  groupEntities!: Table<ShapeGroupRow, [NodeId, string]>;
+  relations!: Table<ShapeRelationRow, [NodeId, string, NodeId]>;
+
+  constructor(name = 'shape-plugin-entities') {
+    super(name);
+    this.version(1).stores({
+      peerEntities: '&nodeId, updatedAt',
+      groupEntities: '&[nodeId+id], nodeId, id, updatedAt',
+      relations: '&[srcNodeId+type+dstNodeId], srcNodeId, dstNodeId, type, updatedAt',
+    });
+  }
+}
+

--- a/packages/node-type/shape-plugin/src/worker/shapeGroupStore.dexie.ts
+++ b/packages/node-type/shape-plugin/src/worker/shapeGroupStore.dexie.ts
@@ -1,0 +1,18 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { GroupItemBase, GroupStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { ShapeEntitiesDB, ShapeGroupRow } from './shapeEntitiesDB';
+
+type Item = GroupItemBase<{ value?: unknown }>;
+
+export function createShapeGroupStoreDexie(db: ShapeEntitiesDB): GroupStore<Item> {
+  return {
+    async list(nodeId: NodeId) { return (await db.groupEntities.where('nodeId').equals(nodeId).toArray()) as any; },
+    async bulkUpsert(nodeId: NodeId, items: Item[]) { await db.groupEntities.bulkPut(items.map((i) => ({ ...i, nodeId, updatedAt: Date.now() })) as ShapeGroupRow[]); },
+    async bulkDelete(nodeId: NodeId, itemIds: string[]) {
+      await db.transaction('rw', db.groupEntities, async () => {
+        for (const id of itemIds) await db.groupEntities.delete([nodeId, id] as any);
+      });
+    },
+  };
+}
+

--- a/packages/node-type/shape-plugin/src/worker/shapePeerStore.dexie.ts
+++ b/packages/node-type/shape-plugin/src/worker/shapePeerStore.dexie.ts
@@ -1,0 +1,13 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { PeerEntity, PeerStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { ShapeEntitiesDB, ShapePeerRow } from './shapeEntitiesDB';
+
+export function createShapePeerStoreDexie(db: ShapeEntitiesDB): PeerStore<any> {
+  return {
+    async get(nodeId: NodeId) { return (await db.peerEntities.get(nodeId)) as any; },
+    async put(e: PeerEntity<any>) { await db.peerEntities.put({ ...e, updatedAt: Date.now() } as ShapePeerRow); },
+    async delete(nodeId: NodeId) { await db.peerEntities.delete(nodeId); },
+    async bulkUpsert(entities: PeerEntity<any>[]) { await db.peerEntities.bulkPut(entities.map((e) => ({ ...e, updatedAt: Date.now() })) as any); },
+  };
+}
+

--- a/packages/node-type/shape-plugin/src/worker/shapeRelationStore.dexie.ts
+++ b/packages/node-type/shape-plugin/src/worker/shapeRelationStore.dexie.ts
@@ -1,0 +1,18 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { RelationBase, RelationStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { ShapeEntitiesDB, ShapeRelationRow } from './shapeEntitiesDB';
+
+type Rel = RelationBase<{ weight?: number }>;
+
+export function createShapeRelationStoreDexie(db: ShapeEntitiesDB): RelationStore<Rel> {
+  return {
+    async listByNode(nodeId: NodeId) { return (await db.relations.where('srcNodeId').equals(nodeId).toArray()) as any; },
+    async bulkUpsert(rels: Rel[]) { await db.relations.bulkPut(rels.map((r) => ({ ...r, updatedAt: Date.now() })) as ShapeRelationRow[]); },
+    async bulkDelete(rels: Rel[]) {
+      await db.transaction('rw', db.relations, async () => {
+        for (const r of rels) await db.relations.delete([r.srcNodeId, r.type, r.dstNodeId] as any);
+      });
+    },
+  };
+}
+


### PR DESCRIPTION
Adds Dexie stores for shape plugin (peerEntities, groupEntities, relations) with auto-registration when indexedDB is available. No behavior change when feature flags are off.