### PR TITLE
feat(ui-map): support feature identification on click

### DIFF
--- a/packages/ui/map/src/components/MapLibreMap.stories.tsx
+++ b/packages/ui/map/src/components/MapLibreMap.stories.tsx
@@ -1,0 +1,190 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useCallback, useState } from 'react';
+import { Box, Divider, Paper, Stack, Typography } from '@mui/material';
+import { MapLibreMap } from './MapLibreMap';
+import type { MapLibreMapInstance } from '../types/maplibre-public';
+import type {
+  MapClickEvent,
+  MapFeatureIdentifyResult,
+  MapFeatureIdentifier,
+} from '../types/unified-map-props';
+
+const DEMO_SOURCE_ID = 'demo-click-points';
+const DEMO_LAYER_ID = 'demo-click-points-layer';
+const DEMO_LABEL_LAYER_ID = 'demo-click-points-label';
+
+const DEMO_POINTS_GEOJSON = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      id: 'tokyo-station',
+      properties: {
+        name: '東京駅',
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [139.767125, 35.681236],
+      },
+    },
+    {
+      type: 'Feature',
+      id: 'osaka-station',
+      properties: {
+        name: '大阪駅',
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [135.498302, 34.702485],
+      },
+    },
+    {
+      type: 'Feature',
+      id: 'sapporo-station',
+      properties: {
+        name: '札幌駅',
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [141.350755, 43.068661],
+      },
+    },
+  ],
+} as const;
+
+const ensureDemoLayers = (map: MapLibreMapInstance) => {
+  if (!map.getSource(DEMO_SOURCE_ID)) {
+    map.addSource(DEMO_SOURCE_ID, {
+      type: 'geojson',
+      data: DEMO_POINTS_GEOJSON as unknown,
+    } as Record<string, unknown>);
+  }
+
+  if (!map.getLayer(DEMO_LAYER_ID)) {
+    map.addLayer({
+      id: DEMO_LAYER_ID,
+      type: 'circle',
+      source: DEMO_SOURCE_ID,
+      paint: {
+        'circle-radius': 10,
+        'circle-color': '#F57C00',
+        'circle-stroke-color': '#ffffff',
+        'circle-stroke-width': 2,
+      },
+    });
+  }
+
+  if (!map.getLayer(DEMO_LABEL_LAYER_ID)) {
+    map.addLayer({
+      id: DEMO_LABEL_LAYER_ID,
+      type: 'symbol',
+      source: DEMO_SOURCE_ID,
+      layout: {
+        'text-field': ['get', 'name'],
+        'text-size': 14,
+        'text-offset': [0, 1.2],
+        'text-anchor': 'top',
+      },
+      paint: {
+        'text-color': '#1a237e',
+      },
+    });
+  }
+};
+
+const meta = {
+  title: 'UI Map/MapLibreMap',
+  component: MapLibreMap,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MapLibreMap>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const FeatureIdentifyContent: React.FC = () => {
+  const [identifyResult, setIdentifyResult] = useState<MapFeatureIdentifyResult | null>(null);
+  const [eventIds, setEventIds] = useState<MapFeatureIdentifier[]>([]);
+
+  const handleMapLoad = useCallback((map: MapLibreMapInstance) => {
+    ensureDemoLayers(map);
+  }, []);
+
+  const handleIdentify = useCallback((result: MapFeatureIdentifyResult) => {
+    setIdentifyResult(result);
+  }, []);
+
+  const handleClick = useCallback((event: MapClickEvent) => {
+    setEventIds(event.identifiedFeatureIds ?? []);
+  }, []);
+
+  const identifyItems = identifyResult?.featureIds ?? [];
+
+  return (
+    <Stack spacing={2} sx={{ height: '100%', p: 2 }}>
+      <Box sx={{ flexGrow: 1, minHeight: 360, borderRadius: 2, overflow: 'hidden', boxShadow: 1 }}>
+        <MapLibreMap
+          width="100%"
+          height="100%"
+          initialViewState={{ longitude: 137.0, latitude: 37.5, zoom: 4.5 }}
+          identifyFeatureOnClick={{
+            layerIds: [DEMO_LAYER_ID],
+            radius: 12,
+            onIdentify: handleIdentify,
+          }}
+          onLoad={handleMapLoad}
+          onClick={handleClick}
+        />
+      </Box>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="subtitle1" gutterBottom>
+          クリックしたフィーチャー
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          identifyFeatureOnClick と onClick(event.identifiedFeatureIds) で取得したIDの例です。
+        </Typography>
+        <Divider sx={{ my: 1.5 }} />
+        <Typography variant="subtitle2">identifyFeatureOnClick.onIdentify</Typography>
+        {identifyItems.length ? (
+          <Stack component="ul" spacing={0.5} sx={{ pl: 3, my: 1 }}>
+            {identifyItems.map((id) => (
+              <Typography component="li" variant="body2" key={`identify-${String(id)}`}>
+                {String(id)}
+              </Typography>
+            ))}
+          </Stack>
+        ) : (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            まだフィーチャーはクリックされていません。
+          </Typography>
+        )}
+        <Divider sx={{ my: 1.5 }} />
+        <Typography variant="subtitle2">onClick: event.identifiedFeatureIds</Typography>
+        {eventIds.length ? (
+          <Stack component="ul" spacing={0.5} sx={{ pl: 3, my: 1 }}>
+            {eventIds.map((id) => (
+              <Typography component="li" variant="body2" key={`event-${String(id)}`}>
+                {String(id)}
+              </Typography>
+            ))}
+          </Stack>
+        ) : (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            こちらもクリックすると更新されます。
+          </Typography>
+        )}
+      </Paper>
+    </Stack>
+  );
+};
+
+export const IdentifyFeaturesOnClick: Story = {
+  name: 'フィーチャーIDの取得',
+  args: {
+    initialViewState: { longitude: 137.0, latitude: 37.5, zoom: 4.5 },
+  },
+  render: () => <FeatureIdentifyContent />,
+};
+

--- a/packages/ui/map/src/components/MapLibreMap.tsx
+++ b/packages/ui/map/src/components/MapLibreMap.tsx
@@ -5,8 +5,14 @@
 
 import React, { useCallback, useRef, useState } from 'react';
 import { Map as ReactMapLibreMap, MapProvider } from '@vis.gl/react-maplibre';
-import type { MapLibreMapInstance } from '../types/maplibre-public';
-import { BaseMapProps, DEFAULT_MAP_CONFIG } from '../types/unified-map-props';
+import type { MapLibreGeoJSONFeature, MapLibreMapInstance } from '../types/maplibre-public';
+import {
+  BaseMapProps,
+  DEFAULT_MAP_CONFIG,
+  type MapClickEvent,
+  type MapFeatureIdentifyResult,
+  type MapFeatureIdentifier,
+} from '../types/unified-map-props';
 // Load MapLibre CSS only in browser contexts to avoid worker/SSR errors
 if (typeof document !== 'undefined') {
   // dynamic import prevents Vite HMR client from injecting styles in workers
@@ -34,6 +40,51 @@ export interface MapLibreMapProps extends BaseMapProps {
 // Default values from unified config
 const { mapStyle: defaultMapStyle, interactionOptions: defaultMapOptions } = DEFAULT_MAP_CONFIG;
 
+const DEFAULT_IDENTIFY_RADIUS = 5;
+const FALLBACK_ID_PROPERTY_KEYS = ['id', 'ID', 'Id', 'feature_id', 'featureId', 'FEATURE_ID', 'OBJECTID', 'objectid'];
+
+const defaultFeatureIdAccessor = (feature: MapLibreGeoJSONFeature | null | undefined): MapFeatureIdentifier | undefined => {
+  if (!feature) return undefined;
+  const { id, properties } = feature;
+
+  if (typeof id === 'string' || typeof id === 'number') {
+    return id as MapFeatureIdentifier;
+  }
+
+  const props = (properties as Record<string, unknown> | null | undefined) ?? undefined;
+  if (!props) return undefined;
+
+  for (const key of FALLBACK_ID_PROPERTY_KEYS) {
+    const value = props[key];
+    if (typeof value === 'string' || typeof value === 'number') {
+      return value as MapFeatureIdentifier;
+    }
+  }
+
+  return undefined;
+};
+
+const filterFeaturesByLayer = (
+  features: MapLibreGeoJSONFeature[] | undefined,
+  layerIds?: string[],
+): MapLibreGeoJSONFeature[] => {
+  if (!Array.isArray(features) || features.length === 0) {
+    return [];
+  }
+
+  if (!layerIds || layerIds.length === 0) {
+    return features.filter((feature): feature is MapLibreGeoJSONFeature => Boolean(feature));
+  }
+
+  const allowed = new Set(layerIds);
+  return features.filter((feature): feature is MapLibreGeoJSONFeature => {
+    if (!feature) return false;
+    const layerId = feature.layer?.id;
+    if (!layerId) return false;
+    return allowed.has(layerId);
+  });
+};
+
 export const MapLibreMap: React.FC<MapLibreMapProps> = ({
                                                           initialViewState,
                                                           mapStyle = defaultMapStyle,
@@ -46,9 +97,78 @@ export const MapLibreMap: React.FC<MapLibreMapProps> = ({
                                                           children,
                                                           mapOptions = defaultMapOptions,
                                                           controls,
+                                                          identifyFeatureOnClick,
                                                         }) => {
   const mapRef = useRef<MapLibreMapInstance | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
+
+  const identifyFeaturesAtClick = useCallback(
+    (event: MapClickEvent): MapFeatureIdentifyResult | null => {
+      if (!identifyFeatureOnClick) {
+        return null;
+      }
+
+      const { layerIds, radius, getFeatureId, onIdentify } = identifyFeatureOnClick;
+      const searchRadius = typeof radius === 'number' && radius >= 0 ? radius : DEFAULT_IDENTIFY_RADIUS;
+
+      const map = mapRef.current;
+      let features: MapLibreGeoJSONFeature[] | undefined;
+
+      if (map && typeof map.queryRenderedFeatures === 'function' && event.point) {
+        try {
+          const queryGeometry =
+            searchRadius > 0
+              ? (
+                  [
+                    [event.point.x - searchRadius, event.point.y - searchRadius],
+                    [event.point.x + searchRadius, event.point.y + searchRadius],
+                  ] as const
+                )
+              : event.point;
+
+          const queryOptions = layerIds && layerIds.length > 0 ? { layers: layerIds } : undefined;
+          const queried = map.queryRenderedFeatures(queryGeometry as any, queryOptions);
+          if (Array.isArray(queried)) {
+            features = queried as MapLibreGeoJSONFeature[];
+          }
+        } catch (error) {
+          console.warn('MapLibreMap: queryRenderedFeatures failed, falling back to event features.', error);
+        }
+      }
+
+      if ((!features || features.length === 0) && Array.isArray(event.features)) {
+        features = event.features as MapLibreGeoJSONFeature[];
+      }
+
+      const filteredFeatures = filterFeaturesByLayer(features, layerIds);
+      const idAccessor = getFeatureId ?? defaultFeatureIdAccessor;
+
+      const seenIds = new Set<MapFeatureIdentifier>();
+      const featureIds: MapFeatureIdentifier[] = [];
+
+      for (const feature of filteredFeatures) {
+        const candidate = idAccessor(feature);
+        if (candidate === null || candidate === undefined) {
+          continue;
+        }
+        if (!seenIds.has(candidate)) {
+          seenIds.add(candidate);
+          featureIds.push(candidate);
+        }
+      }
+
+      const result: MapFeatureIdentifyResult = {
+        featureIds,
+        features: filteredFeatures,
+        originalEvent: event,
+      };
+
+      onIdentify?.(result);
+
+      return result;
+    },
+    [identifyFeatureOnClick],
+  );
 
   const handleMapLoad = useCallback((e: any) => {
     const map = e.target;
@@ -95,6 +215,26 @@ export const MapLibreMap: React.FC<MapLibreMapProps> = ({
     }
   }, [onViewStateChange]);
 
+  const handleMapClick = useCallback(
+    (event: any) => {
+      const mapEvent = event as MapClickEvent;
+      const identifyResult = identifyFeaturesAtClick(mapEvent);
+
+      if (onClick) {
+        if (identifyResult) {
+          onClick({
+            ...mapEvent,
+            identifiedFeatureIds: identifyResult.featureIds,
+            identifiedFeatures: identifyResult.features,
+          });
+        } else {
+          onClick(mapEvent);
+        }
+      }
+    },
+    [identifyFeaturesAtClick, onClick],
+  );
+
   const containerStyle: React.CSSProperties = {
     width,
     height,
@@ -116,7 +256,7 @@ export const MapLibreMap: React.FC<MapLibreMapProps> = ({
           initialViewState={initialViewState}
           onLoad={handleMapLoad}
           onMove={handleViewStateChange}
-          onClick={onClick}
+          onClick={handleMapClick}
           interactive={mapOptions.interactive}
           scrollZoom={mapOptions.scrollZoom}
           dragPan={mapOptions.dragPan}

--- a/packages/ui/map/src/components/MapWithVectorTiles.tsx
+++ b/packages/ui/map/src/components/MapWithVectorTiles.tsx
@@ -61,6 +61,7 @@ export const MapWithVectorTiles: React.FC<MapWithVectorTilesProps> = ({
                                                                         onViewStateChange,
                                                                         onClick,
                                                                         mapOptions,
+                                                                        identifyFeatureOnClick,
 
                                                                         // Layer configuration
                                                                         layerConfig = {},
@@ -92,6 +93,7 @@ export const MapWithVectorTiles: React.FC<MapWithVectorTilesProps> = ({
       onLoad={handleMapLoad}
       onViewStateChange={onViewStateChange}
       onClick={onClick || onMapClick}
+      identifyFeatureOnClick={identifyFeatureOnClick}
       mapOptions={mapOptions}
     >
       {mapInstance && (dbName || tiles || tileDataProvider) && (

--- a/packages/ui/map/src/index.ts
+++ b/packages/ui/map/src/index.ts
@@ -15,6 +15,11 @@ export type {
   MapInteractionOptions,
   MapDimensionsProps,
   MapEventHandlers,
+  MapFeatureIdentifier,
+  MapClickEvent,
+  MapFeatureIdentifyResult,
+  MapFeatureIdentifyConfig,
+  MapIdentifyProps,
   BaseMapProps,
   VectorTileLayerConfig,
   VectorTileDataSource,
@@ -34,4 +39,14 @@ export type { DeckOverlayProps } from './components/MapWithDeckGL';
 export * from './presets/vectorLayers';
 
 //  Stable public typings do not leak upstream maplibre-gl types
-export type { MapLibreMapInstance, MapLibreStyle, MapLibreLayer, MapLibreFilter } from './types/maplibre-public';
+export type {
+  MapLibreMapInstance,
+  MapLibreStyle,
+  MapLibreLayer,
+  MapLibreFilter,
+  MapLibreGeoJSONFeature,
+  MapLibreFeatureIdentifier,
+  MapLibreMapMouseEvent,
+  MapLibrePoint,
+  MapLibreQueryGeometry,
+} from './types/maplibre-public';

--- a/packages/ui/map/src/types/maplibre-public.ts
+++ b/packages/ui/map/src/types/maplibre-public.ts
@@ -23,6 +23,24 @@ export interface MapLibreStyle {
   sources: Record<string, unknown>;
 }
 
+export type MapLibreFeatureIdentifier = string | number;
+
+export interface MapLibreGeoJSONFeature {
+  id?: MapLibreFeatureIdentifier;
+  properties?: Record<string, unknown> | null;
+  layer?: { id?: string };
+}
+
+export interface MapLibrePoint {
+  x: number;
+  y: number;
+}
+
+export type MapLibreQueryGeometry =
+  | MapLibrePoint
+  | [number, number]
+  | [[number, number], [number, number]];
+
 export interface MapLibreMapInstance {
   getStyle(): MapLibreStyle;
 
@@ -52,6 +70,8 @@ export interface MapLibreMapInstance {
 
   addControl(control: unknown, position?: string): void;
 
+  queryRenderedFeatures(geometry?: MapLibreQueryGeometry, parameters?: { layers?: string[]; filter?: MapLibreFilter }): MapLibreGeoJSONFeature[];
+
   // Commonly used convenience methods (subset of MapLibre Map API)
   zoomIn(): void;
   zoomOut(): void;
@@ -59,6 +79,14 @@ export interface MapLibreMapInstance {
   setPitch(pitch: number): void;
   setStyle(style: string | MapLibreStyle): void;
   fitBounds(bounds: [[number, number], [number, number]], options?: { padding?: number }): void;
+}
+
+export interface MapLibreMapMouseEvent {
+  target: MapLibreMapInstance;
+  point: MapLibrePoint;
+  lngLat: { lng: number; lat: number };
+  features?: MapLibreGeoJSONFeature[];
+  originalEvent?: MouseEvent;
 }
 
 // Minimal filter type to avoid leaking upstream types

--- a/packages/ui/map/src/types/unified-map-props.ts
+++ b/packages/ui/map/src/types/unified-map-props.ts
@@ -23,7 +23,14 @@
  *    - Clear separation between data source and display configuration
  */
 
-import type { MapLibreFilter, MapLibreMapInstance, MapLibreStyle } from './maplibre-public';
+import type {
+  MapLibreFeatureIdentifier,
+  MapLibreFilter,
+  MapLibreGeoJSONFeature,
+  MapLibreMapInstance,
+  MapLibreMapMouseEvent,
+  MapLibreStyle,
+} from './maplibre-public';
 
 /**
  * Base map view state - shared across all map components
@@ -83,6 +90,13 @@ export interface MapDimensionsProps {
  * RATIONALE: Consistent naming prevents confusion when switching between components
  * All callbacks now follow the same pattern: on[Event] instead of on[Map][Event]
  */
+export type MapFeatureIdentifier = MapLibreFeatureIdentifier;
+
+export interface MapClickEvent extends MapLibreMapMouseEvent {
+  identifiedFeatureIds?: MapFeatureIdentifier[];
+  identifiedFeatures?: MapLibreGeoJSONFeature[];
+}
+
 export interface MapEventHandlers {
   /** Callback when map loads and is ready for interaction */
   onLoad?: (map: MapLibreMapInstance) => void;
@@ -91,7 +105,32 @@ export interface MapEventHandlers {
   onViewStateChange?: (viewState: MapViewState) => void;
 
   /** Callback when map is clicked */
-  onClick?: (event: any) => void;
+  onClick?: (event: MapClickEvent) => void;
+}
+
+export interface MapFeatureIdentifyResult {
+  featureIds: MapFeatureIdentifier[];
+  features: MapLibreGeoJSONFeature[];
+  originalEvent: MapClickEvent;
+}
+
+export interface MapFeatureIdentifyConfig {
+  /** MapLibre layer IDs to query for features */
+  layerIds?: string[];
+
+  /** Radius in screen pixels used for feature querying (defaults to 5px) */
+  radius?: number;
+
+  /** Custom accessor to derive a stable identifier from a feature */
+  getFeatureId?: (feature: MapLibreGeoJSONFeature) => MapFeatureIdentifier | null | undefined;
+
+  /** Optional callback invoked when identification finishes */
+  onIdentify?: (result: MapFeatureIdentifyResult) => void;
+}
+
+export interface MapIdentifyProps {
+  /** Enables feature identification on map clicks */
+  identifyFeatureOnClick?: MapFeatureIdentifyConfig;
 }
 
 /**
@@ -102,7 +141,7 @@ export interface MapEventHandlers {
  * - Serves as foundation for all map component props
  * - Enables consistent API across MapLibreMap and MapWithVectorTiles
  */
-export interface BaseMapProps extends MapDimensionsProps, MapEventHandlers {
+export interface BaseMapProps extends MapDimensionsProps, MapEventHandlers, MapIdentifyProps {
   /** Initial view state for the map */
   initialViewState: MapViewState;
 


### PR DESCRIPTION
## Summary
- add `identifyFeatureOnClick` configuration to MapLibre map components and emit identified feature ids
- extend the shared MapLibre typings and exports to cover queryRenderedFeatures-based identification
- document the behaviour with a Storybook example that renders a clickable demo layer

## Testing
- pnpm -C packages/ui/map typecheck
- pnpm -C packages/ui/map build

------
https://chatgpt.com/codex/tasks/task_e_68ca1d97b80c8323b61c61826b277ecd