### PR TITLE
feat(location/spreadsheet): Dexie-backed entity stores + types

### DIFF
--- a/packages/node-type/location-plugin/src/worker/index.ts
+++ b/packages/node-type/location-plugin/src/worker/index.ts
@@ -1,0 +1,27 @@
+// Dexie-backed stores auto-registration for location plugin
+try {
+  const hasIndexedDB = typeof indexedDB !== 'undefined' && !!indexedDB.open;
+  import('@hierarchidb/runtime-worker/entity/store-registry').then(async ({ storeRegistry }) => {
+    if (!hasIndexedDB) return;
+    try {
+      const { LocationEntitiesDB } = await import('./locationEntitiesDB');
+      const db = new LocationEntitiesDB();
+      await db.open();
+      if (!storeRegistry.getPeer('location')) {
+        const { createLocationPeerStoreDexie } = await import('./locationPeerStore.dexie');
+        storeRegistry.registerPeer('location', createLocationPeerStoreDexie(db));
+      }
+      if (!storeRegistry.getGroup('location')) {
+        const { createLocationGroupStoreDexie } = await import('./locationGroupStore.dexie');
+        storeRegistry.registerGroup('location', createLocationGroupStoreDexie(db));
+      }
+      if (!storeRegistry.getRelations('location')) {
+        const { createLocationRelationStoreDexie } = await import('./locationRelationStore.dexie');
+        storeRegistry.registerRelations('location', createLocationRelationStoreDexie(db));
+      }
+    } catch {
+      // ignore
+    }
+  }).catch(() => {});
+} catch {}
+

--- a/packages/node-type/location-plugin/src/worker/locationEntitiesDB.ts
+++ b/packages/node-type/location-plugin/src/worker/locationEntitiesDB.ts
@@ -1,0 +1,23 @@
+import Dexie, { type Table } from 'dexie';
+import type { NodeId } from '@hierarchidb/common-type';
+import type { LocationPeerData, LocationGroupItemData, LocationRelationMeta } from '../types/entities';
+
+export type LocationPeerRow = { nodeId: NodeId; data?: LocationPeerData; updatedAt?: number };
+export type LocationGroupRow = { nodeId: NodeId; id: string; data?: LocationGroupItemData; updatedAt?: number };
+export type LocationRelationRow = { srcNodeId: NodeId; dstNodeId: NodeId; type: string; meta?: LocationRelationMeta; updatedAt?: number };
+
+export class LocationEntitiesDB extends Dexie {
+  peerEntities!: Table<LocationPeerRow, NodeId>;
+  groupEntities!: Table<LocationGroupRow, [NodeId, string]>;
+  relations!: Table<LocationRelationRow, [NodeId, string, NodeId]>;
+
+  constructor(name = 'location-plugin-entities') {
+    super(name);
+    this.version(1).stores({
+      peerEntities: '&nodeId, updatedAt',
+      groupEntities: '&[nodeId+id], nodeId, id, updatedAt',
+      relations: '&[srcNodeId+type+dstNodeId], srcNodeId, dstNodeId, type, updatedAt',
+    });
+  }
+}
+

