### PR TITLE
feat(project): (de)serialization utilities + handler wiring

### DIFF
--- a/PR_BODY_project_serialization.md
+++ b/PR_BODY_project_serialization.md
@@ -1,0 +1,33 @@
+PR: project-plugin に直列化/逆直列化ユーティリティを追加し、Handler を接続
+
+要点
+- `ProjectEntitySerializer` を project-plugin に新規追加し、深い走査で `Uint8Array`/`ArrayBuffer` を検出して UUID 参照へ変換。実体は `Map<string, Uint8Array>` に退避。
+- `ProjectEntityHandler.serialize/deserialize` と配列版を同ユーティリティで実装。
+- `*_Uint8Array` サフィックス規約を尊重し、推奨ファイル名に元キー名を反映。
+- 単体テストを追加（`src/shared/__tests__/serialization.test.ts`）。
+
+ブランチ: `feat/project/serialization-impl`
+対応タスク: TASKS.md > Doing > feat/project/serialization-impl
+
+変更詳細
+- 追加: `packages/node-type/project-plugin/src/shared/serialization.ts`
+  - `ProjectEntitySerializer.serialize/deserialize/(de)serializeEntityArray`
+  - JSON 側は UUID 参照、バイナリは `binaryData`/`binaryFilenames` に分離
+- 更新: `packages/node-type/project-plugin/src/handlers/ProjectEntityHandler.ts`
+  - `serialize/deserialize` と配列版をユーティリティ接続
+- 追加(テスト): `packages/node-type/project-plugin/src/shared/__tests__/serialization.test.ts`
+  - `Uint8Array`/`ArrayBuffer` の往復を検証
+
+受け入れ基準（DoD）
+- [x] `handler.serialize/deserialize` がユーティリティ経由で動作する
+- [x] `Uint8Array`/`ArrayBuffer` を含むエンティティで直列化→復元が可能
+- [x] エンティティ配列 API も同様に通る
+- [x] 追加テストがグリーン
+
+ロールバック
+- `packages/node-type/project-plugin/src/shared/serialization.ts` を削除し、`ProjectEntityHandler` の該当メソッドを元のスタブへ差し戻せば機能的影響は限定的。
+
+フォローアップ
+- エクスポート/インポート層（ファイルI/O）で `binaryFilenames` に基づく保存/読み込みを配線（別PR可）。
+- Project エンティティに将来バイナリ追加時は `*_Uint8Array` 規約に揃えると可読性向上。
+

--- a/TASKS.md
+++ b/TASKS.md
@@ -50,7 +50,10 @@
 
 ### Doing（進行中） <a id="kanban-doing"></a>
 
-- 現在なし（2025-09-06）。方針: マージ後にブランチを削除する運用のため、origin にブランチ不在の作業は Done とみなす。
+- feat/project/serialization-impl（Project の直列化/逆直列化の実装）
+  - ブランチ: `feat/project/serialization-impl`
+  - PR: draft 準備済（`PR_BODY_project_serialization.md`）。push 後に作成予定。
+  - 要点: `ProjectEntitySerializer` 追加し、`ProjectEntityHandler` の serialize/deserialize 系を実装。`Uint8Array`/`ArrayBuffer` を UUID 参照へ退避し Map で同梱。
 
 ---
 
@@ -323,6 +326,7 @@ EPIC) i18nコア統一とロケール伝播（React非依存・言語追加を�
 
 ## 運用ログ（today） <a id="log-today"></a>
 
