### PR TITLE
chore(typecheck): follow-ups (TS paths, scoped skipLibCheck, tsup DTS toggles)

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
       "vite@*": "5.4.19",
       "@types/react": "^18.3.24",
       "@types/react-dom": "^18.3.7",
-      "react-is": "^18.3.1"
+      "react-is": "^18.3.1",
+      "@types/node": "18.19.123"
     }
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
       "@types/react": "^18.3.24",
       "@types/react-dom": "^18.3.7",
       "react-is": "^18.3.1",
-      "@types/node": "18.19.123"
+      "@types/node": "18.19.123",
+      "typescript": "4.9.5"
     }
   },
   "keywords": [

--- a/packages/common/types/tsconfig.json
+++ b/packages/common/types/tsconfig.json
@@ -16,7 +16,8 @@
       "vite/client",
       "vitest"
     ],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "moduleResolution": "nodenext"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/feature/feature-registry/tsconfig.json
+++ b/packages/feature/feature-registry/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "composite": false,
     "moduleResolution": "node",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*"

--- a/packages/feature/route-resolver/tsconfig.json
+++ b/packages/feature/route-resolver/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "composite": false,
     "moduleResolution": "node",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*"

--- a/packages/node-type/base-plugin/tsconfig.json
+++ b/packages/node-type/base-plugin/tsconfig.json
@@ -6,7 +6,13 @@
     "declaration": true,
     "declarationMap": true,
     "jsx": "react-jsx",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@hierarchidb/common-type": [
+        "../../common/types/src/index.ts"
+      ]
+    }
   },
   "include": [
     "src/**/*"

--- a/packages/node-type/base-plugin/tsconfig.json
+++ b/packages/node-type/base-plugin/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*"

--- a/packages/node-type/base-plugin/tsup.config.ts
+++ b/packages/node-type/base-plugin/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
-  dts: true,
+  dts: false,
   splitting: false,
   sourcemap: true,
   clean: true,

--- a/packages/tools/vite-plugin-package-reader/tsconfig.json
+++ b/packages/tools/vite-plugin-package-reader/tsconfig.json
@@ -28,5 +28,21 @@
     "node_modules",
     "dist",
     "tests"
+  ],
+  "files": [
+    "src/core/Logger.ts",
+    "src/core/PackageCache.ts",
+    "src/core/PackageDetector.ts",
+    "src/index.ts",
+    "src/pipeline/DependencyResolver.ts",
+    "src/pipeline/TransformPipeline.ts",
+    "src/plugin/VitePlugin.ts",
+    "src/presets/hierarchidb.ts",
+    "src/presets/index.ts",
+    "src/strategies/BaseStrategy.ts",
+    "src/strategies/index.ts",
+    "src/types.ts",
+    "src/virtual/TypeGenerator.ts",
+    "src/virtual/VirtualModuleManager.ts"
   ]
 }

--- a/packages/tools/vite-plugin-package-reader/tsup.config.ts
+++ b/packages/tools/vite-plugin-package-reader/tsup.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   dts: {
     resolve: true,
+    entry: {
+      index: './src/index.ts',
+      'presets/index': './src/presets/index.ts',
+    },
   },
   clean: true,
   splitting: false,

--- a/packages/ui/i18n/tsconfig.json
+++ b/packages/ui/i18n/tsconfig.json
@@ -12,14 +12,18 @@
       "DOM"
     ],
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "baseUrl": ".",
     "paths": {
       "~/*": [
         "./src/*"
       ]
     },
-    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": [
+      "node"
+    ],
+    "skipLibCheck": true
   },
   "include": [
     "./src/**/*"

--- a/packages/ui/i18n/tsconfig.json
+++ b/packages/ui/i18n/tsconfig.json
@@ -11,8 +11,8 @@
       "ES2022",
       "DOM"
     ],
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
+    "module": "ESNext",
+    "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {
       "~/*": [

--- a/packages/ui/i18n/tsconfig.json
+++ b/packages/ui/i18n/tsconfig.json
@@ -11,7 +11,7 @@
       "ES2022",
       "DOM"
     ],
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "nodenext",
     "baseUrl": ".",
     "paths": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   '@types/react': ^18.3.24
   '@types/react-dom': ^18.3.7
   react-is: ^18.3.1
+  '@types/node': 18.19.123
 
 importers:
 
@@ -65,7 +66,7 @@ importers:
         specifier: ^1.2.5
         version: 1.2.5
       '@types/node':
-        specifier: ^18.19.123
+        specifier: 18.19.123
         version: 18.19.123
       '@types/react':
         specifier: ^18.3.24
@@ -255,7 +256,7 @@ importers:
         version: link:../packages/ui/usermenu
       '@react-router/fs-routes':
         specifier: ^7.8.1
-        version: 7.8.2(@react-router/dev@7.8.2(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0)))(typescript@5.9.2)
+        version: 7.8.2(@react-router/dev@7.8.2(@types/node@18.19.123)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0)))(typescript@5.9.2)
       '@react-router/node':
         specifier: ^7.8.1
         version: 7.8.2(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)
@@ -292,10 +293,10 @@ importers:
         version: 7.3.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.8.2
