### PR TITLE
Add dynamic availability worker for shape country matrix

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,3 +1,13 @@
+2026) feat/shape/dynamic-country-matrix (P1) — 完了 (2026-01-09)
+- 要点：Shape Step3 の国×自治体レベルマトリクスをメタデータ駆動でオンデマンド生成し、データソース別ストラテジー＋WebWorkerで可用レベルを取得してUIへ反映するようにした。
+- 原因/影響範囲：従来は geoBoundaries 固定でレベル2までの静的前提だったため、他データソースや実際の可用レベルに追随できず UI が実態と乖離するリスクがあった。影響範囲は shape-plugin Step3 UI（国×自治体レベル選択）と可用性取得の裏側ロジック。
+- 修正内容と適用範囲：ストラテジーID解決を共通化、データソース可用性解決サービスと Comlink WebWorker を追加し、各ストラテジーが提供する可用性情報やメタデータから国別レベルを構築。Step3 フックは可用性通知を受けてマトリクスを再構成し、非対応セルは「-」を表示、仮想化を維持。適用範囲は `plugins/shape-plugin/src/services/datasources/*`, `plugins/shape-plugin/src/ui/hooks/useShapeCountrySelectionStep.ts`, `plugins/shape-plugin/src/ui/workers/*`, `plugins/shape-plugin/src/services/batch/workers/shapeStageWorker.ts`。
+- 検証：`pnpm --filter @hierarchidb/shape-plugin test -- --runInBand --testTimeout=20000`（依存パッケージ @hierarchidb/shape-store / @hierarchidb/util / @hierarchidb/ui-batch の解決不可で失敗。テストは走らず。環境依存のため後続で要再実行）。
+- ロールバック手順：上記ファイルの差分を revert（特に `CountryAvailabilityResolver` 追加や Step3 フックの worker 連携部分を戻す）。
+- 運用ログ：
+  - start: 2026-01-09 00:55 JST Step3 可用性動的化と worker 背景取得の設計開始。
+  - done: 2026-01-09 01:25 JST 実装完了。テストは依存解決不可で失敗（要再試行）。
+
 2026) fix/styler/step5-radio-label-click (P1) — 完了 (2026-01-07)
 - 要点：Styler Step5 のターゲット選択でラベルテキストをクリックしてもラジオが選択されるよう FormControlLabel で関連付け、既存レイアウトを維持。
 - 原因/影響範囲：ラジオとラベルを別要素で描画し for 関連付けがなかったため、ラベルクリックが無反応だった。影響範囲は Styler Step5 のターゲット選択 UI。
@@ -7,4 +17,3 @@
 - 運用ログ：
   - start: 2026-01-07 10:15 JST Step5 ラジオボタンのラベルクリック対応に着手。
   - done: 2026-01-07 11:05 JST FormControlLabel でラジオとラベルを結合し、ラベルクリックで選択できるよう修正。検証: 未実施（UI クリック範囲改善のみ、手動/自動テスト未実行）。ロールバック: 上記差分を revert。
-

--- a/plugins/shape-plugin/src/services/batch/workers/shapeStageWorker.ts
+++ b/plugins/shape-plugin/src/services/batch/workers/shapeStageWorker.ts
@@ -1,6 +1,6 @@
 import type { DownloadTaskRequest, ShapeStageWorkerAPI, ShapeStageWorkerTaskResult, ExtractTaskRequest } from './ShapeStageWorkerTypes.js';
 import { getEphemeralShapeDB } from '../../database/EphemeralShapeDB.js';
-import { defaultDataSourceFactory, type DataSourceStrategyId } from '../../datasources/DataSourceStrategyFactory.js';
+import { defaultDataSourceFactory } from '../../datasources/DataSourceStrategyFactory.js';
 import type { BoundingBox as TaskBoundingBox, Extract1Task, Extract2Task } from '../../../common/types/index.js';
 import type { BoundingBox as DataSourceBoundingBox } from '../../datasources/DataSourceStrategy.js';
 import type { Feature, FeatureCollection } from 'geojson';
