### PR TITLE
fix(shape-plugin): prevent completed task rows from returning to running

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,3 +1,23 @@
+2684) fix/shape/task-status-prevent-completed-to-running-regression (P1) — 完了 (2026-02-10)
+- ブランチ名: ERIA-Cartograph
+- 依存: なし
+- 受け入れ基準: Shapeプラグインのタスク一覧で個別タスクが `Completed` 表示後に `Running` へ逆戻りしない／既存の task update/snapshot マージ挙動を壊さない／影響範囲の検証結果を TASKS.md に記録する／原因・発生範囲・修正方法と適用範囲を TASKS.md に記載する
+- 影響範囲: `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts`
+- ロールバック手順: 上記ファイル差分を revert し、従来の task status マージロジックへ戻す
+- チェックリスト:
+  - `Completed` 到達済みタスクの最新スナップショット/更新イベント取り込み時に `Running` へ戻さない
+  - task delete / reset 時に completed キャッシュも同期削除する
+  - 影響範囲の test/typecheck/build を実行し結果を記録する
+  - 運用ログ start/update/done/blocked を追記する
+- 運用ログ:
+  - start: 2026-02-10 21:50 JST Shapeプラグイン task list で `Completed -> Running` 逆遷移を防止する修正に着手。
+  - update: 2026-02-10 21:52 JST 原因は `useShapeBuildTaskSync.ts` の `resolveTaskSummary` が受信イベントをそのまま正規化し、既に完了確定した taskId でも後続の遅延 `running` update/snapshot を採用し得たこと。発生範囲は同ファイルの task 正規化〜マージ経路（`resolveTaskSummary` / `mergeTask` / `handleSnapshot`）。
+  - update: 2026-02-10 21:53 JST 修正として `completedTasksRef` を追加し、taskId 単位で completed 到達済みタスクを保持。`resolveTaskSummary` で後続 `running` を受信しても completed キャッシュを優先返却するよう変更。加えて `mergeTask`/`handleSnapshot` で completed キャッシュを更新し、`handleDelete`/`syncTasksRef` でも整合を維持。適用範囲は `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts` のみ。
+  - blocked: 2026-02-10 21:55 JST `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx` は corepack 経由 pnpm 取得時に `ENETUNREACH` で失敗（registry 到達不可）。
+  - blocked: 2026-02-10 21:55 JST `node_modules/.bin/turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx` も内部 `pnpm run build` 呼び出しで同じ `ENETUNREACH` により失敗。
+  - blocked: 2026-02-10 21:55 JST 代替として `node_modules/.bin/vitest run plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx` を実行したが、依存パッケージ alias 解決（`@hierarchidb/util`）が未ビルドで import 解決失敗。
+  - done: 2026-02-10 21:56 JST ネットワーク制限で turbo/pnpm ベース検証は完走不可。コード修正は完了し、検証未完了理由と代替実行結果を記録。
+
 2683) feat/map/floating-window-front-order-control-and-persist (P1) — 完了 (2026-02-10)
 - ブランチ名: ERIA-Cartograph
 - 依存: 2682) refactor/map/modeless-windows-use-ui-floating-window

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
@@ -291,6 +291,7 @@ export const useShapeBuildTaskSync = ({ setTasks, setIsLoading, setError }: Sync
   const tasksRef = useRef<ShapeBuildTaskSummary[]>([]);
   const committedTasksRef = useRef<ShapeBuildTaskSummary[]>([]);
   const tasksMapRef = useRef<Map<string, ShapeBuildTaskSummary>>(new Map());
+  const completedTasksRef = useRef<Map<string, ShapeBuildTaskSummary>>(new Map());
   const pendingTasksRef = useRef<ShapeBuildTaskSummary[] | null>(null);
   const pendingDirtyRef = useRef(false);
   const flushScheduledRef = useRef(false);
@@ -339,12 +340,17 @@ export const useShapeBuildTaskSync = ({ setTasks, setIsLoading, setError }: Sync
 
   const resolveTaskSummary = useCallback((task: RawTaskSummary): ShapeBuildTaskSummary => {
     const progress = resolveProgressValue(task.progress);
-    return {
+    const normalized: ShapeBuildTaskSummary = {
       ...task,
       stage: resolveTaskStage(task),
       status: normalizeTaskStatus(task.status, progress),
       progress: progress >= 100 ? 100 : task.progress,
     };
+    const completedTask = completedTasksRef.current.get(normalized.taskId);
+    if (normalized.status === 'running' && completedTask) {
+      return completedTask;
+    }
+    return normalized;
   }, []);
 
   const mergeTask = useCallback((task: ShapeBuildTaskSummary) => {
@@ -359,6 +365,11 @@ export const useShapeBuildTaskSync = ({ setTasks, setIsLoading, setError }: Sync
     const nextMap = new Map(tasksMapRef.current);
     nextMap.set(task.taskId, task);
     tasksMapRef.current = nextMap;
+    if (task.status === 'completed') {
+      const nextCompletedMap = new Map(completedTasksRef.current);
+      nextCompletedMap.set(task.taskId, task);
+      completedTasksRef.current = nextCompletedMap;
+    }
     return { next: upsertTaskInSortedList(baseList, task), changed: true } as const;
   }, []);
 
@@ -366,6 +377,13 @@ export const useShapeBuildTaskSync = ({ setTasks, setIsLoading, setError }: Sync
     const snapshotTasks = next.map(resolveTaskSummary);
     const resolved = mergeSnapshotWithCurrent(snapshotTasks, tasksMapRef.current);
     tasksMapRef.current = new Map(resolved.map((task) => [task.taskId, task]));
+    const nextCompletedMap = new Map(completedTasksRef.current);
+    resolved.forEach((task) => {
+      if (task.status === 'completed') {
+        nextCompletedMap.set(task.taskId, task);
+      }
+    });
+    completedTasksRef.current = nextCompletedMap;
     scheduleFlush(resolved, !areTaskListsEquivalentForView(committedTasksRef.current, resolved));
     if (errorRef.current !== null) {
       setError(null);
@@ -398,6 +416,9 @@ export const useShapeBuildTaskSync = ({ setTasks, setIsLoading, setError }: Sync
     const nextMap = new Map(tasksMapRef.current);
     nextMap.delete(taskId);
     tasksMapRef.current = nextMap;
+    const nextCompletedMap = new Map(completedTasksRef.current);
+    nextCompletedMap.delete(taskId);
+    completedTasksRef.current = nextCompletedMap;
     const current = pendingTasksRef.current ?? committedTasksRef.current;
     const next = removeTaskFromList(current, taskId);
     scheduleFlush(next, true);
@@ -413,6 +434,11 @@ export const useShapeBuildTaskSync = ({ setTasks, setIsLoading, setError }: Sync
     tasksRef.current = tasks;
     committedTasksRef.current = tasks;
     tasksMapRef.current = new Map(tasks.map((task) => [task.taskId, task]));
+    completedTasksRef.current = new Map(
+      tasks
+        .filter((task) => task.status === 'completed')
+        .map((task) => [task.taskId, task]),
+    );
   }, []);
 
   const syncLoadingRef = useCallback((isLoading: boolean) => {


### PR DESCRIPTION
### Motivation
- Prevent a UI regression where a task that reached `completed` could later display as `running` when delayed/late events arrived for the same `taskId`.

### Description
- Added a completed-task cache `completedTasksRef` to `useShapeBuildTaskSync` to persist the last-seen `completed` snapshot per `taskId`.
- Updated `resolveTaskSummary` to prefer the cached completed snapshot when a later `running` update is received for the same `taskId`.
- Kept the cache consistent by updating it on merge/snapshot paths and removing entries on `handleDelete` and `syncTasksRef` rebuilds, and integrated these changes in the existing merge/flush flow in `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts`.
- Documented the change, cause, scope, verification attempts and rollback steps in `TASKS.md`.

### Testing
- Attempted `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx`, but the run was blocked by network/package manager download errors (`corepack/pnpm` failed with `ENETUNREACH`).
- Attempted `node_modules/.bin/turbo run test --filter @hierarchidb/shape-plugin -- --run ...` which also failed due to the same internal `pnpm` download/network error.
- Attempted fallback `node_modules/.bin/vitest run plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx`, which failed due to unresolved workspace alias imports (e.g. `@hierarchidb/util`) because dependent packages were not built in the current environment.
- Code changes committed (`fix(shape-plugin): prevent completed tasks regressing to running`) and documented; automated test validation in this environment is blocked by network/dependency build constraints. Please run `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` in CI or a network-enabled dev environment to complete verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b654255088323825f0b7fcaefe5a8)