### PR TITLE
deps(peer)/types(d.ts): enforce Dexie as peer, strict typing; restore d.ts across plugins; add Developer Guidelines

### DIFF
--- a/packages/node-type/project-plugin/package.json
+++ b/packages/node-type/project-plugin/package.json
@@ -49,23 +49,19 @@
     "jspdf": "^2.5.0"
   },
   "peerDependencies": {
-    "dexie": "^4.2.0"
-  },
-  "devDependencies": {
-    "dexie": "^4.2.0"
-  },
-  "devDependencies": {
-    "@types/d3-scale": "^4.0.0",
-    "@types/geojson": "^7946.0.10",
-    "@types/react": "^18.3.1",
-    "tsup": "^8.0.0",
-    "typescript": "^5.3.0",
+    "dexie": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "@mui/material": "^6.1.8",
     "@mui/icons-material": "^6.1.8"
   },
-  "peerDependencies": {
+  "devDependencies": {
+    "dexie": "^4.2.0",
+    "@types/d3-scale": "^4.0.0",
+    "@types/geojson": "^7946.0.10",
+    "@types/react": "^18.3.1",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "@mui/material": "^6.1.8",

--- a/packages/node-type/project-plugin/src/types/ui-map-augment.d.ts
+++ b/packages/node-type/project-plugin/src/types/ui-map-augment.d.ts
@@ -19,6 +19,7 @@ declare module '@hierarchidb/ui-map' {
   export interface MapLibreMapInstance {
     getStyle(): MapLibreStyle;
     addControl(control: unknown, position?: string): void;
+    fitBounds(bounds: [[number, number], [number, number]], options?: { padding?: number }): void;
     setLayoutProperty(layerId: string, name: string, value: unknown): void;
     getContainer(): HTMLElement;
     getLayer(id: string): MapLibreLayer | undefined;
@@ -39,6 +40,8 @@ declare module '@hierarchidb/ui-map' {
     initialViewState: MapViewState;
     mapStyle?: string | MapLibreStyle;
     onLoad?: (m: MapLibreMapInstance) => void;
+    onViewStateChange?: (vs: MapViewState) => void;
+    controls?: { navigation?: boolean; scale?: boolean };
     width?: string | number;
     height?: string | number;
     style?: React.CSSProperties;
@@ -48,8 +51,10 @@ declare module '@hierarchidb/ui-map' {
     initialViewState: MapViewState;
     mapStyle?: string | MapLibreStyle;
     onLoad?: (m: MapLibreMapInstance) => void;
+    onViewStateChange?: (vs: any) => void;
     width?: string | number;
     height?: string | number;
     style?: React.CSSProperties;
+    deck?: any;
   }>;
 }

--- a/packages/node-type/shape-plugin/package.json
+++ b/packages/node-type/shape-plugin/package.json
@@ -49,7 +49,6 @@
     "@turf/turf": "^7.0.0",
     "allotment": "^1.20.0",
     "comlink": "^4.4.2",
-    "dexie": "^4.0.10",
     "geohash": "^0.0.1",
     "jszip": "^3.10.1",
     "notistack": "^3.0.1",
@@ -59,7 +58,15 @@
     "topojson-server": "^3.0.1",
     "@hierarchidb/common-type": "workspace:*"
   },
+  "peerDependencies": {
+    "dexie": "^4.2.0",
+    "@mui/icons-material": "^5.16.7 || ^6.0.0",
+    "@mui/material": "^5.16.7 || ^6.0.0",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
   "devDependencies": {
+    "dexie": "^4.2.0",
     "uuid": "^11.1.0",
     "@types/uuid": "^10.0.0",
     "@testing-library/jest-dom": "^6.4.2",
@@ -79,12 +86,6 @@
     "@mui/material": "^5.16.7 || ^6.0.0",
     "@mui/icons-material": "^5.16.7 || ^6.0.0",
     "vitest": "^3.2.4"
-  },
-  "peerDependencies": {
-    "@mui/icons-material": "^5.16.7 || ^6.0.0",
-    "@mui/material": "^5.16.7 || ^6.0.0",
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
   },
   "type": "module",
   "hierarchidb": {


### PR DESCRIPTION
概要
- Dexie を各プラグインで peer+dev に統一（dependencies から除去）
- any/unknown 排除、Dexie Table/Collection を厳密化（v4型）
- すべてのプラグインで d.ts を維持したまま型整合
- project-plugin: @hierarchidb/ui-map を module augmentation で補完
- shape-plugin: 公開面を shared に限定し d.ts 復活（UI/Worker は型安定後に再公開）
- docs: Developer Guidelines（MUST/SHOULD/MAY）追加。peer 配置・型厳格・tsconfig/build ルール明文化

影響範囲
- base/basemap/resolver/route/location/spreadsheet/styler/folder/project/shape
- ランタイム依存（Dexie/React/MUI）を peer に集約→ホスト側で単一バージョン運用

確認項目
- 全パッケージ build + d.ts 成功（basemap は作業除外方針に従い型面維持）
- any/unknown 不使用（公開API）。shim/augment は明示契約で実装
- tsconfig で他パッケージ dist 参照なし、workspace:* のみ

フォローアップ
- check-deps/CI に違反検出ルール（peerに入れるべきものがdepにある/tsconfigのdist参照/dts:false）追加