@@ -10,15 +10,7 @@ import { applyFeatureFiltering, type FeatureFilterSettings, extractGeoJson } fro
 import { extractTopoJsonByTiles } from '../utils/topojsonExtract.js';
 import { applyOriginKey, assignFeatureIds, HDB_ORIGIN_KEY } from '../utils/featureIds.js';
 import { AuthRecoveryService } from '@hierarchidb/auth-recovery';
-
-const resolveStrategyId = (source?: string): DataSourceStrategyId | null => {
-  const key = (source ?? '').toLowerCase();
-  if (key.includes('gadm')) return 'gadm-administrative-areas';
-  if (key.includes('natural')) return 'natural-earth-shapes';
-  if (key.includes('geo')) return 'geoboundaries-admin-areas';
-  if (key.includes('osm') || key.includes('openstreet')) return 'openstreetmap-overpass';
-  return null;
-};
+import { resolveStrategyIdFromDataSource } from '../../datasources/strategyIds.js';
 
 const normalizeBoundingBox = (bbox?: TaskBoundingBox): DataSourceBoundingBox | undefined => {
   if (!bbox || bbox.length !== 4) return undefined;
@@ -108,7 +100,7 @@ const processDownloadTask = async ({
   taskIndex,
   input,
 }: DownloadTaskRequest): Promise<ShapeStageWorkerTaskResult> => {
-  const strategyId = resolveStrategyId(input.dataSource);
+  const strategyId = resolveStrategyIdFromDataSource(input.dataSource);
   if (!strategyId) {
     return { status: 'failed', errorMessage: 'No data source strategy available' };
   }

--- a/plugins/shape-plugin/src/services/datasources/CountryAvailabilityResolver.ts
+++ b/plugins/shape-plugin/src/services/datasources/CountryAvailabilityResolver.ts
@@ -1,0 +1,119 @@
+import { metadataLoader } from '../metadata/MetadataLoader.js';
+import { normalizeDataSourceName } from '../utils/utils.js';
+import { defaultDataSourceFactory } from './DataSourceStrategyFactory.js';
+import { resolveStrategyIdFromDataSource } from './strategyIds.js';
+import { DATA_SOURCE_CONFIGS } from '../../common/mock/data.js';
+
+type AvailabilitySource = 'strategy' | 'metadata' | 'none';
+
+export type CountryAvailabilityMatrix = {
+  dataSource: string;
+  availableAdminLevels: Map<string, number[]>;
+  maxAdminLevel: number;
+  source: AvailabilitySource;
+};
+
+type StrategyAvailabilityProvider = {
+  getAvailableCountries?: () => Promise<string[]>;
+  getAvailableAdminLevels?: (country: string) => Promise<Array<string | number>>;
+};
+
+const normalizeLevels = (levels: Array<string | number> | undefined | null): number[] => {
+  if (!levels) return [];
+  const resolved = levels
+    .map((value) => {
+      if (typeof value === 'number') return value;
+      const match = typeof value === 'string' ? value.match(/(\d+)/) : null;
+      if (!match) return Number.NaN;
+      return Number.parseInt(match[1] ?? '', 10);
+    })
+    .filter((value) => Number.isFinite(value) && value >= 0)
+    .map((value) => Number(value));
+  return Array.from(new Set(resolved)).sort((a, b) => a - b);
+};
+
+const toMaxAdminLevel = (levels: Iterable<number>): number => {
+  let max = 0;
+  for (const level of levels) {
+    if (Number.isFinite(level)) {
+      max = Math.max(max, level);
+    }
+  }
+  return max;
+};
+
+const buildAvailabilityFromMetadata = async (dataSource: string): Promise<CountryAvailabilityMatrix> => {
+  const metadata = await metadataLoader.loadMetadata(dataSource);
+  const entries = new Map<string, number[]>();
+  metadata.forEach((country) => {
+    const code = (country.iso3 ?? country.countryCode ?? country.iso2 ?? '').toUpperCase();
+    const levels = normalizeLevels(country.availableAdminLevels);
+    if (code) {
+      entries.set(code, levels);
+    }
+  });
+  const fallbackMax = DATA_SOURCE_CONFIGS[dataSource]?.maxAdminLevel ?? 0;
+  const maxAdminLevel = Math.max(
+    fallbackMax,
+    toMaxAdminLevel(Array.from(entries.values()).flat()),
+  );
+  return {
+    dataSource,
+    availableAdminLevels: entries,
+    maxAdminLevel,
+    source: entries.size > 0 ? 'metadata' : 'none',
+  };
+};
+
+const fetchAvailabilityFromStrategy = async (dataSource: string): Promise<CountryAvailabilityMatrix | null> => {
+  const strategyId = resolveStrategyIdFromDataSource(dataSource);
+  if (!strategyId) return null;
+  const strategy = defaultDataSourceFactory.create(strategyId) as StrategyAvailabilityProvider;
+  if (!strategy.getAvailableCountries || !strategy.getAvailableAdminLevels) {
+    return null;
+  }
+
+  const countries = await strategy.getAvailableCountries();
+  const entries = new Map<string, number[]>();
+  for (const country of countries) {
+    try {
+      const levelsRaw = await strategy.getAvailableAdminLevels(country);
+      const levels = normalizeLevels(levelsRaw);
+      const key = country.trim().toUpperCase();
+      if (key && levels.length > 0) {
+        entries.set(key, levels);
+      }
+    } catch (error) {
+      console.warn('[CountryAvailabilityResolver] failed to load levels for country', country, error);
+    }
+  }
+
+  if (entries.size === 0) {
+    return null;
+  }
+
+  const fallbackMax = DATA_SOURCE_CONFIGS[dataSource]?.maxAdminLevel ?? 0;
+  const maxAdminLevel = Math.max(
+    fallbackMax,
+    toMaxAdminLevel(Array.from(entries.values()).flat()),
+  );
+
+  return {
+    dataSource,
+    availableAdminLevels: entries,
+    maxAdminLevel,
+    source: 'strategy',
+  };
+};
+
+export const fetchCountryAvailability = async (dataSource: string): Promise<CountryAvailabilityMatrix> => {
+  const normalized = normalizeDataSourceName(dataSource ?? '') ?? 'naturalearth';
+  const strategyAvailability = await fetchAvailabilityFromStrategy(normalized).catch((error) => {
+    console.warn('[CountryAvailabilityResolver] strategy availability failed', { normalized, error });
+    return null;
+  });
+  if (strategyAvailability) {
+    return strategyAvailability;
+  }
+  return buildAvailabilityFromMetadata(normalized);
+};

--- a/plugins/shape-plugin/src/services/datasources/strategyIds.ts
+++ b/plugins/shape-plugin/src/services/datasources/strategyIds.ts
@@ -1,0 +1,10 @@
+import type { DataSourceStrategyId } from './DataSourceStrategyFactory.js';
+
+export const resolveStrategyIdFromDataSource = (source?: string): DataSourceStrategyId | null => {
+  const key = (source ?? '').toLowerCase();
+  if (key.includes('gadm')) return 'gadm-administrative-areas';
+  if (key.includes('natural')) return 'natural-earth-shapes';
+  if (key.includes('geo')) return 'geoboundaries-admin-areas';
+  if (key.includes('osm') || key.includes('openstreet')) return 'openstreetmap-overpass';
+  return null;
+};

--- a/plugins/shape-plugin/src/ui/hooks/useShapeCountrySelectionStep.ts
+++ b/plugins/shape-plugin/src/ui/hooks/useShapeCountrySelectionStep.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSnackbar } from 'notistack';
 import { useIsoCountries, type MatrixConfig, type MatrixSelection, type ContinentCode } from '@hierarchidb/ui-country-select';
 import type { CountryMetadata, ShapeEntity } from '../../common/types/index.js';
@@ -12,7 +12,8 @@ import {
 } from '../../common/mock/data.js';
 import { normalizeDataSourceName } from '../../services/utils/utils.js';
 import { clearStagesIfPresent, FULL_INVALIDATION_STAGES, resolveShapeNodeId } from '../utils/sessionInvalidation.js';
-import { fetchGeoBoundariesAvailability } from '../../services/utils/geoBoundariesAvailability.js';
+import type { CountryAvailabilityWorkerAPI, SerializedCountryAvailability } from '../workers/countryAvailability.types.js';
+import { wrap, releaseProxy } from 'comlink';
 
 const CONTINENT_CODES: ContinentCode[] = ['AF', 'AS', 'EU', 'NA', 'SA', 'OC', 'AN'];
 
@@ -78,6 +79,11 @@ const isSelectionEqual = (
   });
 };
 