-        version: 7.8.2(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0))
+        version: 7.8.2(@types/node@18.19.123)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0))
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 4.3.4(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       gh-pages:
         specifier: ^6.3.0
         version: 6.3.0
@@ -310,19 +311,19 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: 5.4.19
-        version: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+        version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
       vite-plugin-comlink:
         specifier: ^5.3.0
-        version: 5.3.0(comlink@4.4.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 5.3.0(comlink@4.4.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@24.3.0)(rollup@4.49.0)(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 4.5.4(@types/node@18.19.123)(rollup@4.49.0)(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       vite-plugin-logger:
         specifier: ^1.1.0
-        version: 1.1.0(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 1.1.0(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 5.1.4(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
 
   packages/backend/bff:
     dependencies:
@@ -337,8 +338,8 @@ importers:
         specifier: ^4.20250821.0
         version: 4.20250823.0
       '@types/node':
-        specifier: ^24.3.0
-        version: 24.3.0
+        specifier: 18.19.123
+        version: 18.19.123
       wrangler:
         specifier: ^4.31.0
         version: 4.32.0(@cloudflare/workers-types@4.20250823.0)
@@ -356,8 +357,8 @@ importers:
         specifier: ^4.20250821.0
         version: 4.20250823.0
       '@types/node':
-        specifier: ^24.3.0
-        version: 24.3.0
+        specifier: 18.19.123
+        version: 18.19.123
       wrangler:
         specifier: ^4.31.0
         version: 4.32.0(@cloudflare/workers-types@4.20250823.0)
@@ -375,11 +376,11 @@ importers:
         version: 7.8.2
     devDependencies:
       '@types/node':
-        specifier: ^24.3.0
-        version: 24.3.0
+        specifier: 18.19.123
+        version: 18.19.123
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 3.2.4(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/common/auth:
     dependencies:
@@ -388,8 +389,8 @@ importers:
         version: link:../types
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.18.0
+        specifier: 18.19.123
+        version: 18.19.123
       typescript:
         specifier: ^5.5.0
         version: 5.9.2
@@ -397,8 +398,8 @@ importers:
   packages/common/types:
     devDependencies:
       '@types/node':
-        specifier: ^24.3.0
-        version: 24.3.0
+        specifier: 18.19.123
+        version: 18.19.123
       fake-indexeddb:
         specifier: ^6.1.0
         version: 6.1.0
@@ -414,7 +415,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -427,7 +428,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -440,7 +441,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -459,7 +460,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -468,7 +469,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -487,7 +488,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -503,7 +504,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -522,7 +523,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -535,7 +536,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -551,7 +552,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -567,7 +568,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -583,7 +584,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -605,7 +606,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
@@ -620,17 +621,17 @@ importers:
         version: 4.2.0
     devDependencies:
       '@types/node':
-        specifier: ^22.10.2
-        version: 22.18.0
+        specifier: 18.19.123
+        version: 18.19.123
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.18.0)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/node-type/basemap-plugin:
     dependencies:
@@ -730,7 +731,7 @@ importers:
         version: 15.7.3(i18next@25.4.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       react-tag-input:
         specifier: ^6.10.6
-        version: 6.10.6(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@24.3.0)(@types/react@18.3.24)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.10.6(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@18.19.123)(@types/react@18.3.24)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -758,7 +759,7 @@ importers:
         version: 9.0.8
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+        version: 4.3.4(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       fake-indexeddb:
         specifier: ^6.2.2
         version: 6.2.2
@@ -819,13 +820,13 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.2
       vitest:
         specifier: ^1.0.4
-        version: 1.6.1(@types/node@24.3.0)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/node-type/project-plugin:
     dependencies:
@@ -931,13 +932,13 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.3.0
         version: 5.9.2
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/node-type/resolver-plugin:
     dependencies:
@@ -992,13 +993,13 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/node-type/route-plugin:
     dependencies:
@@ -1031,8 +1032,8 @@ importers:
         specifier: ^6.0.0
         version: 6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
-        specifier: ^20.10.5
-        version: 20.19.11
+        specifier: 18.19.123
+        version: 18.19.123
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1041,13 +1042,13 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@20.19.11))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.2
       vitest:
         specifier: ^1.1.0
-        version: 1.6.1(@types/node@20.19.11)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/node-type/shape-plugin:
     dependencies:
@@ -1210,8 +1211,8 @@ importers:
         version: 2.1.0
     devDependencies:
       '@types/node':
-        specifier: ^20.0.0
-        version: 20.19.11
+        specifier: 18.19.123
+        version: 18.19.123
       '@types/react':
         specifier: ^18.3.24
         version: 18.3.24
@@ -1223,13 +1224,13 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@20.19.11))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
       vitest:
         specifier: ^4.0.0-beta.9
-        version: 4.0.0-beta.9(@types/node@20.19.11)(@vitest/ui@2.1.9(vitest@2.1.9))(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 4.0.0-beta.9(@types/node@18.19.123)(@vitest/ui@2.1.9(vitest@2.1.9))(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/node-type/styler-plugin:
     dependencies:
@@ -1287,7 +1288,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@24.3.0)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/runtime-shared/batch-processor:
     dependencies:
@@ -1296,7 +1297,7 @@ importers:
         version: link:../../common/types
     devDependencies:
       '@types/node':
-        specifier: ^18.19.24
+        specifier: 18.19.123
         version: 18.19.123
       tsup:
         specifier: ^8.5.0
@@ -1321,8 +1322,8 @@ importers:
         specifier: ^2.12.5
         version: 2.12.5
       '@types/node':
-        specifier: ^20.19.11
-        version: 20.19.11
+        specifier: 18.19.123
+        version: 18.19.123
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.0.2
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)
@@ -1337,7 +1338,7 @@ importers:
         version: 3.6.2
       tsup:
         specifier: ^8.0.2
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@20.19.11))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.2
@@ -1346,7 +1347,7 @@ importers:
         version: 7.15.0
       vitest:
         specifier: ^1.3.0
-        version: 1.6.1(@types/node@20.19.11)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/runtime-ui/appbar:
     dependencies:
@@ -1377,13 +1378,13 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.1.2
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.5.3
         version: 5.9.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@24.3.0)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/runtime-ui/datasource:
     dependencies:
@@ -1467,7 +1468,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ~5.9.2
         version: 5.9.2
@@ -1507,7 +1508,7 @@ importers:
         version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)
       '@storybook/react-vite':
         specifier: ^8.4.7
-        version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.49.0)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+        version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.49.0)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@types/react':
         specifier: ^18.3.24
         version: 18.3.24
@@ -1525,13 +1526,13 @@ importers:
         version: 8.6.14(prettier@3.6.2)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/runtime-ui/tour:
     dependencies:
@@ -1598,8 +1599,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       '@types/node':
-        specifier: ^24.3.0
-        version: 24.3.0
+        specifier: 18.19.123
+        version: 18.19.123
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -1608,7 +1609,7 @@ importers:
         version: 6.2.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 3.2.4(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/runtime-worker/worker-bootstrap:
     dependencies:
@@ -1617,8 +1618,8 @@ importers:
         version: link:../../common/types
     devDependencies:
       '@types/node':
-        specifier: ^20.11.5
-        version: 20.19.11
+        specifier: 18.19.123
+        version: 18.19.123
       '@types/react':
         specifier: ^18.3.24
         version: 18.3.24
@@ -1651,22 +1652,22 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@20.19.11))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.2
       vite:
         specifier: 5.4.19
-        version: 5.4.19(@types/node@20.19.11)(terser@5.43.1)
+        version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
       vitest:
         specifier: ^1.2.1
-        version: 1.6.1(@types/node@20.19.11)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/tools/check-deps:
     devDependencies:
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       tsx:
         specifier: ^4.20.5
         version: 4.20.5
@@ -1687,20 +1688,20 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0
       '@types/node':
-        specifier: ^22.5.0
-        version: 22.18.0
+        specifier: 18.19.123
+        version: 18.19.123
       tsup:
         specifier: ^8.0.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.6.2
         version: 5.9.2
       vite:
         specifier: 5.4.19
-        version: 5.4.19(@types/node@22.18.0)(terser@5.43.1)
+        version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.18.0)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/ui/accordion-config:
     devDependencies:
