### PR TITLE
feat(gis-sdk): support styler code-based coloring for shape tiles

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,3 +1,20 @@
+2295) feat/shape/styler-code-coloring (P1) — 進行中 (2026-01-23)
+- ブランチ名: feat/shape/styler-code-coloring
+- 依存: なし
+- 受け入れ基準: ShapeのベクタータイルにcountryCode/adminCode/adminLevelが補完され、Stylerの生成結果（コード→色）をfeatureIdPropertyで適用できる／ADM0/1/2の塗り分けが可能／既存のタイル生成とメタデータ集計に影響しない／pnpm install・pnpm build・pnpm typecheck が exit 0／TASKS.md に運用ログを記載する
+- 影響範囲: `packages/features/gis-sdk/src/vectorTiles.ts`
+- ロールバック手順: vectorTiles のプロパティ補完差分を revert する
+- チェックリスト:
+  - タイル生成時にcountryCode/adminCode/adminLevelを補完する
+  - StylerのfeatureIdPropertyで参照できることを確認する
+  - pnpm install・pnpm build・pnpm typecheck を実行する
+  - 運用ログ start/done/blocked を追記する
+- 運用ログ：
+  - start: 2026-01-23 09:00 JST Stylerのコード→色対応をShapeタイルで使うため、プロパティ補完の対応に着手。
+  - update: 2026-01-23 09:10 JST vectorTiles 生成時にcountryCode/adminCode/adminLevelを補完する処理を追加。
+  - update: 2026-01-23 09:15 JST pnpm install/build/typecheck が corepack の pnpm 取得失敗（Proxy 403）で停止。
+  - done: 2026-01-23 09:20 JST 仕様どおりにプロパティ補完を実装。検証は pnpm install/build/typecheck が corepack の pnpm 取得失敗（Proxy 403）で未完了。
+
 2292) fix/shape/step6-preview-hover-snackbar (P1) — 進行中 (2026-01-22)
 - ブランチ名: fix/shape/step6-preview-hover-snackbar
 - 依存: なし

--- a/packages/features/gis-sdk/src/vectorTiles.ts
+++ b/packages/features/gis-sdk/src/vectorTiles.ts
@@ -100,6 +100,36 @@ function buildUniqueFeatureId(
   return `${composed}:${index}`;
 }
 
+const normalizePropertyValue = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+  return undefined;
+};
+
+const ensureMetadataProperties = (
+  properties: Record<string, unknown>,
+  metadataContext?: VTMetadataContext,
+): void => {
+  const rawCountryCode = metadataContext?.countryCode ?? pickCountryCode(properties);
+  const normalizedCountryCode = normalizePropertyValue(rawCountryCode)?.toUpperCase();
+  if (normalizedCountryCode && properties.countryCode === undefined) {
+    properties.countryCode = normalizedCountryCode;
+  }
+  const adminCode = normalizePropertyValue(pickAdminCode(properties));
+  if (adminCode && properties.adminCode === undefined) {
+    properties.adminCode = adminCode;
+  }
+  const adminLevel = metadataContext?.adminLevel ?? pickAdminLevel(properties);
+  if (adminLevel != null && properties.adminLevel === undefined) {
+    properties.adminLevel = adminLevel;
+  }
+};
+
 const long2tile = (lon: number, z: number) => lonToTileX(lon, z);
 
 const lat2tile = (lat: number, z: number) => latToTileY(lat, z);
@@ -320,6 +350,7 @@ export const generateVectorTilesFromFeatureCollection = async (
       const properties = feature.properties;
       const tileFeatureId = buildUniqueFeatureId(feature, index, metadataContext);
       properties.id = tileFeatureId;
+      ensureMetadataProperties(properties, metadataContext);
       const stats = extractGeometryStats(feature.geometry);
       records.push({
         id: `${nodeId}-${tileFeatureId}`,
@@ -347,6 +378,7 @@ export const generateVectorTilesFromFeatureCollection = async (
       if (!feature) continue;
       const properties = feature.properties ?? {};
       properties.id = buildUniqueFeatureId(feature, index, metadataContext);
+      ensureMetadataProperties(properties, metadataContext);
     }
   }
   console.debug('[VectorTiles] metadata pass', {


### PR DESCRIPTION
### Motivation
- Provide stable per-feature metadata (`countryCode`, `adminCode`, `adminLevel`) on generated vector tiles so Styler can apply code→color mappings via `featureIdProperty` and enable ADM0/1/2 coloring.

### Description
- Add helper `normalizePropertyValue` and `ensureMetadataProperties` to `packages/features/gis-sdk/src/vectorTiles.ts` to populate `countryCode`, `adminCode`, and `adminLevel` on feature properties during tile generation.
- Invoke `ensureMetadataProperties` in both the metadata collection pass and the non-metadata pass so properties are filled regardless of `metadataEnabled`.
- Record the work and verification status in `TASKS.md` (new task `feat/shape/styler-code-coloring`).

### Testing
- Ran `pnpm install --frozen-lockfile` which failed due to corepack being unable to download pnpm (network/proxy 403) so dependency installation could not be completed.
- Ran `pnpm build` which failed for the same corepack/pnpm download issue and prevented a full build verification.
- Ran `pnpm typecheck` which similarly failed because corepack could not fetch pnpm (proxy 403), so TypeScript checks could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970aa1bebfc8323a370341841cfc9d3)