### PR TITLE
fix(shape): guard progress hooks against update-depth loops

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -39,6 +39,7 @@
 
 ### Doing
 
+- #219 / `codex/fix/shape/max-update-depth-warning-loop` / start: 2026-02-12 20:30 JST
 - #216 / `codex/fix/shape/stage-reset-resume-status-mismatch` / start: 2026-02-12 19:49 JST
 - #215 / `codex/refactor/shape-processing-config` / start: 2026-02-12 14:02 JST
 - #213 / `codex/refactor/build-session-subscription-unify` / start: 2026-02-12 12:49 JST
@@ -56,6 +57,9 @@
 
 ## 今日の運用ログ
 
+- update: 2026-02-12 20:30 JST Issue `fix/shape/max-update-depth-warning-loop` を起票し `https://github.com/kubohiroya/hierarchidb/issues/219` を作成。
+- update: 2026-02-12 20:30 JST Issue #219 を Project `hierarchidb` に追加し、Status を `In Progress`（Doing 相当）へ設定。
+- update: 2026-02-12 20:30 JST ブランチ `codex/fix/shape/max-update-depth-warning-loop` を作成して着手。
 - update: 2026-02-12 19:57 JST #216 原因は `plugins/shape-plugin/src/worker/shouldReuseTaskQueueOnStart.ts` が `session status` 未設定（`undefined/null`）でも task queue 再利用を許可していたこと。発生範囲は `plugins/shape-plugin/src/worker/api.ts` の `startBatchProcess`（`canReuseTaskQueue` 判定〜`seed-task-queue`）で、ステージreset後に stale task が再シードされ Fetch/VT 表示が不整合になっていた。
 - update: 2026-02-12 19:57 JST 修正として (1) `shouldReuseTaskQueueOnStart` を `running/paused/failed` のみ再利用可へ厳格化、(2) `startBatchProcess` の `seed-task-queue` 実行条件を `canReuseTaskQueue === true` に限定。適用範囲は `plugins/shape-plugin/src/worker/shouldReuseTaskQueueOnStart.ts` と `plugins/shape-plugin/src/worker/api.ts`、関連テスト `plugins/shape-plugin/src/ui/__tests__/hooks/unit/shouldReuseTaskQueueOnStart.unit.test.ts`。
 - update: 2026-02-12 19:57 JST 検証完了（`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/shouldReuseTaskQueueOnStart.unit.test.ts` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/app` すべて exit 0）。

--- a/packages/batch/src/progress/useBatchProgress.ts
+++ b/packages/batch/src/progress/useBatchProgress.ts
@@ -21,6 +21,7 @@ export function useBatchProgress(
   const [subscribed, setSubscribed] = useState(false);
   const unsubRef = useRef<Unsubscribe | null>(null);
   const subscribedRef = useRef(false);
+  const subscriptionTokenRef = useRef(0);
   const pendingRef = useRef<BuildUnifiedProgressInfo | null>(null);
   const flushFrameRef = useRef<number | null>(null);
   const adapterRef = useRef<Adapter>(adapter);
@@ -65,6 +66,8 @@ export function useBatchProgress(
   const subscribe = useCallback(() => {
     const currentAdapter = adapterRef.current;
     if (!currentAdapter || subscribedRef.current) return;
+    const subscriptionToken = subscriptionTokenRef.current + 1;
+    subscriptionTokenRef.current = subscriptionToken;
     const result: SubscribeResult = currentAdapter.subscribe((info: BuildUnifiedProgressInfo) => {
       pendingRef.current = info;
       if (flushFrameRef.current !== null) return;
@@ -74,27 +77,36 @@ export function useBatchProgress(
       unsubRef.current = result;
     } else if (result && typeof (result as Promise<unknown>).then === 'function') {
       void (result as Promise<Unsubscribe>).then((value) => {
-        if (typeof value === 'function') {
-          unsubRef.current = value;
+        if (typeof value !== 'function') {
+          return;
         }
+        if (subscriptionTokenRef.current !== subscriptionToken || !subscribedRef.current) {
+          value();
+          return;
+        }
+        unsubRef.current = value;
       });
     }
     subscribedRef.current = true;
-    setSubscribed(true);
+    setSubscribed((prev) => (prev ? prev : true));
   }, [update]);
 
-  const unsubscribe = useCallback(() => {
-    if (!subscribedRef.current) return;
-    unsubRef.current?.();
+  const unsubscribe = useCallback((notify = true) => {
+    if (!subscribedRef.current && !unsubRef.current) return;
+    subscriptionTokenRef.current += 1;
+    const unsubscribeCurrent = unsubRef.current;
     unsubRef.current = null;
+    unsubscribeCurrent?.();
     subscribedRef.current = false;
-    setSubscribed(false);
+    if (notify) {
+      setSubscribed((prev) => (prev ? false : prev));
+    }
   }, []);
 
   useEffect(() => {
     if (adapter && autoSubscribe) subscribe();
     return () => {
-      unsubscribe();
+      unsubscribe(false);
     };
   }, [adapter, autoSubscribe, subscribe, unsubscribe]);
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
@@ -518,9 +518,11 @@ export const useShapeBuildTaskSync = ({ sessionNodeId, setTasks, setIsLoading, s
   const pendingDirtyRef = useRef(false);
   const flushScheduledRef = useRef(false);
   const flushFrameRef = useRef<number | null>(null);
+  const isMountedRef = useRef(true);
 
   useEffect(() => {
     return () => {
+      isMountedRef.current = false;
       pendingTasksRef.current = null;
       pendingDirtyRef.current = false;
       vtParentInputDebugLogKeysRef.current.clear();
@@ -544,10 +546,21 @@ export const useShapeBuildTaskSync = ({ sessionNodeId, setTasks, setIsLoading, s
       return;
     }
     committedTasksRef.current = next;
+    if (!isMountedRef.current) {
+      return;
+    }
     setTasks(next);
   }, [setTasks]);
 
   const scheduleFlush = useCallback((next: ShapeBuildTaskSummary[], dirty = true) => {
+    if (!isMountedRef.current) {
+      return;
+    }
+    const pendingCurrent = pendingTasksRef.current;
+    if (pendingCurrent && areTaskListsEquivalentForView(pendingCurrent, next)) {
+      pendingDirtyRef.current = pendingDirtyRef.current || dirty;
+      return;
+    }
     pendingTasksRef.current = next;
     pendingDirtyRef.current = pendingDirtyRef.current || dirty;
     if (flushScheduledRef.current) return;


### PR DESCRIPTION
## Summary
- prevent stale async subscribe/unsubscribe completions from causing repeated subscription state updates in `useBatchProgress`
- make subscription state updates idempotent and avoid cleanup-time state toggles
- guard `useShapeBuildTaskSync` flush/set state paths after unmount and skip redundant flush scheduling for equivalent pending task lists

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/batch --filter @hierarchidb/shape-plugin --filter @hierarchidb/app`
- `pnpm -w turbo run lint --filter @hierarchidb/batch --filter @hierarchidb/shape-plugin --filter @hierarchidb/app` (no lint tasks executed in scope)

Refs #219