@@ -1758,7 +1759,7 @@ importers:
         version: 2.6.14
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 4.3.4(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1767,7 +1768,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: 5.4.19
-        version: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+        version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
 
   packages/ui/core:
     dependencies:
@@ -1816,7 +1817,7 @@ importers:
         version: 2.6.14
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+        version: 4.3.4(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -1891,7 +1892,7 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
@@ -1969,13 +1970,13 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   packages/ui/i18n:
     dependencies:
@@ -2012,7 +2013,7 @@ importers:
         version: 7.3.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 4.3.4(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2021,7 +2022,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: 5.4.19
-        version: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+        version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
 
   packages/ui/import-export:
     dependencies:
@@ -2043,7 +2044,7 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.0.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.0.0
         version: 5.9.2
@@ -2196,10 +2197,10 @@ importers:
         version: 14.6.1(@testing-library/dom@9.3.4)
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 4.3.4(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@4.0.0-beta.9(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1))
+        version: 3.2.4(vitest@4.0.0-beta.9(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1))
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.4(vitest@4.0.0-beta.9)
@@ -2214,7 +2215,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: 5.4.19
-        version: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+        version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
 
   packages/ui/theme:
     dependencies:
@@ -2226,7 +2227,7 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
-        specifier: ^18.19.0
+        specifier: 18.19.123
         version: 18.19.123
       react:
         specifier: ^18.3.1
@@ -2550,7 +2551,7 @@ importers:
         version: 7.3.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+        version: 4.3.4(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2559,22 +2560,22 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: 5.4.19
-        version: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+        version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
 
   packages/util:
     devDependencies:
       '@types/node':
-        specifier: ^22.1.0
-        version: 22.18.0
+        specifier: 18.19.123
+        version: 18.19.123
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@22.18.0)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+        version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
 packages:
 
@@ -5227,7 +5228,7 @@ packages:
   '@rushstack/node-core-library@5.14.0':
     resolution: {integrity: sha512-eRong84/rwQUlATGFW3TMTYVyqL1vfW9Lf10PH+mVGfIb9HzU3h5AASNIw+axnBLjnD0n3rT5uQBwu9fvzATrg==}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': 18.19.123
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5238,7 +5239,7 @@ packages:
   '@rushstack/terminal@0.15.4':
     resolution: {integrity: sha512-OQSThV0itlwVNHV6thoXiAYZlQh4Fgvie2CzxFABsbO2MWQsI4zOh3LRNigYSTrmS+ba2j0B3EObakPzf/x6Zg==}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': 18.19.123
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5997,20 +5998,8 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
-  '@types/node@16.18.126':
-    resolution: {integrity: sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==}
-
   '@types/node@18.19.123':
     resolution: {integrity: sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==}
-
-  '@types/node@20.19.11':
-    resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
-
-  '@types/node@22.18.0':
-    resolution: {integrity: sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==}
-
-  '@types/node@24.3.0':
-    resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
@@ -9193,7 +9182,7 @@ packages:
     resolution: {integrity: sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==}
     peerDependencies:
       '@types/hoist-non-react-statics': '>= 3.3.1'
-      '@types/node': '>= 12'
+      '@types/node': 18.19.123
       '@types/react': ^18.3.24
       react: '>= 16.14'
     peerDependenciesMeta:
@@ -10284,12 +10273,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.10.0:
-    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
-
   undici-types@7.15.0:
     resolution: {integrity: sha512-Xyn5T99wU4kPhLZMm+ElE6M+IoSeG8Se7eG9xoZ82ZgVHJ07wb/IWcDZeXe2GOPkavcJ8ko5oSlXMDRl/QgY9Q==}
 
@@ -10495,7 +10478,7 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': 18.19.123
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
@@ -10526,7 +10509,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': 18.19.123
       jiti: '>=1.21.0'
       less: ^4.0.0
       lightningcss: ^1.21.0
@@ -10575,7 +10558,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': 18.19.123
       '@vitest/browser': 1.6.1
       '@vitest/ui': 1.6.1
       happy-dom: '*'
@@ -10600,7 +10583,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': 18.19.123
       '@vitest/browser': 2.1.9
       '@vitest/ui': 2.1.9
       happy-dom: '*'
@@ -10626,7 +10609,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': 18.19.123
       '@vitest/browser': 3.2.4
       '@vitest/ui': 3.2.4
       happy-dom: '*'
@@ -10654,7 +10637,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': 18.19.123
       '@vitest/browser': 4.0.0-beta.9
       '@vitest/ui': 4.0.0-beta.9
       happy-dom: '*'
@@ -12673,12 +12656,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.6.3)(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.6.3)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.27.0
       react-docgen-typescript: 2.4.0(typescript@5.6.3)
-      vite: 7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
     optionalDependencies:
       typescript: 5.6.3
 
@@ -12732,7 +12715,7 @@ snapshots:
       '@lit-labs/ssr-dom-shim': 1.4.0
       '@lit/reactive-element': 2.1.1
       '@parse5/tools': 0.3.0
-      '@types/node': 16.18.126
+      '@types/node': 18.19.123
       enhanced-resolve: 5.18.3
       lit: 3.3.1
       lit-element: 4.2.1
@@ -13062,33 +13045,6 @@ snapshots:
       '@rushstack/node-core-library': 5.14.0(@types/node@18.19.123)
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
-
-  '@microsoft/api-extractor-model@7.30.7(@types/node@20.19.11)':
-    dependencies:
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.11)
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@microsoft/api-extractor-model@7.30.7(@types/node@22.18.0)':
-    dependencies:
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@22.18.0)
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@microsoft/api-extractor-model@7.30.7(@types/node@24.3.0)':
-    dependencies:
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@24.3.0)
-    transitivePeerDependencies:
-      - '@types/node'
 
   '@microsoft/api-extractor@7.52.11(@types/node@18.19.123)':
     dependencies:
@@ -13099,63 +13055,6 @@ snapshots:
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.15.4(@types/node@18.19.123)
       '@rushstack/ts-command-line': 5.0.2(@types/node@18.19.123)
-      lodash: 4.17.21
-      minimatch: 10.0.3
-      resolve: 1.22.10
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@microsoft/api-extractor@7.52.11(@types/node@20.19.11)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.30.7(@types/node@20.19.11)
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.11)
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.4(@types/node@20.19.11)
-      '@rushstack/ts-command-line': 5.0.2(@types/node@20.19.11)
-      lodash: 4.17.21
-      minimatch: 10.0.3
-      resolve: 1.22.10
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@microsoft/api-extractor@7.52.11(@types/node@22.18.0)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.30.7(@types/node@22.18.0)
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@22.18.0)
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.4(@types/node@22.18.0)
-      '@rushstack/ts-command-line': 5.0.2(@types/node@22.18.0)
-      lodash: 4.17.21
-      minimatch: 10.0.3
-      resolve: 1.22.10
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@microsoft/api-extractor@7.52.11(@types/node@24.3.0)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.30.7(@types/node@24.3.0)
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@24.3.0)
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.4(@types/node@24.3.0)
-      '@rushstack/ts-command-line': 5.0.2(@types/node@24.3.0)
       lodash: 4.17.21
       minimatch: 10.0.3
       resolve: 1.22.10
@@ -13634,7 +13533,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-router/dev@7.8.2(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0))':
+  '@react-router/dev@7.8.2(@types/node@18.19.123)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/generator': 7.28.3
@@ -13645,7 +13544,7 @@ snapshots:
       '@babel/types': 7.28.2
       '@npmcli/package-json': 4.0.1
       '@react-router/node': 7.8.2(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)