+const createAvailabilityWorker = () => new Worker(
+  new URL('../workers/countryAvailability.worker.ts', import.meta.url),
+  { type: 'module' },
+);
+
 type Args = {
   data: Partial<ShapeEntity>;
   onChange: (patch: Partial<ShapeEntity>) => void;
@@ -89,11 +95,83 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
     data.batchConfig?.dataSource ?? data.dataSourceName,
   ) ?? 'gadm';
   const iso = useIsoCountries();
-  const { metadata: countries, loading, error } = useCountryMetadata({ dataSource: dataSourceKey });
-  const [availableAdminLevels, setAvailableAdminLevels] = useState<Map<string, number[]> | null>(null);
+  const { metadata: countries, loading: metadataLoading, error } = useCountryMetadata({ dataSource: dataSourceKey });
+  const [availability, setAvailability] = useState<SerializedCountryAvailability | null>(null);
+  const [availabilityError, setAvailabilityError] = useState<Error | null>(null);
+  const [availabilityLoading, setAvailabilityLoading] = useState(false);
+  const [isAvailabilityWorkerReady, setAvailabilityWorkerReady] = useState(false);
+  const availabilityWorkerRef = useRef<{
+    worker: Worker;
+    api: ReturnType<typeof wrap<CountryAvailabilityWorkerAPI>>;
+  } | null>(null);
+  const availabilityRequestIdRef = useRef(0);
   const selectedArrayByCountries = data.selectedArrayByCountries;
   const dataSourceConfig = DATA_SOURCE_CONFIGS[dataSourceKey];
