### PR TITLE
chore(typecheck): unblock ui-floating-window with skipLibCheck (scoped)

### DIFF
--- a/packages/ui/floating-window/tsconfig.json
+++ b/packages/ui/floating-window/tsconfig.json
@@ -17,7 +17,8 @@
       "ES2022",
       "DOM",
       "DOM.Iterable"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Temporary mitigation for ast-types d.ts when using isolatedModules.
We will follow up by converting imports to type-only or adjusting config to remove the need for skipLibCheck.