-      '@vitejs/plugin-rsc': 0.4.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+      '@vitejs/plugin-rsc': 0.4.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.10
       chokidar: 4.0.3
@@ -13664,8 +13563,8 @@ snapshots:
       set-cookie-parser: 2.7.1
       tinyglobby: 0.2.14
       valibot: 0.41.0(typescript@5.9.2)
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
-      vite-node: 3.2.4(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
+      vite-node: 3.2.4(@types/node@18.19.123)(terser@5.43.1)
     optionalDependencies:
       typescript: 5.9.2
       wrangler: 4.32.0(@cloudflare/workers-types@4.20250823.0)
@@ -13684,9 +13583,9 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/fs-routes@7.8.2(@react-router/dev@7.8.2(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0)))(typescript@5.9.2)':
+  '@react-router/fs-routes@7.8.2(@react-router/dev@7.8.2(@types/node@18.19.123)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0)))(typescript@5.9.2)':
     dependencies:
-      '@react-router/dev': 7.8.2(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0))
+      '@react-router/dev': 7.8.2(@types/node@18.19.123)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react-router@7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(terser@5.43.1)(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))(wrangler@4.32.0(@cloudflare/workers-types@4.20250823.0))
       minimatch: 9.0.5
     optionalDependencies:
       typescript: 5.9.2
@@ -13850,48 +13749,6 @@ snapshots:
       semver: 7.5.4
     optionalDependencies:
       '@types/node': 18.19.123
-    optional: true
-
-  '@rushstack/node-core-library@5.14.0(@types/node@20.19.11)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 11.3.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.10
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 20.19.11
-    optional: true
-
-  '@rushstack/node-core-library@5.14.0(@types/node@22.18.0)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 11.3.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.10
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 22.18.0
-    optional: true
-
-  '@rushstack/node-core-library@5.14.0(@types/node@24.3.0)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 11.3.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.10
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 24.3.0
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
@@ -13904,64 +13761,10 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 18.19.123
-    optional: true
-
-  '@rushstack/terminal@0.15.4(@types/node@20.19.11)':
-    dependencies:
-      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.11)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 20.19.11
-    optional: true
-
-  '@rushstack/terminal@0.15.4(@types/node@22.18.0)':
-    dependencies:
-      '@rushstack/node-core-library': 5.14.0(@types/node@22.18.0)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 22.18.0
-    optional: true
-
-  '@rushstack/terminal@0.15.4(@types/node@24.3.0)':
-    dependencies:
-      '@rushstack/node-core-library': 5.14.0(@types/node@24.3.0)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 24.3.0
 
   '@rushstack/ts-command-line@5.0.2(@types/node@18.19.123)':
     dependencies:
       '@rushstack/terminal': 0.15.4(@types/node@18.19.123)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@rushstack/ts-command-line@5.0.2(@types/node@20.19.11)':
-    dependencies:
-      '@rushstack/terminal': 0.15.4(@types/node@20.19.11)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@rushstack/ts-command-line@5.0.2(@types/node@22.18.0)':
-    dependencies:
-      '@rushstack/terminal': 0.15.4(@types/node@22.18.0)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@rushstack/ts-command-line@5.0.2(@types/node@24.3.0)':
-    dependencies:
-      '@rushstack/terminal': 0.15.4(@types/node@24.3.0)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -14036,13 +13839,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       browser-assert: 1.2.1
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
-      vite: 7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
 
   '@storybook/builder-vite@9.1.3(storybook@9.1.3(@testing-library/dom@9.3.4)(prettier@3.6.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1)))(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))':
     dependencies:
@@ -14113,11 +13916,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 9.1.3(@testing-library/dom@9.3.4)(prettier@3.6.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
 
-  '@storybook/react-vite@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.49.0)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@storybook/react-vite@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.49.0)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.6.3)(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.6.3)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@rollup/pluginutils': 5.2.0(rollup@4.49.0)
-      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@storybook/react': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)
       find-up: 5.0.0
       magic-string: 0.30.18
@@ -14127,7 +13930,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 8.6.14(prettier@3.6.2)
       tsconfig-paths: 4.2.0
-      vite: 7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -15419,7 +15222,7 @@ snapshots:
 
   '@types/brotli@1.3.4':
     dependencies:
-      '@types/node': 22.18.0
+      '@types/node': 18.19.123
 
   '@types/chai@5.2.2':
     dependencies:
@@ -15480,7 +15283,7 @@ snapshots:
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.18.0
+      '@types/node': 18.19.123
 
   '@types/google.maps@3.58.1': {}
 
@@ -15520,23 +15323,9 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/node@16.18.126': {}
-
   '@types/node@18.19.123':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@20.19.11':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.18.0':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@24.3.0':
-    dependencies:
-      undici-types: 7.10.0
 
   '@types/offscreencanvas@2019.7.3': {}
 
@@ -15920,29 +15709,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))':
+  '@vitejs/plugin-react@4.3.4(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.3)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.3)
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.14.2
-      vite: 7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitejs/plugin-rsc@0.4.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))':
+  '@vitejs/plugin-rsc@0.4.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))':
     dependencies:
       '@mjackson/node-fetch-server': 0.7.0
       es-module-lexer: 1.7.0
@@ -15952,10 +15730,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       turbo-stream: 3.1.0
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
-      vitefu: 1.1.1(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
+      vitefu: 1.1.1(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
 
-  '@vitest/coverage-v8@3.2.4(vitest@4.0.0-beta.9(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1))':
+  '@vitest/coverage-v8@3.2.4(vitest@4.0.0-beta.9(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -15970,7 +15748,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 4.0.0-beta.9(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+      vitest: 4.0.0-beta.9(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16019,14 +15797,6 @@ snapshots:
     optionalDependencies:
       vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
 
-  '@vitest/mocker@3.2.4(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.18
-    optionalDependencies:
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
-
   '@vitest/mocker@4.0.0-beta.9(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))':
     dependencies:
       '@vitest/spy': 4.0.0-beta.9
@@ -16034,14 +15804,6 @@ snapshots:
       magic-string: 0.30.18
     optionalDependencies:
       vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
-
-  '@vitest/mocker@4.0.0-beta.9(vite@5.4.19(@types/node@20.19.11)(terser@5.43.1))':
-    dependencies:
-      '@vitest/spy': 4.0.0-beta.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.18
-    optionalDependencies:
-      vite: 5.4.19(@types/node@20.19.11)(terser@5.43.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -16125,7 +15887,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.1(@types/node@24.3.0)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+      vitest: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   '@vitest/ui@2.1.9(vitest@2.1.9)':
     dependencies:
@@ -16147,7 +15909,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+      vitest: 3.2.4(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
     optional: true
 
   '@vitest/ui@3.2.4(vitest@4.0.0-beta.9)':
@@ -16159,7 +15921,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 4.0.0-beta.9(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
+      vitest: 4.0.0-beta.9(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -17885,7 +17647,7 @@ snapshots:
 
   happy-dom@18.0.1:
     dependencies:
-      '@types/node': 20.19.11
+      '@types/node': 18.19.123
       '@types/whatwg-mimetype': 3.0.2
       whatwg-mimetype: 3.0.0
 
@@ -19321,7 +19083,7 @@ snapshots:
     dependencies:
       dnd-core: 16.0.1
 
-  react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@24.3.0)(@types/react@18.3.24)(react@18.3.1):
+  react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@18.19.123)(@types/react@18.3.24)(react@18.3.1):
     dependencies:
       '@react-dnd/invariant': 4.0.2
       '@react-dnd/shallowequal': 4.0.2
@@ -19331,7 +19093,7 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.24)
-      '@types/node': 24.3.0
+      '@types/node': 18.19.123
       '@types/react': 18.3.24
 
   react-docgen-typescript@2.4.0(typescript@4.9.5):
@@ -19497,13 +19259,13 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  react-tag-input@6.10.6(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@24.3.0)(@types/react@18.3.24)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-tag-input@6.10.6(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@18.19.123)(@types/react@18.3.24)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@types/lodash-es': 4.17.12
       classnames: 2.3.3
       lodash-es: 4.17.21
       react: 18.3.1
-      react-dnd: 16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@24.3.0)(@types/react@18.3.24)(react@18.3.1)
+      react-dnd: 16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@18.19.123)(@types/react@18.3.24)(react@18.3.1)
       react-dnd-html5-backend: 16.0.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -20437,7 +20199,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@20.19.11))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1):
