### PR TITLE
test(shape): correct generateUrlMetadata expected length (US 0,1 + JP 0,1 = 4)

### DIFF
--- a/packages/node-type/shape-plugin/src/shared/__tests__/utils.test.ts
+++ b/packages/node-type/shape-plugin/src/shared/__tests__/utils.test.ts
@@ -137,7 +137,8 @@ describe('generateUrlMetadata', () => {
       mockCountryMetadata
     );
 
-    expect(urlMetadata).toHaveLength(3); // US: 0,1; JP: 0,1 but JP doesn't have level 1
+    // US: levels 0,1; JP: levels 0,1 → total 4
+    expect(urlMetadata).toHaveLength(4);
     expect(urlMetadata.every(meta => meta.url.includes('naturalearth'))).toBe(true);
   });
 


### PR DESCRIPTION
The test expected 3 items but JP is configured with availableAdminLevels [0,1], so total URLs should be 4 (US: 0,1; JP: 0,1). Update the expectation accordingly. No runtime changes.