### PR TITLE
perf(styler-plugin): offload preview filtering to worker

### DIFF
--- a/plugins/styler-plugin/src/ui/components/hooks/useStylerPreview.ts
+++ b/plugins/styler-plugin/src/ui/components/hooks/useStylerPreview.ts
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { i18n } from '@hierarchidb/ui-i18n';
 import { useAtomValue } from 'jotai';
-import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { TabularFilterRule } from '@hierarchidb/ui-tabular';
 import { tabularRowsAtom } from '@hierarchidb/spreadsheet-plugin';
 import {
@@ -14,6 +14,7 @@ import {
 } from '../../../common/types/StylerEntity.js';
 import { normalizeStylerConfig } from '../../../common/utils/colorUtils.js';
 import type { StylerStepProps } from '../StylerStepProps.js';
+import { useTabularFilterWorker } from '../../hooks/useTabularFilterWorker.js';
 
 const useValueColorScale = ({
   baseConfig,
@@ -60,8 +61,6 @@ export const useStylerPreview = ({
     tabularData.length > 0
       ? tabularData
       : (data?.previewRows as StylerTableRow[] | undefined) ?? atomRows;
-  const deferredPreviewRowsSource = useDeferredValue(previewRowsSource);
-  const isPreviewDeferred = deferredPreviewRowsSource !== previewRowsSource;
   const mapping: StylerMapping = {
     ...StylerMappingDefault,
     ...(data?.mapping ?? {}),
@@ -83,109 +82,17 @@ export const useStylerPreview = ({
     direction: null,
   });
 
-  const prepareFilters = useCallback((rules: TabularFilterRule[]) => {
-    return rules
-      .filter((rule) => rule.enabled !== false && rule.column)
-      .map((rule) => {
-        const prepared: {
-          column: string;
-          operator: TabularFilterRule['operator'];
-          value?: string | number;
-          regex?: RegExp;
-        } = {
-          column: rule.column,
-          operator: rule.operator,
-        };
-        if (rule.operator === 'regex' && typeof rule.value === 'string') {
-          try {
-            prepared.regex = new RegExp(rule.value);
-          } catch {
-            prepared.regex = undefined;
-          }
-        } else if (typeof rule.value === 'number' || typeof rule.value === 'string') {
-          prepared.value = rule.value;
-        }
-        return prepared;
-      });
-  }, []);
-
-  const matchesFilters = useCallback(
-    (row: StylerTableRow, filters: ReturnType<typeof prepareFilters>): boolean => {
-      if (!filters.length) return true;
-      const toStr = (v: unknown) => (v === null || v === undefined ? '' : String(v));
-      const toNum = (v: unknown): number | null => {
-        if (typeof v === 'number' && Number.isFinite(v)) return v;
-        if (typeof v === 'string' && /^-?\d+(\.\d+)?$/.test(v.trim())) {
-          const parsed = Number(v);
-          return Number.isFinite(parsed) ? parsed : null;
-        }
-        return null;
-      };
-      return filters.every((filter) => {
-        const rowValue = row[filter.column];
-        switch (filter.operator) {
-          case 'equals':
-            return toStr(rowValue) === toStr(filter.value);
-          case 'not_equals':
-            return toStr(rowValue) !== toStr(filter.value);
-          case 'contains':
-            return typeof filter.value === 'string'
-              ? toStr(rowValue).toLowerCase().includes(filter.value.toLowerCase())
-              : false;
-          case 'not_contains':
-            return typeof filter.value === 'string'
-              ? !toStr(rowValue).toLowerCase().includes(filter.value.toLowerCase())
-              : true;
-          case 'starts_with':
-            return typeof filter.value === 'string'
-              ? toStr(rowValue).toLowerCase().startsWith(filter.value.toLowerCase())
-              : false;
-          case 'ends_with':
-            return typeof filter.value === 'string'
-              ? toStr(rowValue).toLowerCase().endsWith(filter.value.toLowerCase())
-              : false;
-          case 'greater_than': {
-            const rv = toNum(rowValue);
-            const fv = toNum(filter.value);
-            return rv !== null && fv !== null ? rv > fv : false;
-          }
-          case 'greater_equal': {
-            const rv = toNum(rowValue);
-            const fv = toNum(filter.value);
-            return rv !== null && fv !== null ? rv >= fv : false;
-          }
-          case 'less_than': {
-            const rv = toNum(rowValue);
-            const fv = toNum(filter.value);
-            return rv !== null && fv !== null ? rv < fv : false;
-          }
-          case 'less_equal': {
-            const rv = toNum(rowValue);
-            const fv = toNum(filter.value);
-            return rv !== null && fv !== null ? rv <= fv : false;
-          }
-          case 'is_null':
-            return rowValue === null || rowValue === undefined || rowValue === '';
-          case 'is_not_null':
-            return !(rowValue === null || rowValue === undefined || rowValue === '');
-          case 'regex':
-            return filter.regex ? filter.regex.test(toStr(rowValue)) : true;
-          default:
-            return true;
-        }
-      });
-    },
-    [prepareFilters]
+  const filters = useMemo<TabularFilterRule[]>(
+    () => (Array.isArray(data?.filters) ? (data.filters as TabularFilterRule[]) : []),
+    [data?.filters],
   );
 
-  const previewData = useMemo(() => {
-    const sourceRows = deferredPreviewRowsSource;
-    const preparedFilters = prepareFilters((data?.filters as TabularFilterRule[] | undefined) ?? []);
-    const rows: StylerTableRow[] =
-      (Array.isArray(sourceRows) && sourceRows.length > 0 ? (sourceRows as StylerTableRow[]) : []) ?? [];
-    const filtered = preparedFilters.length ? rows.filter((row) => matchesFilters(row, preparedFilters)) : rows;
-    return filtered.slice(0, 1000);
-  }, [data?.filters, deferredPreviewRowsSource, matchesFilters, prepareFilters]);
+  const { filteredRows: previewData, isFiltering: isPreviewDeferred } = useTabularFilterWorker({
+    rows: Array.isArray(previewRowsSource) ? (previewRowsSource as StylerTableRow[]) : [],
+    filters,
+    limit: 1000,
+    debounceMs: 240,
+  });
 
   const columns = useMemo(() => Object.keys(previewData[0] ?? {}), [previewData]);
 

--- a/plugins/styler-plugin/src/ui/hooks/useTabularFilterWorker.ts
+++ b/plugins/styler-plugin/src/ui/hooks/useTabularFilterWorker.ts
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { TabularFilterRule } from '@hierarchidb/ui-tabular';
+import type { StylerTableRow } from '../../common/types/StylerEntity.js';
+import { applyFilters } from '../utils/tabularFilters.js';
+
+type WorkerResponse = {
+  id: number;
+  rows: StylerTableRow[];
+  error?: string;
+};
+
+export interface UseTabularFilterWorkerOptions {
+  rows: StylerTableRow[];
+  filters: TabularFilterRule[];
+  limit?: number;
+  debounceMs?: number;
+  onResult?: (rows: StylerTableRow[]) => void;
+}
+
+export interface UseTabularFilterWorkerResult {
+  filteredRows: StylerTableRow[];
+  isFiltering: boolean;
+  usedFallback: boolean;
+  workerError: string | null;
+}
+
+const DEFAULT_LIMIT = 1000;
+const DEFAULT_DEBOUNCE_MS = 220;
+
+export const useTabularFilterWorker = ({
+  rows,
+  filters,
+  limit = DEFAULT_LIMIT,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  onResult,
+}: UseTabularFilterWorkerOptions): UseTabularFilterWorkerResult => {
+  const [filteredRows, setFilteredRows] = useState<StylerTableRow[]>([]);
+  const [isFiltering, setIsFiltering] = useState(false);
+  const [workerError, setWorkerError] = useState<string | null>(null);
+  const [usedFallback, setUsedFallback] = useState(false);
+  const workerRef = useRef<Worker | null>(null);
+  const requestIdRef = useRef(0);
+  const latestRequestRef = useRef(0);
+  const rowsRef = useRef(rows);
+  const filtersRef = useRef(filters);
+  const debounceTimerRef = useRef<number | null>(null);
+
+  const supportsWorker = useMemo(() => typeof Worker !== 'undefined', []);
+
+  useEffect(() => {
+    rowsRef.current = rows;
+  }, [rows]);
+
+  useEffect(() => {
+    filtersRef.current = filters;
+  }, [filters]);
+
+  useEffect(() => {
+    if (!supportsWorker) return undefined;
+    try {
+      const worker = new Worker(
+        new URL('../workers/tabularFilter.worker.ts', import.meta.url),
+        { type: 'module' },
+      );
+      workerRef.current = worker;
+      const handleMessage = (event: MessageEvent<WorkerResponse>) => {
+        const { id, rows: nextRows, error } = event.data ?? {};
+        if (id !== latestRequestRef.current) {
+          return;
+        }
+        if (error) {
+          setWorkerError(error);
+          setUsedFallback(true);
+          const fallback = applyFilters(rowsRef.current ?? [], filtersRef.current ?? [], limit);
+          setFilteredRows(fallback);
+          onResult?.(fallback);
+          setIsFiltering(false);
+          return;
+        }
+        setWorkerError(null);
+        setFilteredRows(nextRows ?? []);
+        onResult?.(nextRows ?? []);
+        setIsFiltering(false);
+      };
+      worker.addEventListener('message', handleMessage);
+      return () => {
+        worker.removeEventListener('message', handleMessage);
+        worker.terminate();
+        workerRef.current = null;
+      };
+    } catch (error) {
+      setWorkerError(error instanceof Error ? error.message : String(error));
+      setUsedFallback(true);
+      setFilteredRows(applyFilters(rowsRef.current ?? [], filtersRef.current ?? [], limit));
+      onResult?.(applyFilters(rowsRef.current ?? [], filtersRef.current ?? [], limit));
+      setIsFiltering(false);
+      return undefined;
+    }
+  }, [limit, onResult, supportsWorker]);
+
+  useEffect(() => {
+    if (!supportsWorker || !workerRef.current) {
+      const fallback = applyFilters(rows ?? [], filters ?? [], limit);
+      setFilteredRows(fallback);
+      onResult?.(fallback);
+      setIsFiltering(false);
+      setUsedFallback(true);
+      return undefined;
+    }
+    if (debounceTimerRef.current) {
+      window.clearTimeout(debounceTimerRef.current);
+    }
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    latestRequestRef.current = requestId;
+    setIsFiltering(true);
+    debounceTimerRef.current = window.setTimeout(() => {
+      workerRef.current?.postMessage({
+        id: requestId,
+        rows,
+        filters,
+        limit,
+      });
+    }, debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        window.clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, [debounceMs, filters, limit, onResult, rows, supportsWorker]);
+
+  return {
+    filteredRows,
+    isFiltering,
+    usedFallback,
+    workerError,
+  };
+};

--- a/plugins/styler-plugin/src/ui/utils/tabularFilters.ts
+++ b/plugins/styler-plugin/src/ui/utils/tabularFilters.ts
@@ -1,0 +1,147 @@
+import type { TabularFilterRule } from '@hierarchidb/ui-tabular';
+import type { StylerTableRow } from '../../common/types/StylerEntity.js';
+
+export type PreparedFilter = {
+  column: string;
+  operator: TabularFilterRule['operator'];
+  value?: string | number;
+  regex?: RegExp;
+};
+
+const NULL_LIKE_VALUES = new Set(['', 'null', 'undefined']);
+const SAFE_NUMBER_REGEX = /^-?\d+(\.\d+)?$/;
+
+const toComparableString = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+};
+
+const toComparableNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && SAFE_NUMBER_REGEX.test(value.trim())) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+export const prepareFilters = (rules: TabularFilterRule[]): PreparedFilter[] => {
+  return rules
+    .filter((rule) => rule.enabled !== false && rule.column)
+    .map((rule) => {
+      const prepared: PreparedFilter = {
+        column: rule.column,
+        operator: rule.operator,
+      };
+      if (rule.operator === 'regex' && typeof rule.value === 'string') {
+        try {
+          prepared.regex = new RegExp(rule.value);
+        } catch {
+          prepared.regex = undefined;
+        }
+      } else if (typeof rule.value === 'number' || typeof rule.value === 'string') {
+        prepared.value = rule.value;
+      }
+      return prepared;
+    });
+};
+
+const matchContains = (source: unknown, target: string): boolean => {
+  const base = toComparableString(source).toLowerCase();
+  return base.includes(target.toLowerCase());
+};
+
+const startsWith = (source: unknown, target: string): boolean => {
+  return toComparableString(source).toLowerCase().startsWith(target.toLowerCase());
+};
+
+const endsWith = (source: unknown, target: string): boolean => {
+  return toComparableString(source).toLowerCase().endsWith(target.toLowerCase());
+};
+
+const compareNumber = (
+  rowValue: unknown,
+  filter: PreparedFilter,
+  comparator: (row: number, target: number) => boolean,
+): boolean => {
+  if (typeof filter.value === 'number') {
+    const rowNumber = toComparableNumber(rowValue);
+    return rowNumber !== null ? comparator(rowNumber, filter.value) : false;
+  }
+  const parsedFilter = toComparableNumber(filter.value);
+  const parsedRow = toComparableNumber(rowValue);
+  if (parsedFilter === null || parsedRow === null) return false;
+  return comparator(parsedRow, parsedFilter);
+};
+
+export const matchesFilters = (row: StylerTableRow, filters: PreparedFilter[]): boolean => {
+  if (filters.length === 0) return true;
+  return filters.every((filter) => {
+    const rowValue = row[filter.column];
+    switch (filter.operator) {
+      case 'equals':
+        return toComparableString(rowValue) === toComparableString(filter.value);
+      case 'not_equals':
+        return toComparableString(rowValue) !== toComparableString(filter.value);
+      case 'contains':
+        return typeof filter.value === 'string' ? matchContains(rowValue, filter.value) : false;
+      case 'not_contains':
+        return typeof filter.value === 'string' ? !matchContains(rowValue, filter.value) : true;
+      case 'starts_with':
+        return typeof filter.value === 'string' ? startsWith(rowValue, filter.value) : false;
+      case 'ends_with':
+        return typeof filter.value === 'string' ? endsWith(rowValue, filter.value) : false;
+      case 'greater_than':
+        return compareNumber(rowValue, filter, (rowNum, target) => rowNum > target);
+      case 'greater_equal':
+        return compareNumber(rowValue, filter, (rowNum, target) => rowNum >= target);
+      case 'less_than':
+        return compareNumber(rowValue, filter, (rowNum, target) => rowNum < target);
+      case 'less_equal':
+        return compareNumber(rowValue, filter, (rowNum, target) => rowNum <= target);
+      case 'is_null': {
+        if (rowValue === null || rowValue === undefined || rowValue === '') return true;
+        if (typeof rowValue === 'string') {
+          return NULL_LIKE_VALUES.has(rowValue.toLowerCase());
+        }
+        return false;
+      }
+      case 'is_not_null': {
+        if (rowValue === null || rowValue === undefined || rowValue === '') return false;
+        if (typeof rowValue === 'string') {
+          return !NULL_LIKE_VALUES.has(rowValue.toLowerCase());
+        }
+        return true;
+      }
+      case 'regex':
+        return filter.regex ? filter.regex.test(toComparableString(rowValue)) : true;
+      default:
+        return true;
+    }
+  });
+};
+
+export const applyFilters = (
+  rows: StylerTableRow[],
+  rules: TabularFilterRule[],
+  limit = 1000,
+): StylerTableRow[] => {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return [];
+  }
+  const prepared = prepareFilters(rules ?? []);
+  if (!prepared.length) {
+    return rows.slice(0, limit);
+  }
+  const result: StylerTableRow[] = [];
+  for (const row of rows) {
+    if (matchesFilters(row, prepared)) {
+      result.push(row);
+    }
+    if (result.length >= limit) {
+      break;
+    }
+  }
+  return result;
+};

--- a/plugins/styler-plugin/src/ui/workers/tabularFilter.worker.ts
+++ b/plugins/styler-plugin/src/ui/workers/tabularFilter.worker.ts
@@ -1,0 +1,36 @@
+/// <reference lib="webworker" />
+
+import type { TabularFilterRule } from '@hierarchidb/ui-tabular';
+import type { StylerTableRow } from '../../common/types/StylerEntity.js';
+import { applyFilters } from '../utils/tabularFilters.js';
+
+type FilterRequest = {
+  id: number;
+  rows: StylerTableRow[];
+  filters: TabularFilterRule[];
+  limit?: number;
+};
+
+type FilterResponse = {
+  id: number;
+  rows: StylerTableRow[];
+  error?: string;
+};
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+ctx.onmessage = (event: MessageEvent<FilterRequest>) => {
+  const { id, rows, filters, limit = 1000 } = event.data ?? {};
+  try {
+    const filtered = applyFilters(rows ?? [], filters ?? [], limit);
+    const response: FilterResponse = { id, rows: filtered };
+    ctx.postMessage(response);
+  } catch (error) {
+    const response: FilterResponse = {
+      id,
+      rows: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+    ctx.postMessage(response);
+  }
+};


### PR DESCRIPTION
## Summary
- add a shared tabular filter utility and worker to process preview rows off the main thread with debounce
- wire Styler preview step to use the worker-based filter results for up-to-date, responsive views

## Testing
- pnpm --filter @hierarchidb/styler-plugin typecheck *(fails: missing workspace dependency type declarations and unbuilt packages such as @hierarchidb/tabular-store/util/plugin-ui-sdk)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69549dcad5d88323ac5fe8340609f733)