### PR TITLE
Reorder styler preview header chips

### DIFF
--- a/plugins/styler-plugin/src/ui/components/StylerPreviewStep.tsx
+++ b/plugins/styler-plugin/src/ui/components/StylerPreviewStep.tsx
@@ -290,34 +290,34 @@ export const StylerPreviewStep: React.FC<StylerStepProps> = ({
                     sortDirection={isActive && sortState.direction ? sortState.direction : false}
                     sx={{ width: columnWidth, minWidth: columnWidth, maxWidth: columnWidth }}
                   >
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      {isKey && (
-                        <Chip
-                          label={t('stylePreview.keyColumn', 'Key')}
-                          size="small"
-                          color="primary"
-                          variant="outlined"
-                        />
-                      )}
-                      {isValue && (
-                        <Chip
-                          label={t('stylePreview.valueColumn', 'Value')}
-                          size="small"
-                          color="secondary"
-                          variant="outlined"
-                        />
-                      )}
-                      <TableSortLabel
-                        active={isActive}
-                        direction={sortState.direction ?? 'asc'}
-                        hideSortIcon={!isActive}
-                        onClick={() => handleToggleSort(col)}
-                      >
+                    <TableSortLabel
+                      active={isActive}
+                      direction={sortState.direction ?? 'asc'}
+                      hideSortIcon={!isActive}
+                      onClick={() => handleToggleSort(col)}
+                    >
+                      <Stack direction="row" spacing={1} alignItems="center">
                         <Typography variant="subtitle2" component="span">
                           {col}
                         </Typography>
-                      </TableSortLabel>
-                    </Stack>
+                        {isKey && (
+                          <Chip
+                            label={t('stylePreview.keyColumn', 'Key')}
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                          />
+                        )}
+                        {isValue && (
+                          <Chip
+                            label={t('stylePreview.valueColumn', 'Value')}
+                            size="small"
+                            color="secondary"
+                            variant="outlined"
+                          />
+                        )}
+                      </Stack>
+                    </TableSortLabel>
                   </TableCell>
                 );
               })}


### PR DESCRIPTION
## Summary
- move the sort label before the key/value chips so the styler preview header shows column names ahead of the badges

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69558d8e74c0832391f98b0b605782cd)