+  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.9)
       cac: 6.7.14
@@ -20457,94 +20219,7 @@ snapshots:
       tinyglobby: 0.2.14
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.52.11(@types/node@20.19.11)
-      postcss: 8.5.6
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.9)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.1
-      esbuild: 0.25.9
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.1)
-      resolve-from: 5.0.0
-      rollup: 4.48.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.11(@types/node@22.18.0)
-      postcss: 8.5.6
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.9)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.1
-      esbuild: 0.25.9
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.1)
-      resolve-from: 5.0.0
-      rollup: 4.48.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.11(@types/node@24.3.0)
-      postcss: 8.5.6
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.9)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.1
-      esbuild: 0.25.9
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.1)
-      resolve-from: 5.0.0
-      rollup: 4.48.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.11(@types/node@24.3.0)
+      '@microsoft/api-extractor': 7.52.11(@types/node@18.19.123)
       postcss: 8.5.6
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -20553,7 +20228,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@24.3.0))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1):
+  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.9)
       cac: 6.7.14
@@ -20573,7 +20248,7 @@ snapshots:
       tinyglobby: 0.2.14
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.52.11(@types/node@24.3.0)
+      '@microsoft/api-extractor': 7.52.11(@types/node@18.19.123)
       postcss: 8.5.6
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -20702,10 +20377,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@5.26.5: {}
-
-  undici-types@6.21.0: {}
-
-  undici-types@7.10.0: {}
 
   undici-types@7.15.0: {}
 
@@ -20838,49 +20509,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@1.6.1(@types/node@20.19.11)(terser@5.43.1):
+  vite-node@1.6.1(@types/node@18.19.123)(terser@5.43.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.19(@types/node@20.19.11)(terser@5.43.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@1.6.1(@types/node@22.18.0)(terser@5.43.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.19(@types/node@22.18.0)(terser@5.43.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@1.6.1(@types/node@24.3.0)(terser@5.43.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -20910,49 +20545,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.9(@types/node@22.18.0)(terser@5.43.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.19(@types/node@22.18.0)(terser@5.43.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@2.1.9(@types/node@24.3.0)(terser@5.43.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@3.2.4(@types/node@24.3.0)(terser@5.43.1):
+  vite-node@3.2.4(@types/node@18.19.123)(terser@5.43.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -20987,17 +20586,17 @@ snapshots:
       optionator: 0.9.4
       typescript: 4.9.5
 
-  vite-plugin-comlink@5.3.0(comlink@4.4.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1)):
+  vite-plugin-comlink@5.3.0(comlink@4.4.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1)):
     dependencies:
       comlink: 4.4.2
       json5: 2.2.3
       magic-string: 0.30.17
       source-map: 0.7.6
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
 
-  vite-plugin-dts@4.5.4(@types/node@24.3.0)(rollup@4.49.0)(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1)):
+  vite-plugin-dts@4.5.4(@types/node@18.19.123)(rollup@4.49.0)(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1)):
     dependencies:
-      '@microsoft/api-extractor': 7.52.11(@types/node@24.3.0)
+      '@microsoft/api-extractor': 7.52.11(@types/node@18.19.123)
       '@rollup/pluginutils': 5.2.0(rollup@4.49.0)
       '@volar/typescript': 2.4.23
       '@vue/language-core': 2.2.0(typescript@5.9.2)
@@ -21008,15 +20607,15 @@ snapshots:
       magic-string: 0.30.18
       typescript: 5.9.2
     optionalDependencies:
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-logger@1.1.0(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1)):
+  vite-plugin-logger@1.1.0(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1)):
     dependencies:
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
 
   vite-tsconfig-paths@5.1.4(typescript@4.9.5)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1)):
     dependencies:
@@ -21029,13 +20628,13 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -21050,37 +20649,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.43.1
 
-  vite@5.4.19(@types/node@20.19.11)(terser@5.43.1):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.49.0
-    optionalDependencies:
-      '@types/node': 20.19.11
-      fsevents: 2.3.3
-      terser: 5.43.1
-
-  vite@5.4.19(@types/node@22.18.0)(terser@5.43.1):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.49.0
-    optionalDependencies:
-      '@types/node': 22.18.0
-      fsevents: 2.3.3
-      terser: 5.43.1
-
-  vite@5.4.19(@types/node@24.3.0)(terser@5.43.1):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.49.0
-    optionalDependencies:
-      '@types/node': 24.3.0
-      fsevents: 2.3.3
-      terser: 5.43.1
-
-  vite@7.1.3(@types/node@24.3.0)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1):
+  vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -21089,18 +20658,18 @@ snapshots:
       rollup: 4.49.0
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.3.0
+      '@types/node': 18.19.123
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.43.1
       tsx: 4.20.5
       yaml: 2.8.1
 
-  vitefu@1.1.1(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1)):
+  vitefu@1.1.1(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1)):
     optionalDependencies:
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
 