-  const maxAdminLevel = dataSourceConfig?.maxAdminLevel ?? 0;
+  const resolvedMaxAdminLevel = useMemo(() => {
+    const fallback = dataSourceConfig?.maxAdminLevel ?? 0;
+    const fromAvailability = availability?.maxAdminLevel;
+    if (typeof fromAvailability === 'number' && Number.isFinite(fromAvailability)) {
+      return Math.max(0, fromAvailability);
+    }
+    return Math.max(0, fallback);
+  }, [availability?.maxAdminLevel, dataSourceConfig]);
+
+  useEffect(() => {
+    const worker = createAvailabilityWorker();
+    const api = wrap<CountryAvailabilityWorkerAPI>(worker);
+    availabilityWorkerRef.current = { worker, api };
+    setAvailabilityWorkerReady(true);
+    return () => {
+      availabilityWorkerRef.current = null;
+      try {
+        api[releaseProxy]?.();
+      } catch (releaseError) {
+        console.warn('[ShapeCountrySelectionStep] failed to release availability worker', releaseError);
+      }
+      worker.terminate();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isAvailabilityWorkerReady) return;
+    const ref = availabilityWorkerRef.current;
+    if (!ref) return;
+    let cancelled = false;
+    const requestId = availabilityRequestIdRef.current + 1;
+    availabilityRequestIdRef.current = requestId;
+    setAvailabilityLoading(true);
+    setAvailabilityError(null);
+
+    const run = async () => {
+      try {
+        const result = await ref.api.loadAvailability(dataSourceKey);
+        if (cancelled || requestId !== availabilityRequestIdRef.current) return;
+        setAvailability(result);
+      } catch (err) {
+        if (cancelled || requestId !== availabilityRequestIdRef.current) return;
+        const errorObj = err instanceof Error ? err : new Error('Failed to load availability');
+        setAvailabilityError(errorObj);
+        setAvailability(null);
+      } finally {
+        if (!cancelled && requestId === availabilityRequestIdRef.current) {
+          setAvailabilityLoading(false);
+        }
+      }
+    };
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [dataSourceKey, isAvailabilityWorkerReady]);
+
+  useEffect(() => {
+    if (!availabilityError) return;
+    enqueueSnackbar(
+      'Failed to load data source availability. Falling back to bundled metadata.',
+      { variant: 'warning' },
+    );
+  }, [availabilityError, enqueueSnackbar]);
 
   const isoContinentByCode = useMemo(() => {
     if (iso.status !== 'ready') return new Map<string, ContinentCode>();
@@ -112,17 +190,43 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
     );
   }, [countries]);
 