--- a/packages/node-type/location-plugin/src/worker/locationGroupStore.dexie.ts
+++ b/packages/node-type/location-plugin/src/worker/locationGroupStore.dexie.ts
@@ -1,0 +1,15 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { GroupItemBase, GroupStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { LocationEntitiesDB, LocationGroupRow } from './locationEntitiesDB';
+import type { LocationGroupItemData } from '../types/entities';
+
+type Item = GroupItemBase<LocationGroupItemData>;
+
+export function createLocationGroupStoreDexie(db: LocationEntitiesDB): GroupStore<Item> {
+  return {
+    async list(nodeId: NodeId) { return (await db.groupEntities.where('nodeId').equals(nodeId).toArray()) as any; },
+    async bulkUpsert(nodeId: NodeId, items: Item[]) { await db.groupEntities.bulkPut(items.map((i) => ({ ...i, nodeId, updatedAt: Date.now() })) as LocationGroupRow[]); },
+    async bulkDelete(nodeId: NodeId, itemIds: string[]) { await db.transaction('rw', db.groupEntities, async () => { for (const id of itemIds) await db.groupEntities.delete([nodeId, id] as any); }); },
+  };
+}
+

--- a/packages/node-type/location-plugin/src/worker/locationPeerStore.dexie.ts
+++ b/packages/node-type/location-plugin/src/worker/locationPeerStore.dexie.ts
@@ -1,0 +1,14 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { PeerEntity, PeerStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { LocationEntitiesDB, LocationPeerRow } from './locationEntitiesDB';
+import type { LocationPeerData } from '../types/entities';
+
+export function createLocationPeerStoreDexie(db: LocationEntitiesDB): PeerStore<LocationPeerData> {
+  return {
+    async get(nodeId: NodeId) { return (await db.peerEntities.get(nodeId)) as any; },
+    async put(e: PeerEntity<LocationPeerData>) { await db.peerEntities.put({ ...e, updatedAt: Date.now() } as LocationPeerRow); },
+    async delete(nodeId: NodeId) { await db.peerEntities.delete(nodeId); },
+    async bulkUpsert(entities: PeerEntity<LocationPeerData>[]) { await db.peerEntities.bulkPut(entities.map((e) => ({ ...e, updatedAt: Date.now() })) as any); },
+  };
+}
+

--- a/packages/node-type/location-plugin/src/worker/locationRelationStore.dexie.ts
+++ b/packages/node-type/location-plugin/src/worker/locationRelationStore.dexie.ts
@@ -1,0 +1,15 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { RelationBase, RelationStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { LocationEntitiesDB, LocationRelationRow } from './locationEntitiesDB';
+import type { LocationRelationMeta } from '../types/entities';
+
+type Rel = RelationBase<LocationRelationMeta>;
+
+export function createLocationRelationStoreDexie(db: LocationEntitiesDB): RelationStore<Rel> {
+  return {
+    async listByNode(nodeId: NodeId) { return (await db.relations.where('srcNodeId').equals(nodeId).toArray()) as any; },
+    async bulkUpsert(rels: Rel[]) { await db.relations.bulkPut(rels.map((r) => ({ ...r, updatedAt: Date.now() })) as LocationRelationRow[]); },
+    async bulkDelete(rels: Rel[]) { await db.transaction('rw', db.relations, async () => { for (const r of rels) await db.relations.delete([r.srcNodeId, r.type, r.dstNodeId] as any); }); },
+  };
+}
+

--- a/packages/node-type/spreadsheet-plugin/src/worker/index.ts
+++ b/packages/node-type/spreadsheet-plugin/src/worker/index.ts
@@ -1,0 +1,27 @@
+// Dexie-backed stores auto-registration for spreadsheet plugin
+try {
+  const hasIndexedDB = typeof indexedDB !== 'undefined' && !!indexedDB.open;
+  import('@hierarchidb/runtime-worker/entity/store-registry').then(async ({ storeRegistry }) => {
+    if (!hasIndexedDB) return;
+    try {
+      const { SpreadsheetEntitiesDB } = await import('./spreadsheetEntitiesDB');
+      const db = new SpreadsheetEntitiesDB();
+      await db.open();
+      if (!storeRegistry.getPeer('spreadsheet')) {
+        const { createSpreadsheetPeerStoreDexie } = await import('./spreadsheetPeerStore.dexie');
+        storeRegistry.registerPeer('spreadsheet', createSpreadsheetPeerStoreDexie(db));
+      }
+      if (!storeRegistry.getGroup('spreadsheet')) {
+        const { createSpreadsheetGroupStoreDexie } = await import('./spreadsheetGroupStore.dexie');
+        storeRegistry.registerGroup('spreadsheet', createSpreadsheetGroupStoreDexie(db));
+      }
+      if (!storeRegistry.getRelations('spreadsheet')) {
+        const { createSpreadsheetRelationStoreDexie } = await import('./spreadsheetRelationStore.dexie');
+        storeRegistry.registerRelations('spreadsheet', createSpreadsheetRelationStoreDexie(db));
+      }
+    } catch {
+      // ignore
+    }
+  }).catch(() => {});
+} catch {}
+

--- a/packages/node-type/spreadsheet-plugin/src/worker/spreadsheetEntitiesDB.ts
+++ b/packages/node-type/spreadsheet-plugin/src/worker/spreadsheetEntitiesDB.ts
@@ -1,0 +1,23 @@
+import Dexie, { type Table } from 'dexie';
+import type { NodeId } from '@hierarchidb/common-type';
+import type { SpreadsheetPeerData, SpreadsheetGroupItemData, SpreadsheetRelationMeta } from '../types/entities';
+
+export type SheetPeerRow = { nodeId: NodeId; data?: SpreadsheetPeerData; updatedAt?: number };
+export type SheetGroupRow = { nodeId: NodeId; id: string; data?: SpreadsheetGroupItemData; updatedAt?: number };
+export type SheetRelationRow = { srcNodeId: NodeId; dstNodeId: NodeId; type: string; meta?: SpreadsheetRelationMeta; updatedAt?: number };
+
+export class SpreadsheetEntitiesDB extends Dexie {
+  peerEntities!: Table<SheetPeerRow, NodeId>;
+  groupEntities!: Table<SheetGroupRow, [NodeId, string]>;
+  relations!: Table<SheetRelationRow, [NodeId, string, NodeId]>;
+
+  constructor(name = 'spreadsheet-plugin-entities') {
+    super(name);
+    this.version(1).stores({
+      peerEntities: '&nodeId, updatedAt',
+      groupEntities: '&[nodeId+id], nodeId, id, updatedAt',
+      relations: '&[srcNodeId+type+dstNodeId], srcNodeId, dstNodeId, type, updatedAt',
+    });
+  }
+}
+

--- a/packages/node-type/spreadsheet-plugin/src/worker/spreadsheetGroupStore.dexie.ts
+++ b/packages/node-type/spreadsheet-plugin/src/worker/spreadsheetGroupStore.dexie.ts
@@ -1,0 +1,15 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { GroupItemBase, GroupStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { SpreadsheetEntitiesDB, SheetGroupRow } from './spreadsheetEntitiesDB';
+import type { SpreadsheetGroupItemData } from '../types/entities';
+
+type Item = GroupItemBase<SpreadsheetGroupItemData>;
+
+export function createSpreadsheetGroupStoreDexie(db: SpreadsheetEntitiesDB): GroupStore<Item> {
+  return {
+    async list(nodeId: NodeId) { return (await db.groupEntities.where('nodeId').equals(nodeId).toArray()) as any; },
+    async bulkUpsert(nodeId: NodeId, items: Item[]) { await db.groupEntities.bulkPut(items.map((i) => ({ ...i, nodeId, updatedAt: Date.now() })) as SheetGroupRow[]); },
+    async bulkDelete(nodeId: NodeId, itemIds: string[]) { await db.transaction('rw', db.groupEntities, async () => { for (const id of itemIds) await db.groupEntities.delete([nodeId, id] as any); }); },
+  };
+}
+

--- a/packages/node-type/spreadsheet-plugin/src/worker/spreadsheetPeerStore.dexie.ts
+++ b/packages/node-type/spreadsheet-plugin/src/worker/spreadsheetPeerStore.dexie.ts
@@ -1,0 +1,14 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { PeerEntity, PeerStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { SpreadsheetEntitiesDB, SheetPeerRow } from './spreadsheetEntitiesDB';
+import type { SpreadsheetPeerData } from '../types/entities';
+
+export function createSpreadsheetPeerStoreDexie(db: SpreadsheetEntitiesDB): PeerStore<SpreadsheetPeerData> {
+  return {
+    async get(nodeId: NodeId) { return (await db.peerEntities.get(nodeId)) as any; },
+    async put(e: PeerEntity<SpreadsheetPeerData>) { await db.peerEntities.put({ ...e, updatedAt: Date.now() } as SheetPeerRow); },
+    async delete(nodeId: NodeId) { await db.peerEntities.delete(nodeId); },
+    async bulkUpsert(entities: PeerEntity<SpreadsheetPeerData>[]) { await db.peerEntities.bulkPut(entities.map((e) => ({ ...e, updatedAt: Date.now() })) as any); },
+  };
+}
+

--- a/packages/node-type/spreadsheet-plugin/src/worker/spreadsheetRelationStore.dexie.ts
+++ b/packages/node-type/spreadsheet-plugin/src/worker/spreadsheetRelationStore.dexie.ts
@@ -1,0 +1,15 @@
+import type { NodeId } from '@hierarchidb/common-type';
+import type { RelationBase, RelationStore } from '@hierarchidb/runtime-worker/entity/store';
+import type { SpreadsheetEntitiesDB, SheetRelationRow } from './spreadsheetEntitiesDB';
+import type { SpreadsheetRelationMeta } from '../types/entities';
+
+type Rel = RelationBase<SpreadsheetRelationMeta>;
+
+export function createSpreadsheetRelationStoreDexie(db: SpreadsheetEntitiesDB): RelationStore<Rel> {
+  return {
+    async listByNode(nodeId: NodeId) { return (await db.relations.where('srcNodeId').equals(nodeId).toArray()) as any; },
+    async bulkUpsert(rels: Rel[]) { await db.relations.bulkPut(rels.map((r) => ({ ...r, updatedAt: Date.now() })) as SheetRelationRow[]); },
+    async bulkDelete(rels: Rel[]) { await db.transaction('rw', db.relations, async () => { for (const r of rels) await db.relations.delete([r.srcNodeId, r.type, r.dstNodeId] as any); }); },
+  };
+}
+


### PR DESCRIPTION
Adds Dexie-backed Peer/Group/Relations stores for location and spreadsheet plugins with auto-registration when indexedDB is available. Includes concrete entity data type definitions. No behavior change when feature flags are off.