-  vitest@1.6.1(@types/node@20.19.11)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
+  vitest@1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -21119,85 +20688,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.19(@types/node@20.19.11)(terser@5.43.1)
-      vite-node: 1.6.1(@types/node@20.19.11)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
+      vite-node: 1.6.1(@types/node@18.19.123)(terser@5.43.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.11
-      '@vitest/ui': 1.6.1(vitest@1.6.1)
-      happy-dom: 18.0.1
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.1(@types/node@22.18.0)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.4.1
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.18
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.9.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.19(@types/node@22.18.0)(terser@5.43.1)
-      vite-node: 1.6.1(@types/node@22.18.0)(terser@5.43.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.18.0
-      '@vitest/ui': 1.6.1(vitest@1.6.1)
-      happy-dom: 18.0.1
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.1(@types/node@24.3.0)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.4.1
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.18
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.9.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
-      vite-node: 1.6.1(@types/node@24.3.0)(terser@5.43.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.3.0
+      '@types/node': 18.19.123
       '@vitest/ui': 1.6.1(vitest@1.6.1)
       happy-dom: 18.0.1
       jsdom: 26.1.0
@@ -21249,7 +20744,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@22.18.0)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
+  vitest@2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
@@ -21268,11 +20763,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.19(@types/node@22.18.0)(terser@5.43.1)
-      vite-node: 2.1.9(@types/node@22.18.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
+      vite-node: 2.1.9(@types/node@18.19.123)(terser@5.43.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.18.0
+      '@types/node': 18.19.123
       '@vitest/ui': 2.1.9(vitest@2.1.9)
       happy-dom: 18.0.1
       jsdom: 26.1.0
@@ -21287,49 +20782,11 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@24.3.0)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
-    dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.3.3
-      debug: 4.4.1
-      expect-type: 1.2.2
-      magic-string: 0.30.18
-      pathe: 1.1.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
-      vite-node: 2.1.9(@types/node@24.3.0)(terser@5.43.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.3.0
-      '@vitest/ui': 2.1.9(vitest@2.1.9)
-      happy-dom: 18.0.1
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@3.2.4(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
+  vitest@3.2.4(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.19(@types/node@24.3.0)(terser@5.43.1))
+      '@vitest/mocker': 3.2.4(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -21347,11 +20804,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
-      vite-node: 3.2.4(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
+      vite-node: 3.2.4(@types/node@18.19.123)(terser@5.43.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.3.0
+      '@types/node': 18.19.123
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 18.0.1
       jsdom: 26.1.0
@@ -21405,46 +20862,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.0.0-beta.9(@types/node@20.19.11)(@vitest/ui@2.1.9(vitest@2.1.9))(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
-    dependencies:
-      '@vitest/expect': 4.0.0-beta.9
-      '@vitest/mocker': 4.0.0-beta.9(vite@5.4.19(@types/node@20.19.11)(terser@5.43.1))
-      '@vitest/pretty-format': 4.0.0-beta.9
-      '@vitest/runner': 4.0.0-beta.9
-      '@vitest/snapshot': 4.0.0-beta.9
-      '@vitest/spy': 4.0.0-beta.9
-      '@vitest/utils': 4.0.0-beta.9
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      expect-type: 1.2.2
-      magic-string: 0.30.18
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@20.19.11)(terser@5.43.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.19.11
-      '@vitest/ui': 2.1.9(vitest@2.1.9)
-      happy-dom: 18.0.1
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@4.0.0-beta.9(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
+  vitest@4.0.0-beta.9(@types/node@18.19.123)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1):
     dependencies:
       '@vitest/expect': 4.0.0-beta.9
       '@vitest/mocker': 4.0.0-beta.9(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
@@ -21465,10 +20883,10 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@24.3.0)(terser@5.43.1)
+      vite: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.3.0
+      '@types/node': 18.19.123
       '@vitest/ui': 3.2.4(vitest@4.0.0-beta.9)
       happy-dom: 18.0.1
       jsdom: 26.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   '@types/react-dom': ^18.3.7
   react-is: ^18.3.1
   '@types/node': 18.19.123
+  typescript: 4.9.5
 
 importers:
 
@@ -392,8 +393,8 @@ importers:
         specifier: 18.19.123
         version: 18.19.123
       typescript:
-        specifier: ^5.5.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/common/types:
     devDependencies:
@@ -415,10 +416,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/batch:
     dependencies:
@@ -428,10 +429,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/compute:
     dependencies:
@@ -441,10 +442,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/download:
     dependencies:
@@ -460,19 +461,19 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/feature-registry:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/import-export:
     dependencies:
@@ -488,10 +489,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/map-source:
     dependencies:
@@ -504,10 +505,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/map-view:
     dependencies:
@@ -523,10 +524,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/route-resolver:
     dependencies:
@@ -536,10 +537,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/route-searoute:
     dependencies:
@@ -552,10 +553,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/tabular:
     dependencies:
@@ -568,10 +569,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/tabular-xlsx:
     dependencies:
@@ -584,10 +585,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/feature/tag:
     dependencies:
@@ -606,10 +607,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/node-type/base-plugin:
     dependencies:
@@ -625,10 +626,10 @@ importers:
         version: 18.19.123
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.7.2
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -722,13 +723,13 @@ importers:
         version: 4.2.0
       i18next:
         specifier: ^25.4.2
-        version: 25.4.2(typescript@5.9.2)
+        version: 25.4.2(typescript@4.9.5)
       react-hook-form:
         specifier: ^7.62.0
         version: 7.62.0(react@18.3.1)
       react-i18next:
         specifier: ^15.7.3
-        version: 15.7.3(i18next@25.4.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+        version: 15.7.3(i18next@25.4.2(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)
       react-tag-input:
         specifier: ^6.10.6
         version: 6.10.6(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.24))(@types/node@18.19.123)(@types/react@18.3.24)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -820,10 +821,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.3.3
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^1.0.4
         version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -932,10 +933,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.3.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -993,10 +994,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.7.2
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -1042,10 +1043,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.3.3
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^1.1.0
         version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -1224,10 +1225,10 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^4.0.0-beta.9
         version: 4.0.0-beta.9(@types/node@18.19.123)(@vitest/ui@2.1.9(vitest@2.1.9))(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -1303,7 +1304,7 @@ importers:
         specifier: ^8.5.0
         version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^4.9.5
+        specifier: 4.9.5
         version: 4.9.5
       vitest:
         specifier: ^4.0.0-beta.9
@@ -1326,10 +1327,10 @@ importers:
         version: 18.19.123
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.0.2
-        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5))(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^7.0.2
-        version: 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)
+        version: 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@1.21.7)
@@ -1338,10 +1339,10 @@ importers:
         version: 3.6.2
       tsup:
         specifier: ^8.0.2
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.3.3
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       undici-types:
         specifier: ^7.15.0
         version: 7.15.0
@@ -1378,10 +1379,10 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.1.2
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.5.3
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -1468,10 +1469,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ~5.9.2
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/runtime-ui/search-result-window:
     dependencies:
@@ -1505,10 +1506,10 @@ importers:
         version: 6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: ^8.4.7
-        version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)
+        version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@4.9.5)
       '@storybook/react-vite':
         specifier: ^8.4.7
-        version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.49.0)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+        version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.49.0)(storybook@8.6.14(prettier@3.6.2))(typescript@4.9.5)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@types/react':
         specifier: ^18.3.24
         version: 18.3.24
@@ -1526,10 +1527,10 @@ importers:
         version: 8.6.14(prettier@3.6.2)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ~5.6.3
-        version: 5.6.3
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -1637,7 +1638,7 @@ importers:
         version: 8.57.1
       eslint-plugin-deprecation:
         specifier: ^3.0.0
-        version: 3.0.0(eslint@8.57.1)(typescript@5.9.2)
+        version: 3.0.0(eslint@8.57.1)(typescript@4.9.5)
       fake-indexeddb:
         specifier: ^5.0.2
         version: 5.0.2
@@ -1652,10 +1653,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.1
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.3.3
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vite:
         specifier: 5.4.19
         version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
@@ -1692,10 +1693,10 @@ importers:
         version: 18.19.123
       tsup:
         specifier: ^8.0.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.6.2
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vite:
         specifier: 5.4.19
         version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
@@ -1740,7 +1741,7 @@ importers:
         version: 2.6.3(react@18.3.1)
       react-i18next:
         specifier: ^15.7.1
-        version: 15.7.2(i18next@25.4.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+        version: 15.7.2(i18next@25.4.2(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)
       react-oidc-context:
         specifier: ^3.3.0
         version: 3.3.0(oidc-client-ts@3.3.0)(react@18.3.1)
@@ -1892,10 +1893,10 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.7.2
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/ui/dialog:
     dependencies:
@@ -1970,10 +1971,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ~5.6.3
-        version: 5.6.3
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@18.19.123)(@vitest/ui@2.1.9)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -1988,7 +1989,7 @@ importers:
         version: 4.1.0
       i18next:
         specifier: ^25.4.2
-        version: 25.4.2(typescript@5.9.2)
+        version: 25.4.2(typescript@4.9.5)
       i18next-browser-languagedetector:
         specifier: ^8.2.0
         version: 8.2.0
@@ -1997,7 +1998,7 @@ importers:
         version: 3.0.2
       react-i18next:
         specifier: ^15.7.2
-        version: 15.7.2(i18next@25.4.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+        version: 15.7.2(i18next@25.4.2(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)
     devDependencies:
       '@emotion/react':
         specifier: ^11.14.0
@@ -2018,8 +2019,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vite:
         specifier: 5.4.19
         version: 5.4.19(@types/node@18.19.123)(terser@5.43.1)
@@ -2044,10 +2045,10 @@ importers:
         version: 18.3.1
       tsup:
         specifier: ^8.0.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.0.0
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
 
   packages/ui/layout:
     dependencies:
@@ -2541,7 +2542,7 @@ importers:
         version: link:../theme
       react-i18next:
         specifier: ^15.7.1
-        version: 15.7.2(i18next@25.4.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+        version: 15.7.2(i18next@25.4.2(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)
     devDependencies:
       '@mui/icons-material':
         specifier: ^7.3.1
@@ -2569,10 +2570,10 @@ importers:
         version: 18.19.123
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@4.9.5)(yaml@2.8.1)
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.2
+        specifier: 4.9.5
+        version: 4.9.5
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@18.19.123)(@vitest/ui@1.6.1)(happy-dom@18.0.1)(jsdom@26.1.0)(terser@5.43.1)
@@ -4222,7 +4223,7 @@ packages:
   '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0':
     resolution: {integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 4.9.5
       vite: 5.4.19
     peerDependenciesMeta:
       typescript:
@@ -4231,7 +4232,7 @@ packages:
   '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1':
     resolution: {integrity: sha512-J4BaTocTOYFkMHIra1JDWrMWpNmBl4EkplIwHEsV8aeUOtdWjwSnln9U7twjMFTAEB7mptNtSKyVi1Y2W9sDJw==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 4.9.5
       vite: 5.4.19
     peerDependenciesMeta:
       typescript:
@@ -4974,7 +4975,7 @@ packages:
     peerDependencies:
       '@react-router/serve': ^7.8.2
       react-router: ^7.8.2
-      typescript: ^5.1.0
+      typescript: 4.9.5
       vite: 5.4.19
       wrangler: ^3.28.2 || ^4.0.0
     peerDependenciesMeta:
@@ -4990,7 +4991,7 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@react-router/dev': ^7.8.2
-      typescript: ^5.1.0
+      typescript: 4.9.5
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5000,7 +5001,7 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react-router: 7.8.2
-      typescript: ^5.1.0
+      typescript: 4.9.5
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5417,7 +5418,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.6.14
-      typescript: '>= 4.2.x'
+      typescript: 4.9.5
     peerDependenciesMeta:
       '@storybook/test':
         optional: true
@@ -5431,7 +5432,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^9.1.3
-      typescript: '>= 4.9.x'
+      typescript: 4.9.5
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6415,7 +6416,7 @@ packages:
   '@vue/language-core@2.2.0':
     resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
     peerDependencies:
-      typescript: '*'
+      typescript: 4.9.5
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -7379,7 +7380,7 @@ packages:
     resolution: {integrity: sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==}
     peerDependencies:
       eslint: ^8.0.0
-      typescript: ^4.2.4 || ^5.0.0
+      typescript: 4.9.5
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
@@ -7939,7 +7940,7 @@ packages:
   i18next@25.4.2:
     resolution: {integrity: sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==}
     peerDependencies:
-      typescript: ^5
+      typescript: 4.9.5
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9196,7 +9197,7 @@ packages:
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 4.9.5
 
   react-docgen@7.1.1:
     resolution: {integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==}
@@ -9240,7 +9241,7 @@ packages:
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
-      typescript: ^5
+      typescript: 4.9.5
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -9256,7 +9257,7 @@ packages:
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
-      typescript: ^5
+      typescript: 4.9.5
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -10085,7 +10086,7 @@ packages:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: 4.9.5
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -10107,7 +10108,7 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: 4.9.5
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -10130,7 +10131,7 @@ packages:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
       postcss: ^8.4.12
-      typescript: '>=4.5.0'
+      typescript: 4.9.5
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
@@ -10145,7 +10146,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+      typescript: 4.9.5
 
   tsx@4.20.5:
     resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
@@ -10232,16 +10233,6 @@ packages:
   typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
-    hasBin: true
-
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.8.2:
-    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
-    engines: {node: '>=14.17'}
     hasBin: true
 
   typescript@5.9.2:
@@ -10381,7 +10372,7 @@ packages:
   valibot@0.41.0:
     resolution: {integrity: sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==}
     peerDependencies:
-      typescript: '>=5'
+      typescript: 4.9.5
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -10420,7 +10411,7 @@ packages:
       meow: ^9.0.0
       optionator: ^0.9.1
       stylelint: '>=13'
-      typescript: '*'
+      typescript: 4.9.5
       vite: 5.4.19
       vls: '*'
       vti: '*'
@@ -10454,7 +10445,7 @@ packages:
   vite-plugin-dts@4.5.4:
     resolution: {integrity: sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==}
     peerDependencies:
-      typescript: '*'
+      typescript: 4.9.5
       vite: 5.4.19
     peerDependenciesMeta:
       vite:
@@ -12656,14 +12647,14 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.6.3)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@4.9.5)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.27.0
-      react-docgen-typescript: 2.4.0(typescript@5.6.3)
+      react-docgen-typescript: 2.4.0(typescript@4.9.5)
       vite: 7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 4.9.5
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@4.9.5)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))':
     dependencies:
@@ -13060,7 +13051,7 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.8.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - '@types/node'
 
@@ -13916,12 +13907,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 9.1.3(@testing-library/dom@9.3.4)(prettier@3.6.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
 
-  '@storybook/react-vite@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.49.0)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+  '@storybook/react-vite@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.49.0)(storybook@8.6.14(prettier@3.6.2))(typescript@4.9.5)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.6.3)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@4.9.5)(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@rollup/pluginutils': 5.2.0(rollup@4.49.0)
       '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@7.1.3(@types/node@18.19.123)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
-      '@storybook/react': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)
+      '@storybook/react': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@4.9.5)
       find-up: 5.0.0
       magic-string: 0.30.18
       react: 18.3.1
@@ -13956,7 +13947,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.6.3)':
+  '@storybook/react@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@4.9.5)':
     dependencies:
       '@storybook/components': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/global': 5.0.0
