### PR TITLE
fix: stabilize Delete Download Files button state changes

### DIFF
--- a/plugins/shape-plugin/src/ui/components/processing/DownloadCacheActions.tsx
+++ b/plugins/shape-plugin/src/ui/components/processing/DownloadCacheActions.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, Skeleton, Stack, Typography } from '@mui/material';
+import { Button, Grid, Stack, Typography } from '@mui/material';
 import {
   CloudDownload as CloudDownloadIcon,
   FilterAlt as FilterAltIcon,
@@ -54,13 +54,20 @@ export const DownloadCacheActions: React.FC<Props> = ({
             disabled={rawDisabled}
             onClick={onDeleteRaw}
           >
-            {countsLoading ? <Skeleton width="70%" /> : deleteLabel}
-          </Button>
-          {countsLoading ? (
-            <Typography variant="caption" color="text.secondary">
-              {t('processing.download.deleteLoadingHint', 'Loading delete counts...')}
+            <Typography
+              component="span"
+              sx={{ display: 'inline-flex', alignItems: 'center', minHeight: '1.2em' }}
+            >
+              {deleteLabel}
             </Typography>
-          ) : null}
+          </Button>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ visibility: countsLoading ? 'visible' : 'hidden' }}
+          >
+            {t('processing.download.deleteLoadingHint', 'Loading delete counts...')}
+          </Typography>
         </Stack>
       </Grid>
       <Grid size={{ xs: 12, sm: 6 }}>


### PR DESCRIPTION
## Summary
- stop replacing the Delete Download Files label with a loading skeleton when refreshing counts to avoid unnecessary text churn
- keep the loading hint space reserved so the button height stays consistent and the layout does not jump during form edits

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955926761f88323b2299b0ab71101d3)