### PR TITLE
Adjust frameless transparent PluginDialog styling and interactions

### DIFF
--- a/packages/plugin-ui-host/src/headless/components/DialogScaffold.tsx
+++ b/packages/plugin-ui-host/src/headless/components/DialogScaffold.tsx
@@ -9,6 +9,7 @@ import {
   Button,
 } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
+import { useDialogContext } from '@hierarchidb/ui-dialog';
 import { PluginDialogHeader } from './PluginDialogHeader.js';
 import { PluginDialogFooter, type PluginDialogFooterProps } from './PluginDialogFooter.js';
 import type { DialogActionInFlight } from '../types.js';
@@ -26,6 +27,8 @@ export const createHeaderComponent = (
 export const createContentComponent = (dialogRef: React.RefObject<HTMLElement | null>) =>
   memo(
     function DialogContentWrapper(props: React.PropsWithChildren) {
+      const ctx = useDialogContext<Record<string, unknown>>();
+      const disablePadding = Boolean(ctx.frameless && ctx.transparent);
       return (
         <Box
           sx={(theme: Theme) => ({
@@ -35,7 +38,7 @@ export const createContentComponent = (dialogRef: React.RefObject<HTMLElement | 
             display: 'flex',
             flexDirection: 'column',
             overflow: 'auto',
-            padding: theme.spacing(2),
+            padding: disablePadding ? 0 : theme.spacing(2),
           })}
           ref={dialogRef}
         >

--- a/packages/plugin-ui-host/src/headless/components/PluginDialogHeader.tsx
+++ b/packages/plugin-ui-host/src/headless/components/PluginDialogHeader.tsx
@@ -54,6 +54,7 @@ export const PluginDialogHeader: React.FC<PluginDialogHeaderProps> = ({
   const dragHandlePointerDown = ctx.onDragHandlePointerDown;
   const canMinimize = Boolean(ctx.onMinimizeChange);
   const isMinimized = Boolean(ctx.isMinimized);
+  const hideFrameControls = Boolean(ctx.frameless && ctx.transparent);
 
   const headerSubtitle = useMemo(() => {
     if (subtitle && ctx.stepComponents.length <= 1) return subtitle;
@@ -164,33 +165,35 @@ export const PluginDialogHeader: React.FC<PluginDialogHeaderProps> = ({
         )}
       </Stack>
 
-      <Stack direction="row" spacing={1.5} alignItems="center">
-        <Stack direction="row" spacing={0.5} alignItems="center">
-          {canMinimize ? (
-            <PluginDialogMinimizeButton
-              isMinimized={isMinimized}
-              onClick={toggleMinimize}
+      {hideFrameControls ? null : (
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            {canMinimize ? (
+              <PluginDialogMinimizeButton
+                isMinimized={isMinimized}
+                onClick={toggleMinimize}
+                onPointerDown={stopPointerPropagation}
+              />
+            ) : null}
+            <PluginDialogMaximizeButton
+              displayMode={ctx.displayMode === 'maximize' ? 'maximize' : 'default'}
+              onClick={toggleMaximize}
+              onPointerDown={stopPointerPropagation}
+              disabled={!ctx.onDisplayModeChange}
+            />
+            <PluginDialogFullScreenButton
+              displayMode={ctx.displayMode === 'full-screen' ? 'full-screen' : 'default'}
+              onClick={toggleFullscreen}
+              onPointerDown={stopPointerPropagation}
+              disabled={!ctx.onDisplayModeChange}
+            />
+            <PluginDialogCloseButton
+              onClick={() => ctx.onRequestClose('close')}
               onPointerDown={stopPointerPropagation}
             />
-          ) : null}
-          <PluginDialogMaximizeButton
-            displayMode={ctx.displayMode === 'maximize' ? 'maximize' : 'default'}
-            onClick={toggleMaximize}
-            onPointerDown={stopPointerPropagation}
-            disabled={!ctx.onDisplayModeChange}
-          />
-          <PluginDialogFullScreenButton
-            displayMode={ctx.displayMode === 'full-screen' ? 'full-screen' : 'default'}
-            onClick={toggleFullscreen}
-            onPointerDown={stopPointerPropagation}
-            disabled={!ctx.onDisplayModeChange}
-          />
-          <PluginDialogCloseButton
-            onClick={() => ctx.onRequestClose('close')}
-            onPointerDown={stopPointerPropagation}
-          />
+          </Stack>
         </Stack>
-      </Stack>
+      )}
     </Box>
   );
 };

--- a/packages/ui/dialog/src/headless/ModelessDialogFrame.tsx
+++ b/packages/ui/dialog/src/headless/ModelessDialogFrame.tsx
@@ -86,20 +86,7 @@ export function ModelessDialogFrame<TData>(props: ModelessDialogFrameProps<TData
   const transitionTimeout = shouldAnimate ? fadeDuration : 0;
 
   const [isInteracting, setIsInteracting] = useState(false);
-  const [isHeaderVisible, setIsHeaderVisible] = useState(!frameless);
-
-  useEffect(() => {
-    if (!frameless) {
-      setIsHeaderVisible(true);
-    }
-  }, [frameless]);
-
-  const handleFrameContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    if (!frameless) return;
-    event.preventDefault();
-    event.stopPropagation();
-    setIsHeaderVisible((prev) => !prev);
-  }, [frameless]);
+  const isHeaderVisible = !frameless;
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     if (!open) return;
@@ -140,7 +127,9 @@ export function ModelessDialogFrame<TData>(props: ModelessDialogFrameProps<TData
   const handleDragPointerDown = useCallback((event: React.PointerEvent<HTMLElement>) => {
     if (fullScreen) return;
     if (!headlessProps.onPositionChange) return;
-    if (event.button !== 0) return;
+    const isPrimaryButton = event.button === 0;
+    const isSecondaryButton = frameless && event.button === 2;
+    if (!isPrimaryButton && !isSecondaryButton) return;
 
     event.preventDefault();
     event.stopPropagation();
@@ -178,7 +167,7 @@ export function ModelessDialogFrame<TData>(props: ModelessDialogFrameProps<TData
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', handlePointerEnd);
     window.addEventListener('pointercancel', handlePointerEnd);
-  }, [fullScreen, guards, headlessProps, position.x, position.y]);
+  }, [frameless, fullScreen, guards, headlessProps, position.x, position.y]);
 
   const handleResizePointerDown = useCallback((direction: ResizeDirection, event: React.PointerEvent<HTMLElement>) => {
     if (fullScreen || isMinimized) return;
@@ -278,6 +267,8 @@ export function ModelessDialogFrame<TData>(props: ModelessDialogFrameProps<TData
 
   const augmentedHeadlessProps = useMemo(() => ({
     ...headlessProps,
+    frameless,
+    transparent,
     HeaderComponent: headerComponent,
     onDragHandlePointerDown: (event: React.PointerEvent<HTMLElement>) => {
       onRequestFocus?.();
@@ -312,7 +303,7 @@ export function ModelessDialogFrame<TData>(props: ModelessDialogFrameProps<TData
         display: 'flex',
         flexDirection: 'column',
         borderRadius: fullScreen ? 0 : theme.shape.borderRadius,
-        boxShadow: fullScreen ? 'none' : theme.shadows[8],
+        boxShadow: fullScreen || (frameless && transparent) ? 'none' : theme.shadows[8],
         overflow: 'hidden',
         backgroundColor: transparent ? 'transparent' : getDialogSurfaceColor(theme),
         pointerEvents: 'auto',
@@ -328,7 +319,7 @@ export function ModelessDialogFrame<TData>(props: ModelessDialogFrameProps<TData
           }),
       } as const;
     }
-  ), [collapsedHeight, fullScreen, isInteracting, isMinimized, position.x, position.y, size.height, size.width, transparent]);
+  ), [collapsedHeight, fullScreen, frameless, isInteracting, isMinimized, position.x, position.y, size.height, size.width, transparent]);
 
   const combinedFrameSx = useMemo<SxProps<Theme>>(
     () => (frameSx
@@ -343,11 +334,19 @@ export function ModelessDialogFrame<TData>(props: ModelessDialogFrameProps<TData
       role="dialog"
       aria-modal={false}
       onKeyDown={handleKeyDown}
-      onPointerDown={() => {
+      onPointerDown={(event) => {
         onRequestFocus?.();
+        if (frameless && event.button === 2) {
+          handleDragPointerDown(event);
+        }
       }}
       onWheelCapture={guards.handleWheelCapture}
-      onContextMenu={handleFrameContextMenu}
+      onContextMenu={(event) => {
+        if (frameless) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      }}
     >
       <AbstractDialog {...augmentedHeadlessProps} />
       {!fullScreen && !isMinimized && (

--- a/packages/ui/dialog/src/headless/PluginDialogFrame.tsx
+++ b/packages/ui/dialog/src/headless/PluginDialogFrame.tsx
@@ -63,6 +63,8 @@ export function PluginDialogFrame<TData>(props: PluginDialogFrameComponentProps<
   } = props;
 
   const { open, onRequestClose } = headlessProps;
+  const frameless = headlessProps.frameless ?? false;
+  const transparent = headlessProps.transparent ?? false;
 
   const isBrowser = typeof document !== 'undefined';
   const theme = useTheme();
@@ -141,7 +143,9 @@ export function PluginDialogFrame<TData>(props: PluginDialogFrameComponentProps<
   const handleDragPointerDown = useCallback((event: React.PointerEvent<HTMLElement>) => {
     if (fullScreen) return;
     if (!headlessProps.onPositionChange) return;
-    if (event.button !== 0) return;
+    const isPrimaryButton = event.button === 0;
+    const isSecondaryButton = frameless && event.button === 2;
+    if (!isPrimaryButton && !isSecondaryButton) return;
 
     event.preventDefault();
     event.stopPropagation();
@@ -179,7 +183,7 @@ export function PluginDialogFrame<TData>(props: PluginDialogFrameComponentProps<
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', handlePointerEnd);
     window.addEventListener('pointercancel', handlePointerEnd);
-  }, [fullScreen, headlessProps, guards, position.x, position.y]);
+  }, [frameless, fullScreen, headlessProps, guards, position.x, position.y]);
 
   const handleResizePointerDown = useCallback((direction: ResizeDirection, event: React.PointerEvent<HTMLElement>) => {
     if (fullScreen) return;
@@ -265,6 +269,8 @@ export function PluginDialogFrame<TData>(props: PluginDialogFrameComponentProps<
 
   const augmentedHeadlessProps = useMemo(() => ({
     ...headlessProps,
+    frameless,
+    transparent,
     onDragHandlePointerDown: (event: React.PointerEvent<HTMLElement>) => {
       handleDragPointerDown(event);
       headlessProps.onDragHandlePointerDown?.(event);
@@ -286,9 +292,9 @@ export function PluginDialogFrame<TData>(props: PluginDialogFrameComponentProps<
       display: 'flex',
       flexDirection: 'column',
       borderRadius: fullScreen ? 0 : theme.shape.borderRadius,
-      boxShadow: fullScreen ? 'none' : theme.shadows[8],
+      boxShadow: fullScreen || (frameless && transparent) ? 'none' : theme.shadows[8],
       overflow: 'hidden',
-      backgroundColor: getDialogSurfaceColor(theme),
+      backgroundColor: transparent ? 'transparent' : getDialogSurfaceColor(theme),
       ...(isInteracting
         ? {
           transition: 'none',
@@ -300,7 +306,7 @@ export function PluginDialogFrame<TData>(props: PluginDialogFrameComponentProps<
           }),
         }),
     })
-  ), [fullScreen, isInteracting, position.x, position.y, size.height, size.width]);
+  ), [fullScreen, frameless, isInteracting, position.x, position.y, size.height, size.width, transparent]);
 
   const combinedFrameSx = useMemo<SxProps<Theme>>(
     () => (frameSx
@@ -333,6 +339,16 @@ export function PluginDialogFrame<TData>(props: PluginDialogFrameComponentProps<
       role="dialog"
       aria-modal="true"
       onKeyDown={handleKeyDown}
+      onContextMenu={(event: React.MouseEvent<HTMLDivElement>) => {
+        if (frameless) {
+          event.preventDefault();
+        }
+      }}
+      onPointerDown={(event: React.PointerEvent<HTMLDivElement>) => {
+        if (frameless && event.button === 2) {
+          handleDragPointerDown(event);
+        }
+      }}
     >
       <HeadlessPluginDialog {...augmentedHeadlessProps} />
       {!fullScreen && (

--- a/packages/ui/dialog/src/headless/types.ts
+++ b/packages/ui/dialog/src/headless/types.ts
@@ -77,6 +77,8 @@ export interface DialogFrameProps {
   onDisplayModeChange?: (mode: DialogDisplayMode) => void;
   isMinimized?: boolean;
   onMinimizeChange?: (next: boolean) => void;
+  frameless?: boolean;
+  transparent?: boolean;
   headerDisplayMode?: SectionVisibilityMode;
   footerDisplayMode?: SectionVisibilityMode;
   headerHoverZoneHeight?: number;


### PR DESCRIPTION
## Summary
- add frameless and transparent flags to dialog frame props and propagate them through the headless dialog context
- remove padding/shadow and hide header controls when dialogs are frameless and transparent, including modeless map dialogs
- switch right-click behavior to dragging for frameless dialogs instead of toggling headers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695615a95e608323b4c2b597eb9a545d)