+  const availabilityByCountryCode = useMemo(() => {
+    if (!availability) return null;
+    const map = new Map<string, number[]>();
+    availability.entries.forEach((entry) => {
+      const code = entry.countryCode?.trim().toUpperCase();
+      if (!code) return;
+      const levels = Array.from(new Set((entry.adminLevels ?? []).filter((level) => level >= 0))).sort((a, b) => a - b);
+      map.set(code, levels);
+    });
+    return map;
+  }, [availability]);
+
+  const normalizedAvailabilityByCountry = useMemo(() => {
+    if (!availabilityByCountryCode) return null;
+    const map = new Map<string, number[]>();
+    availabilityByCountryCode.forEach((levels, code) => {
+      const normalized = code.trim().toUpperCase();
+      const iso2 = normalized.length === 2 ? normalized : iso3ToIso2.get(normalized) ?? normalized;
+      map.set(iso2, levels);
+    });
+    return map;
+  }, [availabilityByCountryCode, iso3ToIso2]);
+
   const baseCountries = useMemo(() => {
     return countries.map((country, countryIndex) => {
       const normalizedCode = normalizeCountryCodeFromMetadata(country, countryIndex);
       const isoContinent = isoContinentByCode.get(normalizedCode);
       const normalizedContinent = normalizeContinentCode(country.continent) ?? isoContinent ?? 'NA';
-      const geoAdminLevels = dataSourceKey === 'geoboundaries' && availableAdminLevels
-        ? availableAdminLevels.get((country.iso3 ?? normalizedCode).toUpperCase()) ?? []
-        : null;
-      const filteredLevels = geoAdminLevels
-        ? (country.availableAdminLevels ?? []).filter((level) => geoAdminLevels.includes(level))
-        : (country.availableAdminLevels ?? []);
+      const resolvedLevels = normalizedAvailabilityByCountry?.get(normalizedCode)
+        ?? country.availableAdminLevels
+        ?? [];
+      const normalizedLevels = Array.from(
+        new Set(
+          resolvedLevels
+            .filter((level) => Number.isFinite(level) && level >= 0 && level <= resolvedMaxAdminLevel),
+        ),
+      ).sort((a, b) => a - b);
       return {
         country: {
           code: normalizedCode,
@@ -130,10 +234,10 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
           nativeName: country.countryName,
           continent: normalizedContinent,
         },
-        availableAdminLevels: geoAdminLevels ? filteredLevels : (country.availableAdminLevels ?? []),
+        availableAdminLevels: normalizedLevels,
       };
     });
-  }, [availableAdminLevels, countries, dataSourceKey, isoContinentByCode]);
+  }, [countries, isoContinentByCode, normalizedAvailabilityByCountry, resolvedMaxAdminLevel]);
 
   const normalizedSelection = useMemo<Record<string, boolean[]>>(() => {
     if (!selectedArrayByCountries) return {};
@@ -142,7 +246,7 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
       const mapped: Record<string, boolean[]> = {};
       baseCountries.forEach((entry, rowIndex) => {
         const row = legacy[rowIndex] ?? [];
-        mapped[entry.country.code] = Array.from({ length: maxAdminLevel + 1 }, (_, idx) => Boolean(row[idx]));
+        mapped[entry.country.code] = Array.from({ length: resolvedMaxAdminLevel + 1 }, (_, idx) => Boolean(row[idx]));
       });
       return mapped;
     }
@@ -155,18 +259,18 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
       Object.entries(selectedArrayByCountries).map(([code, row]) => [
         resolveSelectionKey(code),
         Array.isArray(row)
-          ? Array.from({ length: maxAdminLevel + 1 }, (_, idx) => Boolean(row[idx]))
-          : Array.from({ length: maxAdminLevel + 1 }, () => false),
+          ? Array.from({ length: resolvedMaxAdminLevel + 1 }, (_, idx) => Boolean(row[idx]))
+          : Array.from({ length: resolvedMaxAdminLevel + 1 }, () => false),
       ]),
     );
