### PR TITLE
chore(ci): align pnpm version with workspace

### DIFF
--- a/.github/workflows/biome-ci.yml
+++ b/.github/workflows/biome-ci.yml
@@ -23,6 +23,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - uses: actions/setup-node@v4
         with:
@@ -47,6 +49,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/dep-fence-guards.yml
+++ b/.github/workflows/dep-fence-guards.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/dts-check.yml
+++ b/.github/workflows/dts-check.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/policy-checks.yml
+++ b/.github/workflows/policy-checks.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/unit-ci.yml
+++ b/.github/workflows/unit-ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -74,6 +76,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -113,6 +117,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -158,6 +164,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -207,6 +215,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- pin pnpm/action-setup to use pnpm 10.17.1 across all workflows so CI matches the workspace packageManager

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5efe4e0908323bee72333fbb878d0