### PR TITLE
Pin i18next to v22 across workspace to avoid TS 4.9 type issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,9 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-i18next": "12.3.1",
+    "i18next": "22.5.0"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/packages/ui/auth/package.json
+++ b/packages/ui/auth/package.json
@@ -30,6 +30,7 @@
     "oidc-client-ts": "^3.3.0",
     "react-gravatar": "^2.6.3",
     "react-i18next": "12.3.1",
+    "i18next": "22.5.0",
     "react-oidc-context": "^3.3.0",
     "react-router-dom": "^7.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
+      i18next:
+        specifier: 22.5.0
+        version: 22.5.0
       jscodeshift:
         specifier: ^17.3.0
         version: 17.3.0(@babel/preset-env@7.28.3(@babel/core@7.28.3))
@@ -143,6 +146,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-i18next:
+        specifier: 12.3.1
+        version: 12.3.1(i18next@22.5.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook:
         specifier: 9.1.3
         version: 9.1.3(@testing-library/dom@9.3.4)(prettier@3.6.2)(vite@5.4.19(@types/node@18.19.123)(terser@5.43.1))
@@ -671,6 +677,9 @@ importers:
       '@hierarchidb/ui-map':
         specifier: workspace:*
         version: link:../../ui/map
+      '@hierarchidb/util':
+        specifier: workspace:*
+        version: link:../../util
     devDependencies:
       '@mui/icons-material':
         specifier: ^7.3.1
@@ -893,6 +902,9 @@ importers:
       '@hierarchidb/ui-map':
         specifier: workspace:*
         version: link:../../ui/map
+      '@hierarchidb/util':
+        specifier: workspace:*
+        version: link:../../util
       '@turf/turf':
         specifier: ^7.0.0
         version: 7.2.0
@@ -963,6 +975,9 @@ importers:
       '@hierarchidb/ui-core':
         specifier: workspace:*
         version: link:../../ui/core
+      '@hierarchidb/util':
+        specifier: workspace:*
+        version: link:../../util
       comlink:
         specifier: ^4.4.1
         version: 4.4.2
@@ -1024,6 +1039,12 @@ importers:
       '@hierarchidb/shape-plugin':
         specifier: workspace:*
         version: link:../shape-plugin
+      '@hierarchidb/ui-core':
+        specifier: workspace:*
+        version: link:../../ui/core
+      '@hierarchidb/util':
+        specifier: workspace:*
+        version: link:../../util
       dexie:
         specifier: 4.2.0
         version: 4.2.0
@@ -1676,6 +1697,9 @@ importers:
       '@react-oauth/google':
         specifier: ^0.12.2
         version: 0.12.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      i18next:
+        specifier: 22.5.0
+        version: 22.5.0
       oidc-client-ts:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1684,7 +1708,7 @@ importers:
         version: 2.6.3(react@18.3.1)
       react-i18next:
         specifier: 12.3.1
-        version: 12.3.1(i18next@25.4.2(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 12.3.1(i18next@22.5.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-oidc-context:
         specifier: ^3.3.0
         version: 3.3.0(oidc-client-ts@3.3.0)(react@18.3.1)
@@ -7677,14 +7701,6 @@ packages:
 
   i18next@22.5.0:
     resolution: {integrity: sha512-sqWuJFj+wJAKQP2qBQ+b7STzxZNUmnSxrehBCCj9vDOW9RDYPfqCaK1Hbh2frNYQuPziz6O2CGoJPwtzY3vAYA==}
-
-  i18next@25.4.2:
-    resolution: {integrity: sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==}
-    peerDependencies:
-      typescript: 4.9.5
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -17051,12 +17067,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.3
 
-  i18next@25.4.2(typescript@4.9.5):
-    dependencies:
-      '@babel/runtime': 7.28.3
-    optionalDependencies:
-      typescript: 4.9.5
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -18408,15 +18418,6 @@ snapshots:
       '@babel/runtime': 7.28.3
       html-parse-stringify: 3.0.1
       i18next: 22.5.0
-      react: 18.3.1
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
-
-  react-i18next@12.3.1(i18next@25.4.2(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.28.3
-      html-parse-stringify: 3.0.1
-      i18next: 25.4.2(typescript@4.9.5)
       react: 18.3.1
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
# Pin i18next to v22 across workspace to avoid TS 4.9 type issues

## Summary
- Pins `i18next` to `22.5.0` at the root and in `@hierarchidb/ui-auth` to satisfy `react-i18next`’s peer and avoid v25’s advanced typings that break with TypeScript 4.9.
- Leaves shim removals and UI refactors for separate PRs.

## Changes
- Root `package.json`: add `devDependencies.i18next: 22.5.0`.
- `packages/ui/auth/package.json`: add `dependencies.i18next: 22.5.0`.
- `pnpm-lock.yaml`: updated to resolve `react-i18next@12.3.1` against `i18next@22.5.0`.

## Rationale
- `i18next@25` introduces types incompatible with TS 4.9, producing errors in UI packages.
- Pinning to v22 stabilizes types while we stay on TS 4.9. We can revisit v25 alongside a TS upgrade later.

## Impact
- Runtime: none (v22 remains compatible with current code).
- Type safety: removes `i18next@25`-driven type errors.

## Verification
1. Clean install: `pnpm -w install --force`.
2. Confirm versions: `pnpm -w why i18next` → all importers should resolve to `22.5.0`.
3. Typecheck: `pnpm typecheck` → no i18next-related errors.

## Follow-ups
- Remove spreadsheet i18n shims and tsconfig path aliases in a separate PR.
- Optional CI check to assert `i18next` major is locked to 22 until TS is upgraded.

