### PR TITLE
Add Deck.gl vector tile highlight story

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 
 /**
  * This function is used to resolve the absolute path of a package.
@@ -31,7 +31,10 @@ const config: StorybookConfig = {
         ...config.resolve,
         alias: {
           ...config.resolve?.alias,
-          // 必要に応じてエイリアスを追加
+          '@deck.gl/core': resolve(__dirname, '../packages/node-type/linker-plugin/node_modules/@deck.gl/core'),
+          '@deck.gl/layers': resolve(__dirname, '../packages/node-type/linker-plugin/node_modules/@deck.gl/layers'),
+          '@deck.gl/geo-layers': resolve(__dirname, '../packages/node-type/linker-plugin/node_modules/@deck.gl/geo-layers'),
+          '@deck.gl/mapbox': resolve(__dirname, '../packages/node-type/linker-plugin/node_modules/@deck.gl/mapbox'),
         },
       },
     };

--- a/packages/ui/map/src/stories/MapWithDeckGLVectorTiles.stories.tsx
+++ b/packages/ui/map/src/stories/MapWithDeckGLVectorTiles.stories.tsx
@@ -1,0 +1,231 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useMemo } from 'react';
+import type { Feature, Polygon } from 'geojson';
+import { TileLayer } from '@deck.gl/geo-layers';
+import { GeoJsonLayer } from '@deck.gl/layers';
+import MapWithDeckGL from '../components/MapWithDeckGL';
+import { DEFAULT_MAP_CONFIG } from '../types/unified-map-props';
+
+type PrefectureFeatureProperties = {
+  name: string;
+  prefecture: string;
+  description: string;
+};
+
+type PrefectureFeature = Feature<Polygon, PrefectureFeatureProperties>;
+
+type HighlightArgs = {
+  /** Highlight feature that matches this id */
+  highlightId?: string;
+  /** GeoJSON property key to test */
+  matchProperty?: keyof PrefectureFeatureProperties;
+  /** Expected property value to highlight */
+  matchValue?: string;
+};
+
+const INITIAL_VIEW_STATE = {
+  longitude: 139.7,
+  latitude: 35.6,
+  zoom: 9,
+  pitch: 0,
+  bearing: 0,
+};
+
+const BASE_FILL_COLOR: [number, number, number, number] = [180, 196, 210, 110];
+const HIGHLIGHT_FILL_COLOR: [number, number, number, number] = [234, 102, 60, 210];
+const OUTLINE_COLOR: [number, number, number, number] = [64, 64, 64, 220];
+
+const PREFECTURE_FEATURES: PrefectureFeature[] = [
+  {
+    type: 'Feature',
+    id: 'tokyo-central',
+    properties: {
+      name: 'Tokyo Station Area',
+      prefecture: 'Tokyo',
+      description: 'Represents the Marunouchi business district around Tokyo Station.',
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [139.75, 35.69],
+          [139.77, 35.69],
+          [139.77, 35.67],
+          [139.75, 35.67],
+          [139.75, 35.69],
+        ],
+      ],
+    },
+  },
+  {
+    type: 'Feature',
+    id: 'yokohama-bay',
+    properties: {
+      name: 'Yokohama Bay Area',
+      prefecture: 'Kanagawa',
+      description: 'Covers the Minato Mirai district around Yokohama port.',
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [139.63, 35.47],
+          [139.66, 35.47],
+          [139.66, 35.44],
+          [139.63, 35.44],
+          [139.63, 35.47],
+        ],
+      ],
+    },
+  },
+  {
+    type: 'Feature',
+    id: 'saitama-city',
+    properties: {
+      name: 'Saitama City Center',
+      prefecture: 'Saitama',
+      description: 'Highlights the Omiya district within Saitama prefecture.',
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [139.63, 35.92],
+          [139.66, 35.92],
+          [139.66, 35.89],
+          [139.63, 35.89],
+          [139.63, 35.92],
+        ],
+      ],
+    },
+  },
+];
+
+const PREFECTURE_IDS = PREFECTURE_FEATURES.map((feature) => feature.id as string);
+const PREFECTURE_NAMES = Array.from(new Set(PREFECTURE_FEATURES.map((feature) => feature.properties.prefecture)));
+
+const createVectorTileLayer = ({ highlightId, matchProperty, matchValue }: HighlightArgs) =>
+  new TileLayer<PrefectureFeature[]>({
+    id: 'prefecture-vector-tiles',
+    tileSize: 512,
+    minZoom: 5,
+    maxZoom: 12,
+    getTileData: () => PREFECTURE_FEATURES,
+    renderSubLayers: (props) => {
+      const data = (props.data as PrefectureFeature[]) ?? [];
+      return new GeoJsonLayer<PrefectureFeatureProperties>({
+        ...props,
+        id: `${props.id}-geojson`,
+        data,
+        stroked: true,
+        filled: true,
+        getLineColor: OUTLINE_COLOR,
+        lineWidthMinPixels: 1.5,
+        pickable: true,
+        getFillColor: (feature) => {
+          if (!feature) return BASE_FILL_COLOR;
+          const featureId = (feature.id as string | number | undefined)?.toString();
+          const matchesId = highlightId ? featureId === highlightId : false;
+          const matchesProperty = matchProperty && matchValue
+            ? feature.properties?.[matchProperty] === matchValue
+            : false;
+          return matchesId || matchesProperty ? HIGHLIGHT_FILL_COLOR : BASE_FILL_COLOR;
+        },
+        updateTriggers: {
+          getFillColor: [highlightId, matchProperty, matchValue],
+        },
+      });
+    },
+  });
+
+const VectorTileHighlightDemo = ({ highlightId, matchProperty, matchValue }: HighlightArgs) => {
+  const layers = useMemo(
+    () => [createVectorTileLayer({ highlightId, matchProperty, matchValue })],
+    [highlightId, matchProperty, matchValue],
+  );
+
+  return (
+    <MapWithDeckGL
+      initialViewState={INITIAL_VIEW_STATE}
+      mapStyle={DEFAULT_MAP_CONFIG.mapStyle}
+      height="520px"
+      deck={{
+        layers,
+        getTooltip: ({ object }) =>
+          object
+            ? {
+                text: `${object.properties?.name}\n${object.properties?.prefecture}`,
+              }
+            : null,
+      }}
+      style={{ minHeight: '520px', borderRadius: 12, overflow: 'hidden', boxShadow: '0 12px 30px rgba(15, 23, 42, 0.18)' }}
+    />
+  );
+};
+
+const meta = {
+  title: 'Map/Deck.gl Vector Tiles/Feature Highlight',
+  component: VectorTileHighlightDemo,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Deck.gl の TileLayer + GeoJsonLayer を利用して、指定した ID もしくはプロパティ値に一致するフィーチャーだけを強調表示します。',
+      },
+    },
+  },
+  argTypes: {
+    highlightId: {
+      options: PREFECTURE_IDS,
+      control: { type: 'select' },
+      description: '塗りつぶし対象にしたいフィーチャー ID',
+    },
+    matchProperty: {
+      options: ['prefecture'],
+      control: { type: 'select' },
+      description: '判定に利用する GeoJSON プロパティのキー',
+    },
+    matchValue: {
+      options: PREFECTURE_NAMES,
+      control: { type: 'select' },
+      description: '判定に利用する GeoJSON プロパティの値',
+    },
+  },
+} satisfies Meta<typeof VectorTileHighlightDemo>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const HighlightById: Story = {
+  name: 'ID での強調表示',
+  args: {
+    highlightId: 'yokohama-bay',
+    matchProperty: undefined,
+    matchValue: undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'ID が `yokohama-bay` のタイルだけを Deck.gl のカラー設定で強調表示します。',
+      },
+    },
+  },
+};
+
+export const HighlightByPropertyValue: Story = {
+  name: 'プロパティ値での強調表示',
+  args: {
+    highlightId: undefined,
+    matchProperty: 'prefecture',
+    matchValue: 'Tokyo',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '`prefecture` プロパティが `Tokyo` のフィーチャーだけを塗り分ける例です。',
+      },
+    },
+  },
+};

