### PR TITLE
refactor(ui-batch): unify build-session subscriptions and query API access

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -39,6 +39,7 @@
 
 ### Doing
 
+- #213 / `codex/refactor/build-session-subscription-unify` / start: 2026-02-12 12:49 JST
 - #200 / `codex/fix/shape/vt-parent-geojson-input-summary` / start: 2026-02-11 20:27 JST
 - #201 / `codex/refactor/app/modeless-use-feature-metadata` / start: 2026-02-11 22:15 JST
 - #205 / `ERIA-Cartograph` / start: 2026-02-12 01:28 JST
@@ -52,6 +53,12 @@
 
 ## 今日の運用ログ
 
+- update: 2026-02-12 12:49 JST Issue `refactor/app/build-session-subscription-unify` を起票し `https://github.com/kubohiroya/hierarchidb/issues/213` を作成。
+- update: 2026-02-12 12:49 JST Issue #213 を Project `hierarchidb` に追加し、Status を `In Progress`（Doing 相当）へ設定。
+- update: 2026-02-12 12:49 JST ブランチ `codex/refactor/build-session-subscription-unify` を作成して着手。
+- update: 2026-02-12 12:50 JST #213 で `useBuildSessionSnapshots` に共有購読レジストリを導入し、同一 `api + nodeType` の重複 subscribe を1本化。`BuildSessionLauncherPanel` は `BuildSessionRuntimeContext` 優先利用へ変更し、Context存在時の追加購読を停止。`getQueryAPI()` は `useWorkerQueryAPI` へ共通化。
+- done: 2026-02-12 12:50 JST 検証完了（`pnpm -w turbo run typecheck --filter @hierarchidb/ui-batch-progress --filter @hierarchidb/app` / `pnpm -w turbo run build --filter @hierarchidb/ui-batch-progress --filter @hierarchidb/app` すべて exit 0）。
+- update: 2026-02-12 08:37 JST Issue #211 を起票し Project `hierarchidb` の Status を `In Progress` に設定、ブランチ `codex/fix/shape/build-session-resume-stalls` を作成して着手。
 - update: 2026-02-12 07:32 JST #209 Reset session 実行後に `Completed/Error` が残留する原因は、`plugins/shape-plugin/src/ui/components/build-config/useShapeBuildCacheActions.ts` の `handleResetSession` が session reset のみで task queue を削除していなかったこと。発生範囲は同ファイルの reset 経路（`handleResetSession`）。修正として `deleteTasksByNode` を追加し、reset 時に task queue を削除してから artifacts/session をクリアするよう変更。回帰テスト `plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildCacheActions.unit.test.tsx` を追加。
 - done: 2026-02-12 07:32 JST 検証完了（`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildCacheActions.unit.test.tsx` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` すべて exit 0）。
 - update: 2026-02-12 07:15 JST #209 追加調査で、`plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts` の `saveDraftBeforeBuild` が `buildConfig` は保存する一方で `selectedArrayByCountries` を draft へ反映しておらず、worker 側 `startBatchProcess` が selection 無しと判定して `Shape batch session requires download task payloads or selection` を返していたことを確認。発生範囲は同ファイルの draft 保存処理（`save-draft` payload 組み立て）。

--- a/packages/ui/batch/src/components/BuildSessionLauncherPanel.tsx
+++ b/packages/ui/batch/src/components/BuildSessionLauncherPanel.tsx
@@ -37,8 +37,9 @@ import {
   Layers as LayersIcon,
   Tune as TuneIcon,
 } from '@mui/icons-material';
-import { useWorkerAPI } from '@hierarchidb/ui-worker-provider';
+import { useOptionalBuildSessionRuntimeContext } from '../contexts/TreeBuildSessionContexts.js';
 import { useBuildSessionSnapshots } from '../hooks/useBuildSessionSnapshots.js';
+import { useWorkerQueryAPI } from '../hooks/useWorkerQueryAPI.js';
 
 export type BuildSessionLauncherEntry = {
   session: BuildSessionSnapshot;
@@ -52,6 +53,10 @@ type BuildSessionLauncherPanelProps = {
   nodeType: NodeType;
   excludeNodeId?: NodeId;
   onNavigateToBuild?: (entry: BuildSessionLauncherEntry, options?: { openInNewTab?: boolean }) => void;
+};
+
+type BuildSessionLauncherPanelInnerProps = Omit<BuildSessionLauncherPanelProps, 'nodeType'> & {
+  sessions: readonly BuildSessionSnapshot[];
 };
 
 type ProgressSummary = {
@@ -191,13 +196,61 @@ const resolveRequestedAt = (session: BuildSessionSnapshot): number => session.up
 
 export function BuildSessionLauncherPanel({
   nodeType,
+  treeId,
+  pageNodeId,
+  excludeNodeId,
+  onNavigateToBuild,
+}: BuildSessionLauncherPanelProps) {
+  const runtimeContext = useOptionalBuildSessionRuntimeContext();
+  if (runtimeContext && runtimeContext.nodeType === nodeType) {
+    return (
+      <BuildSessionLauncherPanelInner
+        treeId={treeId}
+        pageNodeId={pageNodeId}
+        excludeNodeId={excludeNodeId}
+        onNavigateToBuild={onNavigateToBuild}
+        sessions={runtimeContext.sessions}
+      />
+    );
+  }
+  return (
+    <BuildSessionLauncherPanelWithSubscription
+      nodeType={nodeType}
+      treeId={treeId}
+      pageNodeId={pageNodeId}
+      excludeNodeId={excludeNodeId}
+      onNavigateToBuild={onNavigateToBuild}
+    />
+  );
+}
+
+function BuildSessionLauncherPanelWithSubscription({
+  nodeType,
+  treeId,
+  pageNodeId,
+  excludeNodeId,
+  onNavigateToBuild,
+}: BuildSessionLauncherPanelProps) {
+  const { sessions } = useBuildSessionSnapshots(nodeType);
+  return (
+    <BuildSessionLauncherPanelInner
+      treeId={treeId}
+      pageNodeId={pageNodeId}
+      excludeNodeId={excludeNodeId}
+      onNavigateToBuild={onNavigateToBuild}
+      sessions={sessions}
+    />
+  );
+}
+
+function BuildSessionLauncherPanelInner({
   onNavigateToBuild,
   excludeNodeId,
-}: BuildSessionLauncherPanelProps) {
-  const { api } = useWorkerAPI();
+  sessions,
+}: BuildSessionLauncherPanelInnerProps) {
+  const { apiAvailable, getQueryAPIOrNull } = useWorkerQueryAPI();
   const { t } = useGlobalI18nTranslator();
   const { resolveIcon } = useIconRegistry();
-  const { sessions, isRunnerTab, activeSessionId } = useBuildSessionSnapshots(nodeType);
   const stages = useBuildStages(t);
   const stageById = useMemo(() => new Map(stages.map((stage) => [stage.id, stage])), [stages]);
   const [entries, setEntries] = useState<BuildSessionLauncherEntry[]>([]);
@@ -232,8 +285,8 @@ export function BuildSessionLauncherPanel({
     });
   }, []);
 
-  const refreshEntries = useCallback(async (sessionSnapshots: BuildSessionSnapshot[]) => {
-    if (!api) {
+  const refreshEntries = useCallback(async (sessionSnapshots: readonly BuildSessionSnapshot[]) => {
+    if (!apiAvailable) {
       scheduleEntriesUpdate([]);
       return;
     }
@@ -243,7 +296,7 @@ export function BuildSessionLauncherPanel({
     }
     const currentRefreshId = refreshIdRef.current + 1;
     refreshIdRef.current = currentRefreshId;
-    const queryAPI = await api.getQueryAPI().catch(() => null);
+    const queryAPI = await getQueryAPIOrNull();
     if (!queryAPI) {
       if (currentRefreshId === refreshIdRef.current) {
         const fallbackEntries: BuildSessionLauncherEntry[] = sessionSnapshots.map((session) => ({
@@ -284,7 +337,7 @@ export function BuildSessionLauncherPanel({
       return a.nodePath.localeCompare(b.nodePath);
     });
     scheduleEntriesUpdate(nextEntries);
-  }, [api, scheduleEntriesUpdate]);
+  }, [apiAvailable, getQueryAPIOrNull, scheduleEntriesUpdate]);
 
   useEffect(() => {
     void refreshEntries(sessions);
@@ -379,8 +432,8 @@ export function BuildSessionLauncherPanel({
           const nodeTypeResolved = entry.node?.nodeType ?? 'folder';
           const nodePath = entry.nodePath || nodeName;
           const icon = resolveIcon({ nodeType: nodeTypeResolved });
-          const isActive = isRunnerTab && activeSessionId === String(entry.session.nodeId);
-          const variant = isRunnerTab ? 'outlined' : 'text';
+          const isActive = entry.session.isActive;
+          const variant = isActive ? 'outlined' : 'text';
           const color = isActive ? 'primary' : 'inherit';
           const countsText = t(
             'stage.progress.countsWithUnit',

--- a/packages/ui/batch/src/hooks/useBuildSessionSnapshots.ts
+++ b/packages/ui/batch/src/hooks/useBuildSessionSnapshots.ts
@@ -1,34 +1,35 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { BuildSessionRuntimeRecord } from '@hierarchidb/batch-api';
 import type { NodeId, NodeType } from '@hierarchidb/core-types';
-import { createSessionCoordinator } from '@hierarchidb/session-coordinator';
+import type { WorkerAPI } from '@hierarchidb/worker-api';
 import { proxy } from 'comlink';
-import { useWorkerAPI } from '@hierarchidb/ui-worker-provider';
-
-type BuildSessionRecordLike = {
-  nodeId: NodeId;
-  status?: unknown;
-  progress?: unknown;
-  updatedAt?: number;
-};
+import type { Remote } from 'comlink';
+import { useWorkerQueryAPI } from './useWorkerQueryAPI.js';
 
 export type BuildSessionSnapshot = {
   nodeId: NodeId;
-  status?: unknown;
-  progress?: unknown;
+  status: BuildSessionRuntimeRecord['status'];
+  progress?: BuildSessionRuntimeRecord['progress'];
   updatedAt?: number;
+  isActive: boolean;
+  revision: number;
 };
 
 export type BuildSessionSnapshotsResult = {
   sessions: BuildSessionSnapshot[];
-  isRunnerTab: boolean;
-  activeSessionId: string | null;
-  tabId: string;
 };
+
+const IN_PROGRESS_STATUSES: BuildSessionRuntimeRecord['status'][] = [
+  'starting',
+  'running',
+  'pausing',
+  'resuming',
+  'finalizing',
+];
 
 const buildSessionSignature = (sessions: BuildSessionSnapshot[]): string => {
   return sessions
     .map((session) => {
-      const status = typeof session.status === 'string' ? session.status : '';
       const updatedAt = session.updatedAt ?? '';
       const progressKey = (() => {
         if (session.progress === null || session.progress === undefined) return '';
@@ -41,108 +42,166 @@ const buildSessionSignature = (sessions: BuildSessionSnapshot[]): string => {
           return '';
         }
       })();
-      return `${session.nodeId}|${status}|${updatedAt}|${progressKey}`;
+      return `${session.nodeId}|${session.status}|${session.isActive ? 1 : 0}|${session.revision}|${updatedAt}|${progressKey}`;
     })
     .join('||');
 };
 
-export const useBuildSessionSnapshots = (nodeType: NodeType): BuildSessionSnapshotsResult => {
-  const { api, initialize, loading } = useWorkerAPI();
-  const coordinator = useMemo(() => (
-    createSessionCoordinator({
-      channelName: 'sessions',
-      pollIntervalTimeout: 3000,
-      quietThresholdTimeout: 5000,
-    })
-  ), []);
-  const [sessions, setSessions] = useState<BuildSessionSnapshot[]>([]);
-  const sessionMapRef = useRef<Map<string, BuildSessionSnapshot>>(new Map());
-  const signatureRef = useRef('');
-  const [isRunnerTab, setIsRunnerTab] = useState(false);
-  const tabIdRef = useRef<string>(coordinator.getTabId());
-  const initRequestedRef = useRef(false);
+type WorkerPayload = Record<string, unknown>;
+type WorkerApi = WorkerAPI<WorkerPayload>;
+type WorkerApiRemote = Remote<WorkerApi>;
+type BuildSessionListener = (sessions: BuildSessionSnapshot[]) => void;
 
-  useEffect(() => {
-    if (api || loading || initRequestedRef.current) return;
-    initRequestedRef.current = true;
-    void initialize().catch((error: unknown) => {
-      initRequestedRef.current = false;
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn('[useBuildSessionSnapshots] worker initialize failed', message);
-    });
-  }, [api, initialize, loading]);
+class SharedBuildSessionSubscription {
+  private readonly listeners = new Set<BuildSessionListener>();
+  private sessions: BuildSessionSnapshot[] = [];
+  private signature = '';
+  private unsubscribe: (() => void) | null = null;
+  private subscribeRequested = false;
+  private disposed = false;
+  private cleanedUp = false;
 
-  const updateSessions = useCallback((nextMap: Map<string, BuildSessionSnapshot>) => {
-    const nextSessions = Array.from(nextMap.values()).sort((a, b) => {
-      return String(a.nodeId).localeCompare(String(b.nodeId));
-    });
+  constructor(
+    private readonly api: WorkerApiRemote,
+    private readonly nodeType: NodeType,
+    private readonly cleanup: () => void
+  ) {}
+
+  addListener(listener: BuildSessionListener): () => void {
+    this.listeners.add(listener);
+    listener(this.sessions);
+    this.ensureSubscribed();
+    return () => {
+      this.listeners.delete(listener);
+      if (this.listeners.size === 0) {
+        this.disposeAndCleanup();
+      }
+    };
+  }
+
+  private ensureSubscribed() {
+    if (this.subscribeRequested || this.disposed) {
+      return;
+    }
+    this.subscribeRequested = true;
+    void this.start();
+  }
+
+  private async start() {
+    try {
+      const unsubscribe = await this.api.subscribeBuildSessionRuntimes(
+        this.nodeType,
+        { statuses: IN_PROGRESS_STATUSES },
+        proxy((incoming: BuildSessionRuntimeRecord[]) => {
+          this.handleIncoming(incoming);
+        })
+      );
+      if (this.disposed) {
+        if (typeof unsubscribe === 'function') {
+          unsubscribe();
+        }
+        return;
+      }
+      this.unsubscribe = typeof unsubscribe === 'function' ? unsubscribe : null;
+    } catch (error) {
+      if (!this.disposed) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn('[useBuildSessionSnapshots] subscribe failed', message);
+      }
+      this.subscribeRequested = false;
+    }
+  }
+
+  private handleIncoming(incoming: BuildSessionRuntimeRecord[]) {
+    if (this.disposed) {
+      return;
+    }
+    const nextSessions = incoming
+      .map((session) => ({
+        nodeId: session.nodeId,
+        status: session.status,
+        progress: session.progress,
+        updatedAt: session.updatedAt,
+        isActive: session.isActive,
+        revision: session.revision,
+      }))
+      .sort((a, b) => String(a.nodeId).localeCompare(String(b.nodeId)));
     const signature = buildSessionSignature(nextSessions);
-    if (signature === signatureRef.current) return;
-    signatureRef.current = signature;
-    setSessions(nextSessions);
-  }, []);
+    if (signature === this.signature) {
+      return;
+    }
+    this.signature = signature;
+    this.sessions = nextSessions;
+    for (const listener of this.listeners) {
+      listener(nextSessions);
+    }
+  }
+
+  private disposeAndCleanup() {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+    this.listeners.clear();
+    this.sessions = [];
+    this.signature = '';
+    if (!this.cleanedUp) {
+      this.cleanedUp = true;
+      this.cleanup();
+    }
+  }
+}
+
+const sharedSubscriptionsByApi = new WeakMap<
+  object,
+  Map<string, SharedBuildSessionSubscription>
+>();
+
+const getSharedBuildSessionSubscription = (
+  api: WorkerApiRemote,
+  nodeType: NodeType
+): SharedBuildSessionSubscription => {
+  const apiKey = api as unknown as object;
+  let subscriptionsByNodeType = sharedSubscriptionsByApi.get(apiKey);
+  if (!subscriptionsByNodeType) {
+    subscriptionsByNodeType = new Map<string, SharedBuildSessionSubscription>();
+    sharedSubscriptionsByApi.set(apiKey, subscriptionsByNodeType);
+  }
+  const nodeTypeKey = String(nodeType);
+  const existing = subscriptionsByNodeType.get(nodeTypeKey);
+  if (existing) {
+    return existing;
+  }
+  const created = new SharedBuildSessionSubscription(api, nodeType, () => {
+    const latest = sharedSubscriptionsByApi.get(apiKey);
+    if (!latest) {
+      return;
+    }
+    latest.delete(nodeTypeKey);
+    if (latest.size === 0) {
+      sharedSubscriptionsByApi.delete(apiKey);
+    }
+  });
+  subscriptionsByNodeType.set(nodeTypeKey, created);
+  return created;
+};
+
+export const useBuildSessionSnapshots = (nodeType: NodeType): BuildSessionSnapshotsResult => {
+  const { api } = useWorkerQueryAPI();
+  const [sessions, setSessions] = useState<BuildSessionSnapshot[]>([]);
 
   useEffect(() => {
     if (!api) {
-      sessionMapRef.current = new Map();
-      updateSessions(new Map());
+      setSessions([]);
       return;
     }
-    let active = true;
-    let unsubscribe: (() => void) | null = null;
-    const subscribe = async () => {
-      const unsub = await api.subscribeBuildSessionRecordsByStatus(
-        nodeType,
-        ['running'],
-        proxy(async (incoming: BuildSessionRecordLike[]) => {
-          if (!active) return;
-          const nextMap = new Map<string, BuildSessionSnapshot>();
-          incoming.forEach((session: BuildSessionRecordLike) => {
-            const key = String(session.nodeId);
-            nextMap.set(key, {
-              nodeId: session.nodeId,
-              status: session.status,
-              progress: session.progress,
-              updatedAt: session.updatedAt,
-            });
-          });
-          sessionMapRef.current = nextMap;
-          updateSessions(nextMap);
-        })
-      );
-      unsubscribe = () => {
-        if (typeof unsub === 'function') {
-          unsub();
-        }
-      };
-    };
-    void subscribe();
-    return () => {
-      active = false;
-      if (unsubscribe) {
-        unsubscribe();
-      }
-    };
-  }, [api, nodeType, updateSessions]);
+    const sharedSubscription = getSharedBuildSessionSubscription(api, nodeType);
+    return sharedSubscription.addListener(setSessions);
+  }, [api, nodeType]);
 
-  useEffect(() => {
-    const updateRunner = () => {
-      const now = Date.now();
-      setIsRunnerTab(coordinator.isRunnerTab(now));
-    };
-    updateRunner();
-    const intervalId = setInterval(updateRunner, 1000);
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [coordinator]);
-
-  const activeSessionId = coordinator.readActiveSessionId();
-
-  return useMemo(() => ({
-    sessions,
-    isRunnerTab,
-    activeSessionId,
-    tabId: tabIdRef.current,
-  }), [activeSessionId, isRunnerTab, sessions]);
+  return useMemo(() => ({ sessions }), [sessions]);
 };

--- a/packages/ui/batch/src/hooks/useWorkerQueryAPI.ts
+++ b/packages/ui/batch/src/hooks/useWorkerQueryAPI.ts
@@ -1,0 +1,68 @@
+import type { TreeQueryAPI } from '@hierarchidb/tree-api';
+import type { WorkerAPI } from '@hierarchidb/worker-api';
+import { useWorkerAPI } from '@hierarchidb/ui-worker-provider';
+import type { Remote } from 'comlink';
+import { useCallback, useEffect, useRef } from 'react';
+
+const queryApiPromiseByWorkerApi = new WeakMap<object, Promise<TreeQueryAPI>>();
+
+type WorkerPayload = Record<string, unknown>;
+type WorkerApi = WorkerAPI<WorkerPayload>;
+type WorkerApiRemote = Remote<WorkerApi>;
+
+type UseWorkerQueryApiResult = {
+  api: WorkerApiRemote | null;
+  apiAvailable: boolean;
+  getQueryAPIOrNull: () => Promise<TreeQueryAPI | null>;
+};
+
+export function useWorkerQueryAPI(): UseWorkerQueryApiResult {
+  const { api, initialize, loading } = useWorkerAPI();
+  const initializeRequestedRef = useRef(false);
+
+  useEffect(() => {
+    if (api || loading || initializeRequestedRef.current) {
+      return;
+    }
+    initializeRequestedRef.current = true;
+    void initialize()
+      .catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn('[useWorkerQueryAPI] worker initialize failed', message);
+      })
+      .finally(() => {
+        initializeRequestedRef.current = false;
+      });
+  }, [api, initialize, loading]);
+
+  const getQueryAPIOrNull = useCallback(async (): Promise<TreeQueryAPI | null> => {
+    if (!api) {
+      return null;
+    }
+    const apiKey = api as unknown as object;
+    const cachedPromise = queryApiPromiseByWorkerApi.get(apiKey);
+    if (cachedPromise) {
+      try {
+        return await cachedPromise;
+      } catch {
+        queryApiPromiseByWorkerApi.delete(apiKey);
+      }
+    }
+    const nextPromise = api.getQueryAPI();
+    queryApiPromiseByWorkerApi.set(apiKey, nextPromise);
+    try {
+      return await nextPromise;
+    } catch (error) {
+      queryApiPromiseByWorkerApi.delete(apiKey);
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn('[useWorkerQueryAPI] getQueryAPI failed', message);
+      return null;
+    }
+  }, [api]);
+
+  return {
+    api,
+    apiAvailable: Boolean(api),
+    getQueryAPIOrNull,
+  };
+}

--- a/packages/ui/batch/src/index.ts
+++ b/packages/ui/batch/src/index.ts
@@ -1,17 +1,19 @@
+export * from './components/BuildSessionLauncherPanel.js';
+export * from './contexts/TreeBuildSessionContexts.js';
+export * from './hooks/taskSyncHelpers.js';
+export type {
+  BatchProgressState as BuildProgressState,
+  UseBatchProgressStateOptions as UseBuildProgressStateOptions,
+} from './hooks/useBatchProgressState.js';
 export * from './hooks/useBatchProgressState.js';
 export { useBatchProgressState as useBuildProgressState } from './hooks/useBatchProgressState.js';
+export * from './hooks/useBuildSessionSnapshots.js';
+export * from './hooks/useWorkerQueryAPI.js';
+export * from './hooks/useBuildTaskProgress.js';
 export type {
-  UseBatchProgressStateOptions as UseBuildProgressStateOptions,
-  BatchProgressState as BuildProgressState,
-} from './hooks/useBatchProgressState.js';
+  PluginBatchProgressState as PluginBuildProgressState,
+  UsePluginBatchProgressOptions as UsePluginBuildProgressOptions,
+} from './hooks/usePluginBatchProgress.js';
 export * from './hooks/usePluginBatchProgress.js';
 export { usePluginBatchProgress as usePluginBuildProgress } from './hooks/usePluginBatchProgress.js';
-export type {
-  UsePluginBatchProgressOptions as UsePluginBuildProgressOptions,
-  PluginBatchProgressState as PluginBuildProgressState,
-} from './hooks/usePluginBatchProgress.js';
-export * from './hooks/useBuildTaskProgress.js';
-export * from './hooks/useBuildSessionSnapshots.js';
-export * from './components/BuildSessionLauncherPanel.js';
-export * from './hooks/taskSyncHelpers.js';
 export * from './utils/taskProgressSummary.js';


### PR DESCRIPTION
## Summary
- BuildSession 状態購読を単一経路へ寄せ、重複購読を削減
- `useBuildSessionSnapshots` の同一 `api + nodeType` 重複 subscribe を共有購読化で解消
- `getQueryAPI()` 取得を `useWorkerQueryAPI` に共通化

## Changes
- `BuildSessionLauncherPanel` は `BuildSessionRuntimeContext` を優先利用し、Context がある場合は追加購読しない
- `useBuildSessionSnapshots` に共有購読レジストリを導入
- `useWorkerQueryAPI` を追加し、worker 初期化・`getQueryAPI` 取得/キャッシュを共通化

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/ui-batch-progress --filter @hierarchidb/app` (exit 0, 実行済み)
- `pnpm -w turbo run build --filter @hierarchidb/ui-batch-progress --filter @hierarchidb/app` (exit 0, 実行済み)

Refs #213
