### PR TITLE
chore(bff,cors-proxy): TypeScript 5 にピン留め

### DIFF
--- a/packages/backend/bff/package.json
+++ b/packages/backend/bff/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "dev:manual": "wrangler dev",
-    "build": "tsc --noEmit",
+    "typecheck": "pnpm --package=typescript@5.6.2 dlx tsc -p tsconfig.json --noEmit",
+    "build": "pnpm run typecheck",
     "deploy": "wrangler deploy",
     "deploy:production": "wrangler deploy --env production",
     "clean": "rm -rf dist",

--- a/packages/backend/bff/tsconfig.json
+++ b/packages/backend/bff/tsconfig.json
@@ -9,20 +9,18 @@
         "src/*"
       ]
     },
+    "skipLibCheck": true,
     "types": [
       "@cloudflare/workers-types"
     ],
     "lib": [
-      "es2022",
-      "dom",
-      "webworker",
-      "dom.iterable",
-      "esnext.asynciterable"
+      "ES2022"
     ],
     "target": "es2022",
     "module": "esnext",
     "moduleResolution": "node",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/backend/cors-proxy/package.json
+++ b/packages/backend/cors-proxy/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "scripts": {
     "dev:manual": "wrangler dev",
-    "build": "tsc --noEmit",
+    "typecheck": "pnpm --package=typescript@5.6.2 dlx tsc -p tsconfig.json --noEmit",
+    "build": "pnpm run typecheck",
     "deploy": "wrangler deploy",
     "deploy:production": "wrangler deploy --env production",
     "clean": "rm -rf dist",

--- a/packages/backend/cors-proxy/src/index.ts
+++ b/packages/backend/cors-proxy/src/index.ts
@@ -14,7 +14,7 @@ import {
   Statement,
   ImportDeclaration,
 } from 'ts-morph';
-import globby from 'globby';
+import { globby } from 'globby';
 import minimist from 'minimist';
 import path from 'node:path';
 import fs from 'node:fs/promises';
@@ -271,7 +271,7 @@ async function main() {
 
   const patterns = [...includeGlobs, ...excludeGlobs];
 
-  const files = await globby.globby(patterns, { absolute: true });
+  const files = await globby(patterns, { absolute: true });
 
   for (const absPath of files) {
     const sf = project.addSourceFileAtPath(absPath);

--- a/packages/backend/cors-proxy/tsconfig.json
+++ b/packages/backend/cors-proxy/tsconfig.json
@@ -9,6 +9,7 @@
         "src/*"
       ]
     },
+    "skipLibCheck": true,
     "types": [
       "@cloudflare/workers-types"
     ],
@@ -18,7 +19,8 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "node",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
目的\n- @hierarchidb/bff と @hierarchidb/cors-proxy の型チェックのみ TS 5 系固定。\n\n変更\n- 各 package.json にて typecheck/build を TS 5.6.2 で実行（pnpm dlx）。\n- bff: lib を ES2022 のみに、skipLibCheck 追加。\n- cors-proxy: 同様に skipLibCheck 追加、globby の named import へ修正。\n\n背景\n- ルートは TS 4.9 固定のため、パッケージ単位で TS5 を使用する必要があった。\n- Workers 型と DOM/Node 型の衝突を避けるため lib/types を絞り込み。\n\n検証\n- pnpm --filter @hierarchidb/bff build\n- pnpm --filter @hierarchidb/cors-proxy build\n