### PR TITLE
fix(common-auth): suppress TS2865 from ast-types under isolatedModules

### DIFF
--- a/packages/common/auth/tsconfig.json
+++ b/packages/common/auth/tsconfig.json
@@ -10,6 +10,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
+    "isolatedModules": false,
+    "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary
Suppress `TS2865` (ast-types d.ts) when typechecking `@hierarchidb/common-auth` by relaxing package-local TS settings.

## Changes
- `packages/common/auth/tsconfig.json`
  - `isolatedModules: false`
  - `skipLibCheck: true`

## Rationale
`ast-types@0.16.x` d.ts import values that conflict with `isolatedModules: true`. We cannot alter upstream declarations; the mitigation is constrained to this package only and has no runtime impact.

## DoD
- `pnpm -w --filter @hierarchidb/common-auth typecheck` passes.

## Rollback
- Revert the tsconfig change.
