### PR TITLE
refactor(i18n): remove fixed language unions

### DIFF
--- a/packages/node-type/location-plugin/README.md
+++ b/packages/node-type/location-plugin/README.md
@@ -141,7 +141,7 @@ interface LocationProcessingConfig {
   // ジオコーディング設定
   geocodingConfig: {
     enableReverseGeocoding: boolean;
-    geocodingLanguage: 'en' | 'ja' | 'local';
+    geocodingLanguage: string; // e.g., 'en', 'ja', or locale code
     includeAdminBoundaries: boolean;
   };
 }

--- a/packages/runtime-worker/worker/src/utils/workerLogger.ts
+++ b/packages/runtime-worker/worker/src/utils/workerLogger.ts
@@ -7,7 +7,7 @@
  */
 
 // Simple translation map for worker logging
-const translations = {
+const translations: Record<string, Record<string, string>> = {
   en: {
     'worker.initialized': 'Worker API initialized',
     'worker.initializationFailed': 'Failed to initialize Worker API',
@@ -25,13 +25,14 @@ const translations = {
 };
 
 // Get current language from storage (if available) or default to English
-const getCurrentLanguage = (): 'en' | 'ja' => {
+const getCurrentLanguage = (): string => {
   try {
     const storage: any = (typeof globalThis !== 'undefined' && (globalThis as any).localStorage)
       ? (globalThis as any).localStorage
       : null;
     const stored = storage ? storage.getItem('i18nextLng') : null;
-    return stored === 'ja' ? 'ja' : 'en';
+    if (typeof stored === 'string' && stored.length > 0) return stored;
+    return 'en';
   } catch {
     return 'en';
   }
@@ -40,7 +41,8 @@ const getCurrentLanguage = (): 'en' | 'ja' => {
 // Simple translation function
 const t = (key: string, interpolations?: Record<string, any>): string => {
   const currentLang = getCurrentLanguage();
-  let text = translations[currentLang][key as keyof (typeof translations)['en']] || key;
+  const langMap = translations[currentLang] || translations.en;
+  let text = langMap[key] || key;
 
   if (interpolations) {
     Object.entries(interpolations).forEach(([k, v]) => {


### PR DESCRIPTION
目的: コード内の 'en' | 'ja' 固定列挙を撤廃し、追加言語をコード改変不要に。

変更:
- workerLogger: 言語型を string 化し、未知言語は 'en' フォールバック
- ドキュメント例: location-plugin README の geocodingLanguage を string に修正

検証: @hierarchidb/runtime-worker と @hierarchidb/app の typecheck 成功

後続PR: feat/i18n/supported-langs-manifest で supportedLngs をデータ駆動化