+- 2025-09-06 start: feat/project/serialization-impl — 実装・テスト追加。PR本文を作成しローカルブランチにコミット完了（push/PR作成はこの後）。
 - 2025-09-06 start: node-type/* プラグイン監査の結果を ToDo に反映（coverage 導入、project/shape/route/location/base/resolver/spreadsheet/styler/basemap/folder の各タスクを追加）。コード差分は未作成。
 - 2025-09-06 done: TASKS.md を運用方針に合わせて同期（Doing→Done へ移動、ブランチ削除運用の注記を追加）。
 

--- a/packages/node-type/project-plugin/src/handlers/ProjectEntityHandler.ts
+++ b/packages/node-type/project-plugin/src/handlers/ProjectEntityHandler.ts
@@ -9,6 +9,7 @@ import { BaseEntityHandler } from '@hierarchidb/base-plugin';
 import type { ProjectEntity, ProjectWorkingCopy, ProjectCategory } from '~/types/project-types';
 import { projectPluginAPI } from '~/api/ProjectPluginAPI';
 import { createWorkingCopyFromEntity, mapWorkingCopyToUpdates } from '../shared/utils';
+import { ProjectEntitySerializer } from '../shared/serialization';
 
 /**
  * Create project data interface
@@ -519,16 +520,16 @@ export class ProjectEntityHandler extends BaseEntityHandler<ProjectEntity, Creat
     binaryData: Map<string, Uint8Array>;
     binaryFilenames: Map<string, string>;
   }> {
-    // TODO: Implement serialization when PluginEntitySerializer is available
-    return { jsonData: entity, binaryData: new Map(), binaryFilenames: new Map() };
+    const { jsonData, binaryData, binaryFilenames } = ProjectEntitySerializer.serialize(entity);
+    return { jsonData, binaryData, binaryFilenames };
   }
 
   /**
    * Deserialize Project entity with binary data restoration
    */
   async deserialize(jsonData: any, _binaryData: Map<string, Uint8Array>): Promise<ProjectEntity> {
-    // TODO: Implement deserialization when PluginEntitySerializer is available
-    return jsonData as ProjectEntity;
+    const restored = ProjectEntitySerializer.deserialize({ jsonData, binaryData: _binaryData });
+    return restored as ProjectEntity;
   }
 
   /**
@@ -539,8 +540,8 @@ export class ProjectEntityHandler extends BaseEntityHandler<ProjectEntity, Creat
     binaryData: Map<string, Uint8Array>;
     binaryFilenames: Map<string, string>;
   }> {
-    // TODO: Implement array serialization when PluginEntitySerializer is available
-    return { jsonArray: entities, binaryData: new Map(), binaryFilenames: new Map() };
+    const { jsonArray, binaryData, binaryFilenames } = ProjectEntitySerializer.serializeEntityArray(entities);
+    return { jsonArray, binaryData, binaryFilenames };
   }
 
   /**
@@ -550,7 +551,7 @@ export class ProjectEntityHandler extends BaseEntityHandler<ProjectEntity, Creat
     jsonArray: any[],
     _binaryData: Map<string, Uint8Array>
   ): Promise<ProjectEntity[]> {
-    // TODO: Implement array deserialization when PluginEntitySerializer is available
-    return jsonArray as ProjectEntity[];
+    const restored = ProjectEntitySerializer.deserializeEntityArray(jsonArray, _binaryData);
+    return restored as ProjectEntity[];
   }
 }

--- a/packages/node-type/project-plugin/src/shared/__tests__/serialization.test.ts
+++ b/packages/node-type/project-plugin/src/shared/__tests__/serialization.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { ProjectEntitySerializer } from '../serialization';
+
+describe('ProjectEntitySerializer', () => {
+  it('extracts Uint8Array into binary map and leaves UUID in json', () => {
+    const input = {
+      id: 'e1',
+      name: 'P',
+      payload_Uint8Array: new Uint8Array([1, 2, 3]),
+      nested: { more_Uint8Array: new Uint8Array([9, 8, 7]) },
+    };
+
+    const { jsonData, binaryData, binaryFilenames } = ProjectEntitySerializer.serialize(input);
+    // json retains strings for those fields
+    expect(typeof jsonData.payload_Uint8Array).toBe('string');
+    expect(typeof jsonData.nested.more_Uint8Array).toBe('string');
+    // binary maps hold two entries
+    expect(binaryData.size).toBe(2);
+    expect(binaryFilenames.size).toBe(2);
+
+    const restored = ProjectEntitySerializer.deserialize({ jsonData, binaryData });
+    expect(restored.payload_Uint8Array).toBeInstanceOf(Uint8Array);
+    expect(restored.nested.more_Uint8Array).toBeInstanceOf(Uint8Array);
+  });
+
+  it('extracts ArrayBuffer into binary map', () => {
+    const buf = new Uint8Array([10, 20, 30]).buffer;
+    const input = { id: 'e2', tileData: buf };
+    const { jsonData, binaryData } = ProjectEntitySerializer.serialize(input);
+    expect(typeof jsonData.tileData).toBe('string');
+    expect(binaryData.size).toBe(1);
+
+    const restored = ProjectEntitySerializer.deserialize({ jsonData, binaryData });
+    // Restored as Uint8Array view
+    expect(restored.tileData).toBeInstanceOf(Uint8Array);
+    expect(Array.from(restored.tileData)).toEqual([10, 20, 30]);
+  });
+});
+

--- a/packages/node-type/project-plugin/src/shared/serialization.ts
+++ b/packages/node-type/project-plugin/src/shared/serialization.ts
@@ -1,0 +1,106 @@
+/**
+ * Project plugin serialization utilities
+ * - Deeply traverses objects
+ * - Extracts binary values (Uint8Array/ArrayBuffer) to a Map keyed by UUID
+ * - Replaces binary values in JSON with the UUID string reference
+ */
+
+export interface SerializationResult {
+  jsonData: any;
+  binaryData: Map<string, Uint8Array>;
+  binaryFilenames: Map<string, string>;
+}
+
+export interface DeserializationInput {
+  jsonData: any;
+  binaryData: Map<string, Uint8Array>;
+}
+
+const BINARY_SUFFIX = '_Uint8Array';
+
+export class ProjectEntitySerializer {
+  static serialize(entity: any): SerializationResult {
+    const binaryData = new Map<string, Uint8Array>();
+    const binaryFilenames = new Map<string, string>();
+    const jsonData = this.processForSerialization(entity, binaryData, binaryFilenames);
+    return { jsonData, binaryData, binaryFilenames };
+  }
+
+  static deserialize(input: DeserializationInput): any {
+    const { jsonData, binaryData } = input;
+    return this.processForDeserialization(jsonData, binaryData);
+  }
+
+  static serializeEntityArray(entities: any[]): {
+    jsonArray: any[];
+    binaryData: Map<string, Uint8Array>;
+    binaryFilenames: Map<string, string>;
+  } {
+    const jsonArray: any[] = [];
+    const binaryData = new Map<string, Uint8Array>();
+    const binaryFilenames = new Map<string, string>();
+    for (const entity of entities) {
+      const res = this.serialize(entity);
+      jsonArray.push(res.jsonData);
+      res.binaryData.forEach((v, k) => binaryData.set(k, v));
+      res.binaryFilenames.forEach((v, k) => binaryFilenames.set(k, v));
+    }
+    return { jsonArray, binaryData, binaryFilenames };
+  }
+
+  static deserializeEntityArray(jsonArray: any[], binaryData: Map<string, Uint8Array>): any[] {
+    return jsonArray.map((jsonData) => this.deserialize({ jsonData, binaryData }));
+  }
+
+  private static processForSerialization(
+    obj: any,
+    binaryData: Map<string, Uint8Array>,
+    binaryFilenames: Map<string, string>,
+    path: string[] = []
+  ): any {
+    if (obj == null || typeof obj !== 'object') return obj;
+    if (obj instanceof Uint8Array) {
+      const uuid = crypto.randomUUID();
+      binaryData.set(uuid, obj);
+      binaryFilenames.set(uuid, `${path[path.length - 1] || 'binary'}_${uuid}.bin`);
+      return uuid;
+    }
+    if (obj instanceof ArrayBuffer) {
+      const uuid = crypto.randomUUID();
+      const view = new Uint8Array(obj);
+      binaryData.set(uuid, view);
+      binaryFilenames.set(uuid, `${path[path.length - 1] || 'binary'}_${uuid}.bin`);
+      return uuid;
+    }
+    if (Array.isArray(obj)) {
+      return obj.map((item, i) => this.processForSerialization(item, binaryData, binaryFilenames, [...path, String(i)]));
+    }
+
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      // If property name follows _Uint8Array convention and value is Uint8Array/ArrayBuffer, prefer that name in filename
+      const keyForName = key.endsWith(BINARY_SUFFIX) ? key.replace(BINARY_SUFFIX, '') : key;
+      result[key] = this.processForSerialization(value as any, binaryData, binaryFilenames, [...path, keyForName]);
+    }
+    return result;
+  }
+
+  private static processForDeserialization(obj: any, binaryData: Map<string, Uint8Array>): any {
+    if (obj == null || typeof obj !== 'object') return obj;
+    if (Array.isArray(obj)) return obj.map((item) => this.processForDeserialization(item, binaryData));
+
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === 'string' && binaryData.has(value)) {
+        // Restore as Uint8Array when a UUID reference is present
+        result[key] = binaryData.get(value);
+      } else if (typeof value === 'object') {
+        result[key] = this.processForDeserialization(value, binaryData);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+}
+