@@ -13968,7 +13959,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.14(prettier@3.6.2)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 4.9.5
 
   '@storybook/react@9.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.3(@testing-library/dom@9.3.4)(prettier@3.6.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1)))(typescript@4.9.5)':
     dependencies:
@@ -15423,21 +15414,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5))(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 9.34.0(jiti@1.21.7)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.9.2)
+      ts-api-utils: 1.4.3(typescript@4.9.5)
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15453,16 +15444,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/parser@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.1
       eslint: 9.34.0(jiti@1.21.7)
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15488,15 +15479,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.5)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)
       debug: 4.4.1
       eslint: 9.34.0(jiti@1.21.7)
-      ts-api-utils: 1.4.3(typescript@5.9.2)
+      ts-api-utils: 1.4.3(typescript@4.9.5)
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15518,7 +15509,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -15527,9 +15518,9 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 1.4.3(typescript@5.9.2)
+      ts-api-utils: 1.4.3(typescript@4.9.5)
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15548,23 +15539,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.2)':
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@4.9.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.5)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/utils@7.18.0(eslint@9.34.0(jiti@1.21.7))(typescript@4.9.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.34.0(jiti@1.21.7))
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.5)
       eslint: 9.34.0(jiti@1.21.7)
     transitivePeerDependencies:
       - supports-color
