### PR TITLE
fix(build): align moduleResolution to node; unblock TS4.9 typecheck

### DIFF
--- a/packages/ui/navigation/src/types/react-router-dom-shim.d.ts
+++ b/packages/ui/navigation/src/types/react-router-dom-shim.d.ts
@@ -1,0 +1,6 @@
+declare module 'react-router-dom' {
+  import * as React from 'react';
+  export const Link: React.FC<React.ComponentProps<'a'> & { to: string }>;
+  export const NavLink: React.FC<React.ComponentProps<'a'> & { to: string }>;
+  export function useLocation(): { pathname: string; search: string; hash: string; state?: unknown; key?: string };
+}

--- a/packages/ui/navigation/tsconfig.json
+++ b/packages/ui/navigation/tsconfig.json
@@ -17,12 +17,14 @@
     "paths": {
       "~/*": [
         "src/*"
+      ],
+      "@hierarchidb/common-type": [
+        "../../common/types/dist/index.d.ts"
       ]
     }
   },
   "include": [
-    "src",
-    "../../common/types/src/**/*.ts"
+    "src"
   ],
   "references": [
     {


### PR DESCRIPTION
Summary\n- Set moduleResolution: node in root + app tsconfigs\n- Resolve TS issues in ui-core (add shims, exclude tests/stories, add Node types)\n- Minimal TS 4.9 fix in tabular-xlsx (ArrayBufferLike cast)\n- Disable DTS bundling in tools/vite-plugin-package-reader (avoid TS6307 during turbo)\n- Add shims/paths for ui-navigation; remaining depends on @hierarchidb/common-type build ordering\n- Update TASKS.md with DoD + log\n\nDetails\n- TS version is 4.9.5; bundler resolution is unsupported and caused TS6046.\n- nodenext enforced file extensions and cascaded TS2835; avoid code churn by using node.\n- Verified targeted packages typecheck/build; full turbo run green except ui-navigation (needs common-type build first).\n\nDoD\n- ui-accordion-config typecheck/build green\n- ui-treeconsole-* group green\n- many UI/shared packages build green in turbo\n\nRollback\n- Revert tsconfig changes in root/app; revert minimal shims.\n