### PR TITLE
fix(ui-map): add addControl to MapLibreMapInstance

### DIFF
--- a/packages/ui/map/src/types/maplibre-public.ts
+++ b/packages/ui/map/src/types/maplibre-public.ts
@@ -37,6 +37,7 @@ export interface MapLibreMapInstance {
   addSource(id: string, source: Record<string, unknown>): void;
   removeSource(id: string): void;
   removeLayer(id: string): void;
+  addControl(control: unknown, position?: string): void;
 }
 
 // Minimal filter type to avoid leaking upstream types


### PR DESCRIPTION
PR: ui-map build error fix (addControl in MapLibreMapInstance)

- Fixes TS2339 in MapWithDeckGL by adding addControl to maplibre-public MapLibreMapInstance.
- Scope: types only; no runtime impact; build and dts succeed.
- Tested: pnpm --filter @hierarchidb/ui-map build (OK).