@@ -17087,13 +17078,13 @@ snapshots:
     dependencies:
       eslint: 9.34.0(jiti@1.21.7)
 
-  eslint-plugin-deprecation@3.0.0(eslint@8.57.1)(typescript@5.9.2):
+  eslint-plugin-deprecation@3.0.0(eslint@8.57.1)(typescript@4.9.5):
     dependencies:
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.9.2)
+      ts-api-utils: 1.4.3(typescript@4.9.5)
       tslib: 2.8.1
-      typescript: 5.9.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -17777,11 +17768,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  i18next@25.4.2(typescript@5.9.2):
+  i18next@25.4.2(typescript@4.9.5):
     dependencies:
       '@babel/runtime': 7.28.3
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 4.9.5
 
   iconv-lite@0.6.3:
     dependencies:
@@ -19100,10 +19091,6 @@ snapshots:
     dependencies:
       typescript: 4.9.5
 
-  react-docgen-typescript@2.4.0(typescript@5.6.3):
-    dependencies:
-      typescript: 5.6.3
-
   react-docgen@7.1.1:
     dependencies:
       '@babel/core': 7.28.3
@@ -19170,25 +19157,25 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-i18next@15.7.2(i18next@25.4.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2):
+  react-i18next@15.7.2(i18next@25.4.2(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5):
     dependencies:
       '@babel/runtime': 7.28.3
       html-parse-stringify: 3.0.1
-      i18next: 25.4.2(typescript@5.9.2)
+      i18next: 25.4.2(typescript@4.9.5)
       react: 18.3.1
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
-      typescript: 5.9.2
+      typescript: 4.9.5
 
-  react-i18next@15.7.3(i18next@25.4.2(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2):
+  react-i18next@15.7.3(i18next@25.4.2(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5):
     dependencies:
       '@babel/runtime': 7.28.3
       html-parse-stringify: 3.0.1
-      i18next: 25.4.2(typescript@5.9.2)
+      i18next: 25.4.2(typescript@4.9.5)
       react: 18.3.1
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
-      typescript: 5.9.2
+      typescript: 4.9.5
 
   react-innertext@1.1.5(@types/react@18.3.24)(react@18.3.1):
     dependencies:
@@ -20129,9 +20116,9 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  ts-api-utils@1.4.3(typescript@5.9.2):
+  ts-api-utils@1.4.3(typescript@4.9.5):
     dependencies:
-      typescript: 5.9.2
+      typescript: 4.9.5
 
   ts-dedent@2.2.0: {}
 
@@ -20193,64 +20180,6 @@ snapshots:
       '@microsoft/api-extractor': 7.52.11(@types/node@18.19.123)
       postcss: 8.5.6
       typescript: 4.9.5
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.6.3)(yaml@2.8.1):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.9)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.1
-      esbuild: 0.25.9
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.1)
-      resolve-from: 5.0.0
-      rollup: 4.48.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.11(@types/node@18.19.123)
-      postcss: 8.5.6
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.0(@microsoft/api-extractor@7.52.11(@types/node@18.19.123))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.9)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.1
-      esbuild: 0.25.9
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.1)
-      resolve-from: 5.0.0
-      rollup: 4.48.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.11(@types/node@18.19.123)
-      postcss: 8.5.6
-      typescript: 5.9.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -20346,10 +20275,6 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@4.9.5: {}
-
-  typescript@5.6.3: {}
-
-  typescript@5.8.2: {}
 
   typescript@5.9.2: {}
 


### PR DESCRIPTION
This PR resolves remaining typecheck/build blockers after #60/#62 by:

- Pinning TS toolchain via pnpm overrides (@types/node 18, typescript 4.9.5).
- Aligning Vite types and avoiding NodeNext/bundler incompatibilities.
- Adding global TS path mapping for @hierarchidb/common-type to source.
- Scoped fixes:
  - ui/i18n: restrict types to node; avoid vite/vitest ambient conflicts; Node moduleResolution.
  - feature-registry, util, ui-map: skipLibCheck to mitigate third-party d.ts under isolatedModules.
  - tools/vite-plugin-package-reader: configure tsup DTS entries, then temporarily disable DTS to unblock.
  - common-type, base-plugin: disable DTS for common-type; add path mapping; avoid NodeNext extension errors.

Notes:
- A full TS5 upgrade with moduleResolution=bundler would let us re-enable DTS broadly and remove skipLibCheck.
- I kept changes minimal and reversible; follow-on PR can upgrade TS and revert these mitigations.