--- a/packages/ui/map/tsconfig.json
+++ b/packages/ui/map/tsconfig.json
@@ -15,6 +15,21 @@
     "paths": {
       "~/*": [
         "./src/*"
+      ],
+      "@deck.gl/core": [
+        "../../node-type/linker-plugin/node_modules/@deck.gl/core"
+      ],
+      "@deck.gl/layers": [
+        "../../node-type/linker-plugin/node_modules/@deck.gl/layers"
+      ],
+      "@deck.gl/geo-layers": [
+        "../../node-type/linker-plugin/node_modules/@deck.gl/geo-layers"
+      ],
+      "@deck.gl/mapbox": [
+        "../../node-type/linker-plugin/node_modules/@deck.gl/mapbox"
+      ],
+      "geojson": [
+        "../../node-type/linker-plugin/node_modules/@types/geojson"
       ]
     },
     "lib": [


### PR DESCRIPTION
## Summary
- add a new Storybook example that renders Deck.gl vector tiles and highlights features by id or property
- wire Storybook's Vite config to resolve Deck.gl packages from the existing linker-plugin workspace dependencies
- teach the map package's tsconfig about local Deck.gl and GeoJSON type paths so the story type-checks

## Testing
- pnpm -C packages/ui/map typecheck
- pnpm -C packages/ui/map build

------
https://chatgpt.com/codex/tasks/task_e_68ca19dbeba883238be8b65550a94d79