### PR TITLE
fix(map-source): suppress TS2865 from ast-types under isolatedModules (v2)

### DIFF
--- a/packages/feature/map-source/tsconfig.json
+++ b/packages/feature/map-source/tsconfig.json
@@ -6,6 +6,8 @@
     "declaration": true,
     "composite": false,
     "moduleResolution": "node",
+    "isolatedModules": false,
+    "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
       "dexie": [


### PR DESCRIPTION
## Summary
Replaces #77 with a minimal, conflict-free PR created from the latest `main`.
Suppress `TS2865` from `ast-types` when typechecking `@hierarchidb/map-source` by relaxing package-local TS settings.

## Changes
- packages/feature/map-source/tsconfig.json
  - `isolatedModules: false` (package-local override)
  - `skipLibCheck: true`

## Rationale
`ast-types@0.16.x` declaration files conflict with `isolatedModules: true` (value imports in d.ts). We cannot patch upstream types.
The relaxation is scoped to this package only and does not affect runtime behavior.

## DoD
- `pnpm -w --filter @hierarchidb/map-source typecheck` passes.

## Rollback
- Revert the tsconfig change.

Supersedes: #77
