### PR TITLE
feat(route): add shortest route finder between locations

### DIFF
--- a/packages/node-type/route-plugin/src/entities/RouteEntityHandler.ts
+++ b/packages/node-type/route-plugin/src/entities/RouteEntityHandler.ts
@@ -308,6 +308,107 @@ export class RouteEntityHandler extends BaseEntityHandler<RouteEntity, Partial<R
   }
 
   /**
+   * Find the shortest sequence of routes that connects two locations.
+   * Uses Dijkstra's algorithm with route distance as the edge weight.
+   * Returns an empty array when no connecting routes are available.
+   */
+  async getShortestRouteSetBetweenLocations(
+    startLocationId: NodeId,
+    endLocationId: NodeId,
+  ): Promise<RouteEntity[]> {
+    if (startLocationId === endLocationId) {
+      return [];
+    }
+
+    const routes = (await this.table.toArray()) as RouteEntity[];
+    const adjacency = new Map<NodeId, Array<{ to: NodeId; route: RouteEntity; weight: number }>>();
+
+    for (const route of routes) {
+      const start = route.startLocationId;
+      const end = route.endLocationId;
+      if (!start || !end || start === end) {
+        continue;
+      }
+
+      const weight = this.getRouteWeight(route);
+      if (weight === null) {
+        continue;
+      }
+
+      let edges = adjacency.get(start);
+      if (!edges) {
+        edges = [];
+        adjacency.set(start, edges);
+      }
+
+      edges.push({ to: end, route, weight });
+    }
+
+    if (!adjacency.has(startLocationId)) {
+      return [];
+    }
+
+    const distances = new Map<NodeId, number>();
+    const previousNodes = new Map<NodeId, NodeId>();
+    const previousRoutes = new Map<NodeId, RouteEntity>();
+    const visited = new Set<NodeId>();
+    const queue: Array<{ nodeId: NodeId; distance: number }> = [
+      { nodeId: startLocationId, distance: 0 },
+    ];
+
+    distances.set(startLocationId, 0);
+
+    while (queue.length > 0) {
+      queue.sort((a, b) => a.distance - b.distance);
+      const current = queue.shift()!;
+
+      if (visited.has(current.nodeId)) {
+        continue;
+      }
+      visited.add(current.nodeId);
+
+      if (current.nodeId === endLocationId) {
+        break;
+      }
+
+      const edges = adjacency.get(current.nodeId);
+      if (!edges) {
+        continue;
+      }
+
+      for (const edge of edges) {
+        const newDistance = current.distance + edge.weight;
+        if (newDistance < (distances.get(edge.to) ?? Number.POSITIVE_INFINITY)) {
+          distances.set(edge.to, newDistance);
+          previousNodes.set(edge.to, current.nodeId);
+          previousRoutes.set(edge.to, edge.route);
+          queue.push({ nodeId: edge.to, distance: newDistance });
+        }
+      }
+    }
+
+    if (!previousRoutes.has(endLocationId)) {
+      return [];
+    }
+
+    const path: RouteEntity[] = [];
+    let currentNode: NodeId | undefined = endLocationId;
+
+    while (currentNode && currentNode !== startLocationId) {
+      const route = previousRoutes.get(currentNode);
+      const previousNode = previousNodes.get(currentNode);
+      if (!route || !previousNode) {
+        return [];
+      }
+
+      path.push(route);
+      currentNode = previousNode;
+    }
+
+    return path.reverse();
+  }
+
+  /**
    * Get connected routes from a location
    */
   async getConnectedRoutes(locationId: NodeId): Promise<{
@@ -409,6 +510,83 @@ export class RouteEntityHandler extends BaseEntityHandler<RouteEntity, Partial<R
    */
 
   // Note: uses base search (name/createdAt/updatedAt). Route-specific criteria can be added later.
+
+  private getRouteWeight(route: RouteEntity): number | null {
+    if (typeof route.distance === 'number' && Number.isFinite(route.distance) && route.distance >= 0) {
+      return route.distance;
+    }
+
+    if (route.lineGeometry && route.lineGeometry.length >= 2) {
+      const lineDistance = this.calculateLineGeometryDistance(route.lineGeometry);
+      if (lineDistance > 0) {
+        return lineDistance;
+      }
+    }
+
+    const coordinatePath: [number, number][] = [];
+    if (route.startPoint?.coordinates) {
+      coordinatePath.push(route.startPoint.coordinates);
+    }
+    if (route.waypoints?.length) {
+      for (const waypoint of route.waypoints) {
+        if (waypoint?.coordinates) {
+          coordinatePath.push(waypoint.coordinates);
+        }
+      }
+    }
+    if (route.endPoint?.coordinates) {
+      coordinatePath.push(route.endPoint.coordinates);
+    }
+
+    if (coordinatePath.length >= 2) {
+      const fallbackDistance = this.calculateLineGeometryDistance(coordinatePath);
+      if (fallbackDistance > 0) {
+        return fallbackDistance;
+      }
+    }
+
+    return null;
+  }
+
+  private calculateLineGeometryDistance(line: [number, number][]): number {
+    let total = 0;
+
+    for (let i = 0; i < line.length - 1; i++) {
+      const current = line[i];
+      const next = line[i + 1];
+      if (!current || !next) {
+        continue;
+      }
+
+      total += this.calculateDistance(current, next);
+    }
+
+    return total;
+  }
+
+  private calculateDistance(
+    point1: [number, number],
+    point2: [number, number],
+  ): number {
+    const R = 6371000; // Earth radius in meters
+
+    const lat1 = this.toRadians(point1[1]);
+    const lat2 = this.toRadians(point2[1]);
+    const deltaLat = this.toRadians(point2[1] - point1[1]);
+    const deltaLon = this.toRadians(point2[0] - point1[0]);
+
+    const a = Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+      Math.cos(lat1) * Math.cos(lat2) *
+      Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return R * c;
+  }
+
+  private toRadians(degrees: number): number {
+    return degrees * (Math.PI / 180);
+  }
 
   /**
    * Clean up route-specific data

--- a/packages/node-type/route-plugin/src/entities/__tests__/RouteEntityHandler.shortest-route.test.ts
+++ b/packages/node-type/route-plugin/src/entities/__tests__/RouteEntityHandler.shortest-route.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import type { Table } from 'dexie';
+import type { NodeId } from '@hierarchidb/common-type';
+import { RouteEntityHandler } from '../RouteEntityHandler';
+import type { RouteEntity } from '../RouteEntity';
+
+type RouteFactoryOptions = {
+  id: string;
+  start: NodeId;
+  end: NodeId;
+  distance: number;
+  overrides?: Partial<RouteEntity>;
+};
+
+function createRoute({ id, start, end, distance, overrides }: RouteFactoryOptions): RouteEntity {
+  const now = Date.now();
+
+  return {
+    id: id as NodeId,
+    nodeId: `${id}-node` as NodeId,
+    name: id,
+    category: { primary: 'road' },
+    metadata: {},
+    customFields: {},
+    createdAt: now,
+    updatedAt: now,
+    version: 1,
+    startLocationId: start,
+    endLocationId: end,
+    waypointLocationIds: [],
+    startPoint: { coordinates: [0, 0] },
+    endPoint: { coordinates: [0, 0] },
+    waypoints: [],
+    lineGeometry: [[0, 0], [0, 0]],
+    generationMethod: 'direct',
+    distance,
+    transportMode: 'road',
+    processingStatus: 'completed',
+    childRouteIds: [],
+    ...overrides,
+  } as RouteEntity;
+}
+
+async function seedRoutes(handler: RouteEntityHandler, routes: RouteEntity[]): Promise<void> {
+  const table = (handler as any).table as Table<RouteEntity, NodeId>;
+  await table.bulkAdd(routes);
+}
+
+async function disposeHandler(handler: RouteEntityHandler): Promise<void> {
+  await ((handler as any).routeDB?.close?.() ?? Promise.resolve());
+}
+
+describe('RouteEntityHandler.getShortestRouteSetBetweenLocations', () => {
+  it('returns a direct route when it is the only option', async () => {
+    const handler = new RouteEntityHandler();
+    const locationA = 'loc-a' as NodeId;
+    const locationB = 'loc-b' as NodeId;
+
+    try {
+      await seedRoutes(handler, [
+        createRoute({ id: 'route-ab', start: locationA, end: locationB, distance: 1200 }),
+      ]);
+
+      const result = await handler.getShortestRouteSetBetweenLocations(locationA, locationB);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe('route-ab');
+    } finally {
+      await disposeHandler(handler);
+    }
+  });
+
+  it('chooses the path with the smallest total distance', async () => {
+    const handler = new RouteEntityHandler();
+    const locationA = 'loc-a' as NodeId;
+    const locationB = 'loc-b' as NodeId;
+    const locationC = 'loc-c' as NodeId;
+
+    try {
+      await seedRoutes(handler, [
+        createRoute({ id: 'route-ab', start: locationA, end: locationB, distance: 500 }),
+        createRoute({ id: 'route-bc', start: locationB, end: locationC, distance: 500 }),
+        createRoute({ id: 'route-ac-direct', start: locationA, end: locationC, distance: 2000 }),
+      ]);
+
+      const result = await handler.getShortestRouteSetBetweenLocations(locationA, locationC);
+      expect(result.map(route => route.id)).toEqual(['route-ab', 'route-bc']);
+    } finally {
+      await disposeHandler(handler);
+    }
+  });
+
+  it('returns an empty array when no connecting routes exist', async () => {
+    const handler = new RouteEntityHandler();
+    const locationA = 'loc-a' as NodeId;
+    const locationC = 'loc-c' as NodeId;
+
+    try {
+      await seedRoutes(handler, [
+        createRoute({ id: 'route-ab', start: locationA, end: 'loc-b' as NodeId, distance: 800 }),
+      ]);
+
+      const result = await handler.getShortestRouteSetBetweenLocations(locationA, locationC);
+      expect(result).toEqual([]);
+    } finally {
+      await disposeHandler(handler);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `RouteEntityHandler.getShortestRouteSetBetweenLocations` that uses Dijkstra search to assemble the lightest set of routes between two location nodes
- calculate fallback route weights from stored geometry or waypoint coordinates when explicit distances are missing
- cover the new behaviour with vitest cases for direct, multi-hop and unreachable location combinations

## Testing
- `pnpm -C packages/node-type/route-plugin typecheck` *(fails: package still depends on missing `@hierarchidb/runtime-*` typings and outdated RouteBatch APIs)*
- `pnpm -C packages/node-type/route-plugin build`
- `ROUTE_TESTS=1 pnpm --filter @hierarchidb/route-plugin exec vitest run` *(fails: existing suites expect unresolved UI and manager exports)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1eebfab4832399407f149182fee7