### PR DESCRIPTION
PR: project-plugin に直列化/逆直列化ユーティリティを追加し、Handler を接続

要点
- `ProjectEntitySerializer` を project-plugin に新規追加し、深い走査で `Uint8Array`/`ArrayBuffer` を検出して UUID 参照へ変換。実体は `Map<string, Uint8Array>` に退避。
- `ProjectEntityHandler.serialize/deserialize` と配列版を同ユーティリティで実装。
- `*_Uint8Array` サフィックス規約を尊重し、推奨ファイル名に元キー名を反映。
- 単体テストを追加（`src/shared/__tests__/serialization.test.ts`）。

ブランチ: `feat/project/serialization-impl`
対応タスク: TASKS.md > Doing > feat/project/serialization-impl

変更詳細
- 追加: `packages/node-type/project-plugin/src/shared/serialization.ts`
  - `ProjectEntitySerializer.serialize/deserialize/(de)serializeEntityArray`
  - JSON 側は UUID 参照、バイナリは `binaryData`/`binaryFilenames` に分離
- 更新: `packages/node-type/project-plugin/src/handlers/ProjectEntityHandler.ts`
  - `serialize/deserialize` と配列版をユーティリティ接続
- 追加(テスト): `packages/node-type/project-plugin/src/shared/__tests__/serialization.test.ts`
  - `Uint8Array`/`ArrayBuffer` の往復を検証

受け入れ基準（DoD）
- [x] `handler.serialize/deserialize` がユーティリティ経由で動作する
- [x] `Uint8Array`/`ArrayBuffer` を含むエンティティで直列化→復元が可能
- [x] エンティティ配列 API も同様に通る
- [x] 追加テストがグリーン

ロールバック
- `packages/node-type/project-plugin/src/shared/serialization.ts` を削除し、`ProjectEntityHandler` の該当メソッドを元のスタブへ差し戻せば機能的影響は限定的。

フォローアップ
- エクスポート/インポート層（ファイルI/O）で `binaryFilenames` に基づく保存/読み込みを配線（別PR可）。
- Project エンティティに将来バイナリ追加時は `*_Uint8Array` 規約に揃えると可読性向上。