-  }, [baseCountries, iso3ToIso2, maxAdminLevel, selectedArrayByCountries]);
+  }, [baseCountries, iso3ToIso2, resolvedMaxAdminLevel, selectedArrayByCountries]);
 
   const checkboxMatrix = useMemo<boolean[][]>(() => {
     return baseCountries.map((entry) => {
       const row = normalizedSelection[entry.country.code] ?? [];
-      return Array.from({ length: maxAdminLevel + 1 }, (_, idx) => Boolean(row[idx]));
+      return Array.from({ length: resolvedMaxAdminLevel + 1 }, (_, idx) => Boolean(row[idx]));
     });
-  }, [baseCountries, maxAdminLevel, normalizedSelection]);
+  }, [baseCountries, normalizedSelection, resolvedMaxAdminLevel]);
 
   useEffect(() => {
     if (!Array.isArray(selectedArrayByCountries)) return;
@@ -175,56 +279,11 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
   }, [normalizedSelection, onChange, selectedArrayByCountries]);
 
   useEffect(() => {
-    let cancelled = false;
-    const run = async () => {
-      if (dataSourceKey !== 'geoboundaries') {
-        setAvailableAdminLevels(null);
-        return;
-      }
-      try {
-        const { entries, totalItems } = await fetchGeoBoundariesAvailability(
-          'https://www.geoboundaries.org/api/current/gbOpen/ALL/ALL/',
-        );
-        console.debug('[ShapeCountrySelectionStep] GeoBoundaries availability fetched', {
-          totalItems,
-          countries: entries.size,
-          sample: Array.from(entries.entries()).slice(0, 3),
-        });
-        if (!cancelled && entries.size > 0) {
-          setAvailableAdminLevels(entries);
-        } else if (!cancelled) {
-          setAvailableAdminLevels(null);
-          console.debug('[ShapeCountrySelectionStep] GeoBoundaries availability empty', {
-            totalItems,
-          });
-          enqueueSnackbar(
-            'GeoBoundaries availability is empty. Showing full selection.',
-            { variant: 'warning' },
-          );
-        }
-      } catch (fetchError) {
-        console.warn('[ShapeCountrySelectionStep] failed to load GeoBoundaries availability', fetchError);
-        if (!cancelled) {
-          setAvailableAdminLevels(null);
-          enqueueSnackbar(
-            'GeoBoundaries availability lookup failed. Showing full selection.',
-            { variant: 'warning' },
-          );
-        }
-      }
-    };
-    void run();
-    return () => {
-      cancelled = true;
-    };
-  }, [dataSourceKey, enqueueSnackbar]);
-
-  useEffect(() => {
-    if (dataSourceKey !== 'geoboundaries' || !availableAdminLevels) return;
+    if (baseCountries.length === 0) return;
     const nextSelection: Record<string, boolean[]> = {};
     baseCountries.forEach((entry) => {
       const row = normalizedSelection[entry.country.code] ?? [];
-      nextSelection[entry.country.code] = Array.from({ length: maxAdminLevel + 1 }, (_, colIndex) => (
+      nextSelection[entry.country.code] = Array.from({ length: resolvedMaxAdminLevel + 1 }, (_, colIndex) => (
         entry.availableAdminLevels.includes(colIndex) ? Boolean(row[colIndex]) : false
       ));
     });
@@ -232,35 +291,27 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
       onChange({ selectedArrayByCountries: nextSelection });
     }
   }, [
-    availableAdminLevels,
     baseCountries,
-    dataSourceKey,
-    maxAdminLevel,
     normalizedSelection,
     onChange,
+    resolvedMaxAdminLevel,
   ]);
 
   const columns: MatrixConfig['columns'] = useMemo(
     () =>
-      Array.from({ length: maxAdminLevel + 1 }, (_, levelIndex) => ({
+      Array.from({ length: resolvedMaxAdminLevel + 1 }, (_, levelIndex) => ({
         id: `level-${levelIndex}`,
         label: `Level ${levelIndex}`,
         description: `Admin level ${levelIndex}`,
         type: 'custom',
       })),
-    [maxAdminLevel],
-  );
-
-  const disabledColumnIds = useMemo(
-    () => columns.filter((_, levelIndex) => levelIndex >= 2).map((column) => column.id),
-    [columns],
+    [resolvedMaxAdminLevel],
   );
 
   const matrixConfig: MatrixConfig = useMemo(() => ({
     columns,
-    disabledColumnIds,
     virtualization: { rowHeight: 40, overscan: 8 },
-  }), [columns, disabledColumnIds]);
+  }), [columns]);
 
   const currentSelections: MatrixSelection[] = useMemo(() => {
     return baseCountries.map((entry, countryIndex) => {
@@ -310,7 +361,6 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
       columns,
       countries,
       data,
-      dataSourceKey,
       enqueueSnackbar,
       onChange,
       normalizedSelection,
@@ -328,8 +378,10 @@ export const useShapeCountrySelectionStep = ({ data, onChange }: Args) => {
     [baseCountries, columns],
   );
 
+  const combinedLoading = metadataLoading || (availabilityLoading && !availability);
+
   return {
-    loading,
+    loading: combinedLoading,
     error,
     matrixConfig,
     countries: baseCountries.map((entry) => entry.country),

--- a/plugins/shape-plugin/src/ui/workers/countryAvailability.types.ts
+++ b/plugins/shape-plugin/src/ui/workers/countryAvailability.types.ts
@@ -1,0 +1,16 @@
+export type SerializedCountryAvailabilityEntry = {
+  countryCode: string;
+  adminLevels: number[];
+};
+
+export type SerializedCountryAvailability = {
+  dataSource: string;
+  entries: SerializedCountryAvailabilityEntry[];
+  maxAdminLevel: number;
+  source: 'strategy' | 'metadata' | 'none';
+  fetchedAt: number;
+};
+
+export interface CountryAvailabilityWorkerAPI {
+  loadAvailability(dataSource: string): Promise<SerializedCountryAvailability>;
+}

--- a/plugins/shape-plugin/src/ui/workers/countryAvailability.worker.ts
+++ b/plugins/shape-plugin/src/ui/workers/countryAvailability.worker.ts
@@ -1,0 +1,21 @@
+import { expose } from 'comlink';
+import { fetchCountryAvailability } from '../../services/datasources/CountryAvailabilityResolver.js';
+import type { CountryAvailabilityWorkerAPI, SerializedCountryAvailability } from './countryAvailability.types.js';
+
+const api: CountryAvailabilityWorkerAPI = {
+  async loadAvailability(dataSource: string): Promise<SerializedCountryAvailability> {
+    const availability = await fetchCountryAvailability(dataSource);
+    return {
+      dataSource: availability.dataSource,
+      entries: Array.from(availability.availableAdminLevels.entries()).map(([countryCode, adminLevels]) => ({
+        countryCode,
+        adminLevels,
+      })),
+      maxAdminLevel: availability.maxAdminLevel,
+      source: availability.source,
+      fetchedAt: Date.now(),
+    };
+  },
+};
+
+expose(api);


### PR DESCRIPTION
## Summary
- add a shared strategy id resolver and country availability resolver that prefers strategy-provided APIs and falls back to metadata
- run availability fetching inside a Comlink web worker and feed the results into Step3 country-level matrix rendering with virtualization
- normalize selections against per-country admin level support and keep batch invalidation when selections change

## Testing
- pnpm --filter @hierarchidb/shape-plugin test -- --runInBand --testTimeout=20000 *(fails: missing @hierarchidb/shape-store, @hierarchidb/util, @hierarchidb/ui-batch in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955c7273b008323a52facac3c7ccc7f)