### PR TITLE
fix(shape): prevent stalled start when metadata cache is stale

### DIFF
--- a/plugins/shape-plugin/src/services/batch/ShapeBuildAPIClient.ts
+++ b/plugins/shape-plugin/src/services/batch/ShapeBuildAPIClient.ts
@@ -26,9 +26,7 @@ import type {
   ShapeVTMetadata,
 } from '@hierarchidb/shape-api';
 import {
-  bufferDeserializer,
-  bufferSerializer,
-  createShapeChunkStore,
+  deleteRawDataDataSourceBuffersForNode,
   storeRawDataDataSourceBufferForNode,
 } from '../utils/chunkStore.js';
 import { resolveCountryContinentName, resolveCountryName } from '../utils/iso3166.js';
@@ -820,8 +818,7 @@ export class EphemeralShapeApiImpl {
     await ephemeralShapeDB.clearStage(nodeId, stage);
     if (stage === 'fetch') {
       try {
-        const store = createShapeChunkStore(bufferSerializer, bufferDeserializer);
-        await store.deleteAllForNode(nodeId);
+        await deleteRawDataDataSourceBuffersForNode(nodeId);
       } catch (error) {
         console.warn('[shapeBuildAPI] failed to clear download chunk-store entries', error);
       }

--- a/plugins/shape-plugin/src/services/metadata/metadataSources.ts
+++ b/plugins/shape-plugin/src/services/metadata/metadataSources.ts
@@ -89,6 +89,12 @@ type MetadataFetchOptions = {
   force?: boolean;
 };
 
+const METADATA_FETCH_TIMEOUT_MS = 45_000;
+
+const isAbortError = (error: unknown): boolean => (
+  error instanceof Error && error.name === 'AbortError'
+);
+
 const getCachedOrFetchForNode = async <T>(params: {
   store: ReturnType<typeof createShapeChunkStoreWithNetworkPort<T>>;
   nodeId: NodeId;
@@ -96,8 +102,17 @@ const getCachedOrFetchForNode = async <T>(params: {
   cacheKey: string;
   accept: string;
   force?: boolean;
+  timeoutMs?: number;
 }): Promise<{ value: T }> => {
-  const { store, nodeId, url, cacheKey, accept, force } = params;
+  const {
+    store,
+    nodeId,
+    url,
+    cacheKey,
+    accept,
+    force,
+    timeoutMs = METADATA_FETCH_TIMEOUT_MS,
+  } = params;
   if (!force) {
     const hasRelation = await store.hasRelationForNode(nodeId, cacheKey);
     if (hasRelation) {
@@ -111,7 +126,32 @@ const getCachedOrFetchForNode = async <T>(params: {
       }
     }
   }
-  return store.getOrFetchForNode(nodeId, url, { accept, cacheKey });
+  const canAbort = typeof AbortController === 'function';
+  const controller = canAbort ? new AbortController() : null;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  let didTimeout = false;
+  if (controller && timeoutMs > 0) {
+    timeoutHandle = setTimeout(() => {
+      didTimeout = true;
+      controller.abort();
+    }, timeoutMs);
+  }
+  try {
+    return await store.getOrFetchForNode(nodeId, url, {
+      accept,
+      cacheKey,
+      signal: controller?.signal,
+    });
+  } catch (error) {
+    if (didTimeout && isAbortError(error)) {
+      throw new Error(`Metadata fetch timed out after ${timeoutMs}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
 };
 
 export async function fetchGeoBoundariesMetadata(

--- a/plugins/shape-plugin/src/services/vt/shapeFetchStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapeFetchStage.ts
@@ -1070,6 +1070,21 @@ const createFetchHandler = (params: {
 export const runShapeFetchStage = async (params: ShapeFetchStageParams): Promise<void> => {
   const abortSignal = params.abortController?.signal;
   const resumeExistingTasks = Boolean(params.resumeExistingTasks);
+  const countSelectedAdminPairs = (selectedArrayByCountries: SelectedArrayByCountries | undefined): number => {
+    if (!selectedArrayByCountries || typeof selectedArrayByCountries !== 'object' || Array.isArray(selectedArrayByCountries)) {
+      return 0;
+    }
+    let selectedAdminPairCount = 0;
+    Object.values(selectedArrayByCountries).forEach((row) => {
+      if (!Array.isArray(row)) return;
+      row.forEach((selected) => {
+        if (selected === true) {
+          selectedAdminPairCount += 1;
+        }
+      });
+    });
+    return selectedAdminPairCount;
+  };
   if (!resumeExistingTasks) {
     const staleTasks = await listTasksByStage(params.taskQueue, params.nodeId, 'fetch');
     await deleteTasksByIds(params.taskQueue, staleTasks.map((task) => task.taskId));
@@ -1077,16 +1092,34 @@ export const runShapeFetchStage = async (params: ShapeFetchStageParams): Promise
   const existingTasks = resumeExistingTasks
     ? await listTasksByStage(params.taskQueue, params.nodeId, 'fetch')
     : [];
-  const metadata = params.metadata ?? await metadataLoader.loadMetadata(params.dataSource, params.nodeId);
-  const payloads = resolveFetchPayloads(params, metadata);
+  let metadataForPayloads = params.metadata ?? await metadataLoader.loadMetadata(params.dataSource, params.nodeId);
+  let payloads = resolveFetchPayloads(params, metadataForPayloads);
+  const selectedAdminPairCount = countSelectedAdminPairs(params.selectedArrayByCountries);
+  if (
+    payloads.length === 0
+    && selectedAdminPairCount > 0
+    && (!params.downloadTaskPayloads || params.downloadTaskPayloads.length === 0)
+    && !params.metadata
+  ) {
+    metadataLoader.clearCache(params.dataSource);
+    const refreshedMetadata = await metadataLoader.loadMetadata(params.dataSource, params.nodeId, { force: true });
+    metadataForPayloads = refreshedMetadata;
+    payloads = resolveFetchPayloads(params, metadataForPayloads);
+  }
   const reuseExistingTasks = resumeExistingTasks && existingTasks.length > 0 && payloads.length === 0;
   if (payloads.length === 0 && !reuseExistingTasks) {
+    if (selectedAdminPairCount > 0) {
+      throw new Error(
+        `[shape-fetch] No fetch tasks generated for ${selectedAdminPairCount}`
+        + ' selected entries. Metadata may be stale or incompatible with the selection.',
+      );
+    }
     setFetchPlannedTotal(params.nodeId, 0);
     return;
   }
   const configSignature = buildStableSignature(params.buildConfig.fetchConfig ?? null);
   if (!reuseExistingTasks) {
-    const tasks = buildFetchTasks(params.nodeId, payloads, metadata, configSignature);
+    const tasks = buildFetchTasks(params.nodeId, payloads, metadataForPayloads, configSignature);
     setFetchPlannedTotal(params.nodeId, tasks.length);
     await reconcileFetchTasks(params, existingTasks, tasks, resumeExistingTasks);
   } else {

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
@@ -14,6 +14,19 @@ let subscriber: ((event: BuildTaskUpdateEvent) => void) | null = null;
 let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null;
 let consoleDebugSpy: ReturnType<typeof vi.spyOn> | null = null;
 
+const setTaskSyncDebugConfig = (
+  config: Partial<Record<'taskUpdate100' | 'runningResidue' | 'all', boolean>> | undefined,
+): void => {
+  const scope = globalThis as typeof globalThis & {
+    __HDB_SHAPE_BUILD_TASK_SYNC_DEBUG__?: Partial<Record<'taskUpdate100' | 'runningResidue' | 'all', boolean>>;
+  };
+  if (!config) {
+    delete scope.__HDB_SHAPE_BUILD_TASK_SYNC_DEBUG__;
+    return;
+  }
+  scope.__HDB_SHAPE_BUILD_TASK_SYNC_DEBUG__ = config;
+};
+
 vi.mock('@hierarchidb/ui-worker-client', () => ({
   getWorkerBridge: () => ({
     initialize: initializeMock,
@@ -34,6 +47,7 @@ describe('useShapeBuildTasks', () => {
     getBuildTasksMock.mockReset();
     subscriber = null;
     initializeMock.mockResolvedValue(undefined);
+    setTaskSyncDebugConfig(undefined);
     consoleLogSpy?.mockRestore();
     consoleDebugSpy?.mockRestore();
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -110,7 +124,8 @@ describe('useShapeBuildTasks', () => {
       expect(result.current.tasks[0]?.status).toBe('completed');
     });
 
-    expect(getBuildTasksMock).not.toHaveBeenCalled();
+    expect(getBuildTasksMock).toHaveBeenCalledTimes(1);
+    expect(getBuildTasksMock).toHaveBeenCalledWith('shape', 'node-1');
   });
 
   it('keeps completed 100% when a running 100% update arrives later', async () => {
@@ -410,6 +425,7 @@ describe('useShapeBuildTasks', () => {
   });
 
   it('logs TaskUpdate100 with parsed scope when update progress reaches 100', async () => {
+    setTaskSyncDebugConfig({ taskUpdate100: true });
     renderHook(() => useShapeBuildTasks('node-4'));
 
     await waitFor(() => {
@@ -462,6 +478,34 @@ describe('useShapeBuildTasks', () => {
 
     await waitFor(() => {
       expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringContaining('[TaskUpdate100]'));
+    });
+  });
+
+  it('ignores task events when nodeId does not match the active subscription', async () => {
+    const { result } = renderHook(() => useShapeBuildTasks('node-mismatch'));
+
+    await waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalled();
+    });
+
+    act(() => {
+      subscriber?.({
+        type: 'update',
+        nodeId: 'node-other',
+        task: {
+          taskId: 'node-other:fetch:JP:0',
+          stage: 'fetch',
+          status: 'running',
+          progress: 50,
+          message: 'running',
+          index: 1,
+          sequence: 1,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(0);
     });
   });
 
@@ -653,4 +697,58 @@ describe('useShapeBuildTasks', () => {
       );
     });
   });
+
+  it('recovers task snapshot when initial subscription events are missing', async () => {
+    vi.useFakeTimers();
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      return window.setTimeout(() => cb(performance.now()), 0);
+    });
+    const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number) => {
+      window.clearTimeout(id);
+    });
+    try {
+      getBuildTasksMock.mockResolvedValue([
+        {
+          taskId: 'node-reconcile:fetch:JP:0',
+          stage: 'fetch',
+          status: 'running',
+          progress: 20,
+          message: 'Running',
+          index: 1,
+          sequence: 1,
+        },
+      ]);
+
+      const { result } = renderHook(() => useShapeBuildTasks('node-reconcile'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(subscribeMock).toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(getBuildTasksMock).toHaveBeenCalled();
+      expect(result.current.tasks).toHaveLength(1);
+      expect(result.current.tasks[0]?.status).toBe('running');
+      expect(result.current.isLoading).toBe(false);
+    } finally {
+      rafSpy.mockRestore();
+      cancelSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  }, 10000);
 });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeCountrySelectionStep.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeCountrySelectionStep.unit.test.tsx
@@ -1,0 +1,150 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { NodeId } from '@hierarchidb/core-types';
+import type { CountryMetadata } from '../../../../../common/types/index.js';
+
+const enqueueSnackbarMock = vi.fn();
+const onStepNavigateMock = vi.fn();
+const onChangeMock = vi.fn();
+
+const mockWorkerApi = {
+  setUiStorageBridge: vi.fn().mockResolvedValue(undefined),
+  loadAvailability: vi.fn(),
+  loadMetadata: vi.fn(),
+  clearMetadataCache: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar: enqueueSnackbarMock }),
+}));
+
+vi.mock('@hierarchidb/ui-country-select', () => ({
+  useIsoCountries: () => ({
+    status: 'ready',
+    countries: [{ code: 'JP', continent: 'AS' }],
+  }),
+}));
+
+vi.mock('@hierarchidb/ui-dialog', () => ({
+  useDialogContext: () => ({
+    onStepNavigate: onStepNavigateMock,
+  }),
+}));
+
+vi.mock('@hierarchidb/ui-worker-client', () => ({
+  getWorkerBridge: () => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getTreeNodeUpdaterAPI: vi.fn().mockResolvedValue({
+      getTreeNode: vi.fn().mockResolvedValue({ draftData: {} }),
+      updateTreeNode: vi.fn().mockResolvedValue(undefined),
+    }),
+  }),
+}));
+
+vi.mock('comlink', () => ({
+  wrap: vi.fn(() => mockWorkerApi),
+  proxy: (value: unknown) => value,
+}));
+
+type DummyWorker = {
+  terminate: () => void;
+};
+
+const createDummyWorker = (): DummyWorker => ({
+  terminate: vi.fn(),
+});
+
+const baseMetadata: CountryMetadata[] = [{
+  countryCode: 'JP',
+  countryName: 'Japan',
+  continent: 'Asia',
+  availableAdminLevels: [0],
+  iso2: 'JP',
+  iso3: 'JPN',
+  dataQuality: 'high',
+}];
+
+const baseAvailability = {
+  dataSource: 'geoboundaries' as const,
+  entries: [{ countryCode: 'JPN', adminLevels: [0] }],
+  maxAdminLevel: 2,
+  source: 'metadata' as const,
+  fetchedAt: Date.now(),
+};
+
+const buildArgs = (nodeId: NodeId) => ({
+  nodeId,
+  data: {
+    buildConfig: { dataSourceName: 'geoboundaries' as const },
+    selectedArrayByCountries: {},
+  },
+  onChange: onChangeMock,
+});
+
+describe('useShapeCountrySelectionStep cache behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockWorkerApi.setUiStorageBridge.mockResolvedValue(undefined);
+    mockWorkerApi.loadMetadata.mockResolvedValue(baseMetadata);
+    mockWorkerApi.loadAvailability.mockResolvedValue(baseAvailability);
+    (globalThis as { Worker?: unknown }).Worker = vi.fn(() => createDummyWorker()) as unknown as typeof Worker;
+  });
+
+  it('loads metadata/availability only on first open for same node/dataSource', async () => {
+    const { useShapeCountrySelectionStep } = await import('../../../components/country-selection/useShapeCountrySelectionStep.ts');
+    const nodeId = 'node-country-1' as NodeId;
+
+    const first = renderHook(() => useShapeCountrySelectionStep(buildArgs(nodeId)));
+    await waitFor(() => {
+      expect(first.result.current.loading).toBe(false);
+    });
+    first.unmount();
+
+    const second = renderHook(() => useShapeCountrySelectionStep(buildArgs(nodeId)));
+    await waitFor(() => {
+      expect(second.result.current.loading).toBe(false);
+    });
+
+    expect(mockWorkerApi.loadMetadata).toHaveBeenCalledTimes(1);
+    expect(mockWorkerApi.loadAvailability).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches metadata/availability when reloadAll is explicitly requested', async () => {
+    const { useShapeCountrySelectionStep } = await import('../../../components/country-selection/useShapeCountrySelectionStep.ts');
+    const nodeId = 'node-country-2' as NodeId;
+    const { result } = renderHook(() => useShapeCountrySelectionStep(buildArgs(nodeId)));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.reloadAll();
+    });
+
+    expect(mockWorkerApi.loadMetadata).toHaveBeenCalledTimes(2);
+    expect(mockWorkerApi.loadMetadata).toHaveBeenLastCalledWith('geoboundaries', nodeId, { force: true });
+    expect(mockWorkerApi.loadAvailability).toHaveBeenCalledTimes(2);
+    expect(mockWorkerApi.loadAvailability).toHaveBeenLastCalledWith('geoboundaries', nodeId);
+  });
+
+  it('does not reuse cache across different nodes', async () => {
+    const { useShapeCountrySelectionStep } = await import('../../../components/country-selection/useShapeCountrySelectionStep.ts');
+    const firstNodeId = 'node-country-3' as NodeId;
+    const secondNodeId = 'node-country-4' as NodeId;
+
+    const first = renderHook(() => useShapeCountrySelectionStep(buildArgs(firstNodeId)));
+    await waitFor(() => {
+      expect(first.result.current.loading).toBe(false);
+    });
+    first.unmount();
+
+    const second = renderHook(() => useShapeCountrySelectionStep(buildArgs(secondNodeId)));
+    await waitFor(() => {
+      expect(second.result.current.loading).toBe(false);
+    });
+
+    expect(mockWorkerApi.loadMetadata).toHaveBeenCalledTimes(2);
+    expect(mockWorkerApi.loadAvailability).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
@@ -132,12 +132,34 @@ const resolveTaskScope = (task: ShapeBuildTaskSummary): { iso2: string; adminLev
   };
 };
 
+const isDev = import.meta.env.DEV;
+type TaskSyncDebugChannel = 'taskUpdate100' | 'runningResidue';
+type TaskSyncDebugConfig = Partial<Record<TaskSyncDebugChannel | 'all', boolean>>;
+
+const readTaskSyncDebugConfig = (): TaskSyncDebugConfig | null => {
+  const scope = globalThis as typeof globalThis & {
+    __HDB_SHAPE_BUILD_TASK_SYNC_DEBUG__?: unknown;
+  };
+  const raw = scope.__HDB_SHAPE_BUILD_TASK_SYNC_DEBUG__;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  return raw as TaskSyncDebugConfig;
+};
+
+const isTaskSyncDebugEnabled = (channel: TaskSyncDebugChannel): boolean => {
+  if (!isDev) return false;
+  const config = readTaskSyncDebugConfig();
+  if (!config) return false;
+  return config.all === true || config[channel] === true;
+};
+
 const TASK_UPDATE100_LOG_LIMIT = 300;
 let taskUpdate100LogCount = 0;
 let taskUpdate100LogLimitNotified = false;
 
 const logTaskUpdate100 = (task: ShapeBuildTaskSummary): void => {
-  if (!import.meta.env.DEV) return;
+  if (!isTaskSyncDebugEnabled('taskUpdate100')) return;
   if (resolveProgressValue(task.progress) < 100) return;
   if (taskUpdate100LogCount >= TASK_UPDATE100_LOG_LIMIT) {
     if (!taskUpdate100LogLimitNotified) {
@@ -153,11 +175,17 @@ const logTaskUpdate100 = (task: ShapeBuildTaskSummary): void => {
   console.log(`[TaskUpdate100] ${scope.iso2}, ${scope.adminLevel}, ${message}, ${status}`);
 };
 
-const isDev = import.meta.env.DEV;
 const RUNNING_RESIDUE_LOG_PREFIX = '[ShapeRunningResidue]';
 const RUNNING_RESIDUE_LOG_LIMIT = 600;
 let runningResidueLogCount = 0;
 let runningResidueLogLimitNotified = false;
+
+const resetTaskSyncDebugLogCounters = (): void => {
+  taskUpdate100LogCount = 0;
+  taskUpdate100LogLimitNotified = false;
+  runningResidueLogCount = 0;
+  runningResidueLogLimitNotified = false;
+};
 
 type RunningResidueLogPayload = {
   nodeId: string | null;
@@ -188,7 +216,7 @@ const formatLogValue = (value: unknown): string => {
 };
 
 const emitRunningResidueLog = (keyword: string, payload: RunningResidueLogPayload): void => {
-  if (!isDev) return;
+  if (!isTaskSyncDebugEnabled('runningResidue')) return;
   if (runningResidueLogCount >= RUNNING_RESIDUE_LOG_LIMIT) {
     if (!runningResidueLogLimitNotified) {
       runningResidueLogLimitNotified = true;
@@ -535,6 +563,7 @@ export const useShapeBuildTaskSync = ({ sessionNodeId, setTasks, setIsLoading, s
 
   useEffect(() => {
     vtParentInputDebugLogKeysRef.current.clear();
+    resetTaskSyncDebugLogCounters();
   }, [sessionNodeId]);
 
   const flushTasks = useCallback((next: ShapeBuildTaskSummary[], dirty: boolean) => {
@@ -744,6 +773,13 @@ export const useShapeBuildTaskSync = ({ sessionNodeId, setTasks, setIsLoading, s
   }, [scheduleFlush, sessionNodeId, setError, setIsLoading]);
 
   const syncTasksRef = useCallback((tasks: ShapeBuildTaskSummary[]) => {
+    pendingTasksRef.current = null;
+    pendingDirtyRef.current = false;
+    flushScheduledRef.current = false;
+    if (flushFrameRef.current !== null) {
+      window.cancelAnimationFrame(flushFrameRef.current);
+      flushFrameRef.current = null;
+    }
     tasksRef.current = tasks;
     committedTasksRef.current = tasks;
     tasksMapRef.current = new Map(tasks.map((task) => [task.taskId, task]));

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks.ts
@@ -27,7 +27,28 @@ export interface UseShapeBuildTasksState {
 const SHAPE_NODE_TYPE = 'shape' as NodeType;
 const isDev = import.meta.env.DEV;
 const RUNNING_RESIDUE_LOG_PREFIX = '[ShapeRunningResidue]';
-const TASK_SNAPSHOT_RECONCILE_INTERVAL_MS = 5000;
+const TASK_SNAPSHOT_RECONCILE_INTERVAL_MS = 1000;
+const EMPTY_TASK_RECONCILE_WINDOW_MS = 60_000;
+
+type TaskSyncDebugConfig = Partial<Record<'runningResidue' | 'all', boolean>>;
+
+const readTaskSyncDebugConfig = (): TaskSyncDebugConfig | null => {
+  const scope = globalThis as typeof globalThis & {
+    __HDB_SHAPE_BUILD_TASK_SYNC_DEBUG__?: unknown;
+  };
+  const raw = scope.__HDB_SHAPE_BUILD_TASK_SYNC_DEBUG__;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  return raw as TaskSyncDebugConfig;
+};
+
+const isRunningResidueDebugEnabled = (): boolean => {
+  if (!isDev) return false;
+  const config = readTaskSyncDebugConfig();
+  if (!config) return false;
+  return config.all === true || config.runningResidue === true;
+};
 
 const isTaskInFlight = (task: ShapeBuildTaskSummary): boolean => (
   task.status === 'running' || task.status === 'queued'
@@ -40,7 +61,7 @@ const logRunningResidueDrop = (payload: {
   reason?: string;
   taskId?: string | null;
 }): void => {
-  if (!isDev) return;
+  if (!isRunningResidueDebugEnabled()) return;
   if (payload.reason === 'subscription_cancelled') {
     // Expected during unmount/reload/reset cleanup.
     return;
@@ -151,6 +172,16 @@ export function useShapeBuildTasks(
     let cancelled = false;
 
     const handleEvent = (event: BuildTaskUpdateEvent<RawTaskSummary>) => {
+      if (String(event.nodeId) !== String(nodeId)) {
+        logRunningResidueDrop({
+          nodeId: nodeId ? String(nodeId) : null,
+          source: 'subscription',
+          eventType: event.type,
+          taskId: event.type === 'update' ? event.task.taskId : event.type === 'delete' ? event.taskId : null,
+          reason: 'node_id_mismatch',
+        });
+        return;
+      }
       if (cancelled || subscriptionIdRef.current !== subscriptionId) {
         logRunningResidueDrop({
           nodeId: nodeId ? String(nodeId) : null,
@@ -174,33 +205,14 @@ export function useShapeBuildTasks(
       }
     };
 
-    const start = async () => {
-      try {
-        await bridgeRef.current.initialize();
-        const unsubscribe = await bridgeRef.current.subscribeBuildTasks(
-          SHAPE_NODE_TYPE,
-          nodeId,
-          handleEvent,
-        );
-        if (cancelled) {
-          unsubscribe();
-          return;
-        }
-        subscriptionRef.current = unsubscribe;
-      } catch (err) {
-        if (cancelled) return;
-        const errObj = err instanceof Error ? err : new Error('Failed to subscribe build tasks');
-        setError(errObj);
-        setIsLoading(false);
-      }
-    };
-
-    void start();
+    const subscribedAt = Date.now();
 
     const reconcileSnapshot = async () => {
       if (cancelled || subscriptionIdRef.current !== subscriptionId) return;
-      if (isLoadingRef.current) return;
-      if (!tasksRef.current.some((task) => isTaskInFlight(task))) return;
+      const hasInFlightTasks = tasksRef.current.some((task) => isTaskInFlight(task));
+      const hasNoTasks = tasksRef.current.length === 0;
+      const withinEmptyTaskWindow = Date.now() - subscribedAt <= EMPTY_TASK_RECONCILE_WINDOW_MS;
+      if (!hasInFlightTasks && !(hasNoTasks && withinEmptyTaskWindow)) return;
       if (reconcileInFlightRef.current) return;
       reconcileInFlightRef.current = true;
       try {
@@ -217,6 +229,30 @@ export function useShapeBuildTasks(
         reconcileInFlightRef.current = false;
       }
     };
+
+    const start = async () => {
+      try {
+        await bridgeRef.current.initialize();
+        const unsubscribe = await bridgeRef.current.subscribeBuildTasks(
+          SHAPE_NODE_TYPE,
+          nodeId,
+          handleEvent,
+        );
+        if (cancelled) {
+          unsubscribe();
+          return;
+        }
+        subscriptionRef.current = unsubscribe;
+        void reconcileSnapshot();
+      } catch (err) {
+        if (cancelled) return;
+        const errObj = err instanceof Error ? err : new Error('Failed to subscribe build tasks');
+        setError(errObj);
+        setIsLoading(false);
+      }
+    };
+
+    void start();
     const reconcileTimer = window.setInterval(() => {
       void reconcileSnapshot();
     }, TASK_SNAPSHOT_RECONCILE_INTERVAL_MS);

--- a/plugins/shape-plugin/src/ui/components/country-selection/useShapeCountrySelectionStep.ts
+++ b/plugins/shape-plugin/src/ui/components/country-selection/useShapeCountrySelectionStep.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../common/utils/estimates.js';
 import { isDataSourceName, SHAPE_DATA_SOURCE_BY_NAME } from '../../../common/types/index.js';
 import type { CountryAvailabilityWorkerAPI, SerializedCountryAvailability } from '../../workers/countryAvailability.types.js';
-import { wrap, releaseProxy, proxy } from 'comlink';
+import { wrap, proxy } from 'comlink';
 import type { NodeId } from '@hierarchidb/core-types';
 import { useDialogContext } from '@hierarchidb/ui-dialog';
 import { getWorkerBridge } from '@hierarchidb/ui-worker-client';
@@ -26,6 +26,51 @@ import { sanitizeShapeDraftData } from '../../utils/sanitizeShapeDraftData.ts';
 const createAvailabilityWorker = () => new Worker(
   new URL('../../workers/countryAvailability.worker.ts', import.meta.url),
   { type: 'module' },
+);
+
+type AvailabilityWorkerHandle = {
+  worker: Worker;
+  api: ReturnType<typeof wrap<CountryAvailabilityWorkerAPI>>;
+  bridgeReady: Promise<void>;
+};
+
+let sharedAvailabilityWorkerHandle: AvailabilityWorkerHandle | null = null;
+
+const getOrCreateAvailabilityWorkerHandle = (): AvailabilityWorkerHandle => {
+  if (sharedAvailabilityWorkerHandle) return sharedAvailabilityWorkerHandle;
+  const worker = createAvailabilityWorker();
+  const api = wrap<CountryAvailabilityWorkerAPI>(worker);
+  const bridgeReady = api.setUiStorageBridge(
+    proxy({
+      getItem: async (key: string) => localStorage.getItem(key),
+      setItem: async (key: string, value: string) => {
+        localStorage.setItem(key, value);
+      },
+      removeItem: async (key: string) => {
+        localStorage.removeItem(key);
+      },
+    }),
+  ).catch((error) => {
+    console.warn('[ShapeCountrySelectionStep] failed to register storage bridge', error);
+  });
+  sharedAvailabilityWorkerHandle = {
+    worker,
+    api,
+    bridgeReady,
+  };
+  return sharedAvailabilityWorkerHandle;
+};
+
+type CountrySelectionBootstrapCacheEntry = {
+  countries: CountryMetadata[];
+  availability: SerializedCountryAvailability | null;
+  fetchedAt: number;
+};
+
+const countrySelectionBootstrapCache = new Map<string, CountrySelectionBootstrapCacheEntry>();
+
+const buildBootstrapCacheKey = (nodeId: NodeId, dataSourceKey: string): string => (
+  `${String(nodeId)}:${dataSourceKey}`
 );
 
 const CONTINENT_CODES: ContinentCode[] = ['AF', 'AS', 'EU', 'NA', 'SA', 'OC', 'AN', 'XX'];
@@ -184,42 +229,29 @@ export const useShapeCountrySelectionStep = ({ data, onChange, nodeId: _nodeId }
   const availabilityBridgeReadyRef = useRef<Promise<void> | null>(null);
   const availabilityRequestIdRef = useRef(0);
 
+  const ensureAvailabilityWorker = useCallback(() => {
+    if (availabilityWorkerRef.current && availabilityBridgeReadyRef.current) {
+      return availabilityWorkerRef.current;
+    }
+    const handle = getOrCreateAvailabilityWorkerHandle();
+    availabilityWorkerRef.current = { worker: handle.worker, api: handle.api };
+    availabilityBridgeReadyRef.current = handle.bridgeReady;
+    return availabilityWorkerRef.current;
+  }, []);
+
   useEffect(() => {
-    const worker = createAvailabilityWorker();
-    const api = wrap<CountryAvailabilityWorkerAPI>(worker);
-    availabilityBridgeReadyRef.current = api.setUiStorageBridge(
-      proxy({
-        getItem: async (key: string) => localStorage.getItem(key),
-        setItem: async (key: string, value: string) => {
-          localStorage.setItem(key, value);
-        },
-        removeItem: async (key: string) => {
-          localStorage.removeItem(key);
-        },
-      }),
-    ).catch((error) => {
-      console.warn('[ShapeCountrySelectionStep] failed to register storage bridge', error);
-    });
-    availabilityWorkerRef.current = { worker, api };
     return () => {
       availabilityWorkerRef.current = null;
       availabilityBridgeReadyRef.current = null;
-      try {
-        api[releaseProxy]?.();
-      } catch (releaseError) {
-        console.warn('[ShapeCountrySelectionStep] failed to release availability worker', releaseError);
-      }
-      worker.terminate();
     };
   }, []);
 
-  const loadAvailability = useCallback(async () => {
+  const loadAvailability = useCallback(async (): Promise<SerializedCountryAvailability | null> => {
     if (!dataSourceKey) {
       setAvailability(null);
-      return;
+      return null;
     }
-    const ref = availabilityWorkerRef.current;
-    if (!ref) return;
+    const ref = ensureAvailabilityWorker();
     const requestId = availabilityRequestIdRef.current + 1;
     availabilityRequestIdRef.current = requestId;
 
@@ -232,29 +264,30 @@ export const useShapeCountrySelectionStep = ({ data, onChange, nodeId: _nodeId }
       }
       await bridgeReady;
       const result = await ref.api.loadAvailability(dataSourceKey, nodeId);
-      if (requestId !== availabilityRequestIdRef.current) return;
+      if (requestId !== availabilityRequestIdRef.current) return null;
       setAvailability(result);
+      return result;
     } catch (e) {
-      if (requestId !== availabilityRequestIdRef.current) return;
+      if (requestId !== availabilityRequestIdRef.current) return null;
       const err = e instanceof Error ? e : new Error(String(e));
       setAvailabilityError(err);
       setAvailability(null);
+      return null;
     } finally {
       if (requestId === availabilityRequestIdRef.current) {
         setAvailabilityLoading(false);
       }
     }
-  }, [dataSourceKey, nodeId]);
+  }, [dataSourceKey, ensureAvailabilityWorker, nodeId]);
 
-  const loadMetadata = useCallback(async (options?: { force?: boolean }) => {
+  const loadMetadata = useCallback(async (options?: { force?: boolean }): Promise<CountryMetadata[] | null> => {
     if (!dataSourceKey) {
       setCountries([]);
       setMetadataError(null);
       setMetadataLoading(false);
-      return;
+      return null;
     }
-    const ref = availabilityWorkerRef.current;
-    if (!ref) return;
+    const ref = ensureAvailabilityWorker();
     const requestId = metadataRequestIdRef.current + 1;
     metadataRequestIdRef.current = requestId;
 
@@ -267,27 +300,56 @@ export const useShapeCountrySelectionStep = ({ data, onChange, nodeId: _nodeId }
       }
       await bridgeReady;
       const result = await ref.api.loadMetadata(dataSourceKey, nodeId, options);
-      if (requestId !== metadataRequestIdRef.current) return;
+      if (requestId !== metadataRequestIdRef.current) return null;
       setCountries(Array.isArray(result) ? result : []);
       if (!result?.length) {
         throw new Error(`No country metadata returned for data source: ${dataSourceKey}`);
       }
+      return Array.isArray(result) ? result : [];
     } catch (e) {
-      if (requestId !== metadataRequestIdRef.current) return;
+      if (requestId !== metadataRequestIdRef.current) return null;
       const err = e instanceof Error ? e : new Error(String(e));
       setMetadataError(err);
       setCountries([]);
+      return null;
     } finally {
       if (requestId === metadataRequestIdRef.current) {
         setMetadataLoading(false);
       }
     }
-  }, [dataSourceKey, nodeId]);
+  }, [dataSourceKey, ensureAvailabilityWorker, nodeId]);
 
   const loadAll = useCallback(async (options?: { force?: boolean }) => {
-    await loadMetadata(options);
-    await loadAvailability();
-  }, [loadAvailability, loadMetadata]);
+    if (!dataSourceKey) {
+      await loadMetadata(options);
+      await loadAvailability();
+      return;
+    }
+    const cacheKey = buildBootstrapCacheKey(nodeId, dataSourceKey);
+    if (!options?.force) {
+      const cached = countrySelectionBootstrapCache.get(cacheKey);
+      if (cached) {
+        setCountries(cached.countries);
+        setMetadataError(null);
+        setMetadataLoading(false);
+        setAvailability(cached.availability);
+        setAvailabilityError(null);
+        setAvailabilityLoading(false);
+        return;
+      }
+    } else {
+      countrySelectionBootstrapCache.delete(cacheKey);
+    }
+    const metadata = await loadMetadata(options);
+    const availabilityResult = await loadAvailability();
+    if (metadata && metadata.length > 0) {
+      countrySelectionBootstrapCache.set(cacheKey, {
+        countries: metadata,
+        availability: availabilityResult,
+        fetchedAt: Date.now(),
+      });
+    }
+  }, [dataSourceKey, loadAvailability, loadMetadata, nodeId]);
 
   useEffect(() => {
     void loadAll();
@@ -653,8 +715,9 @@ export const useShapeCountrySelectionStep = ({ data, onChange, nodeId: _nodeId }
 
   const reloadAll = useCallback(async () => {
     if (!dataSourceKey) return;
+    countrySelectionBootstrapCache.delete(buildBootstrapCacheKey(nodeId, dataSourceKey));
     await loadAll({ force: true });
-  }, [dataSourceKey, loadAll]);
+  }, [dataSourceKey, loadAll, nodeId]);
 
   const combinedLoading = metadataLoading || (availabilityLoading && !availability);
 

--- a/plugins/shape-plugin/src/worker/api.ts
+++ b/plugins/shape-plugin/src/worker/api.ts
@@ -43,9 +43,7 @@ import {
   getPreferredCountryCodeFormat,
 } from '../services/utils/utils.js';
 import {
-  bufferDeserializer,
-  bufferSerializer,
-  createShapeChunkStore,
+  deleteRawDataDataSourceBuffersForNode,
   deleteRawDataDataSourceBuffersForNodeKeys,
 } from '../services/utils/chunkStore.js';
 import { normalizeCountryCodeFormat } from '../services/utils/iso3166.js';
@@ -97,6 +95,24 @@ const buildFetchStageOptions = (buildConfig: ShapeRuntimeBuildConfig) => ({
   retryDelay: buildConfig.fetchConfig.retryDelay,
 });
 
+const countSelectedAdminPairs = (
+  selectedArrayByCountries: SelectedArrayByCountries | undefined,
+): number => {
+  if (!selectedArrayByCountries || typeof selectedArrayByCountries !== 'object' || Array.isArray(selectedArrayByCountries)) {
+    return 0;
+  }
+  let selectedAdminPairCount = 0;
+  Object.values(selectedArrayByCountries).forEach((row) => {
+    if (!Array.isArray(row)) return;
+    row.forEach((selected) => {
+      if (selected === true) {
+        selectedAdminPairCount += 1;
+      }
+    });
+  });
+  return selectedAdminPairCount;
+};
+
 const resolveFetchTaskPayloadsForPlan = async (input: {
   nodeId: NodeId;
   dataSource: DataSourceName;
@@ -110,11 +126,31 @@ const resolveFetchTaskPayloadsForPlan = async (input: {
     return [];
   }
   const strategy = resolveFetchStageStrategy(input.dataSource);
-  const countryMetadata = await metadataLoader.loadMetadata(input.dataSource, input.nodeId);
-  return strategy.buildFetchTaskPayloads({
+  const selectedAdminPairCount = countSelectedAdminPairs(input.selectedArrayByCountries);
+  const buildPayloads = (countryMetadata: CountryMetadata[]): FetchTaskPayload[] => strategy.buildFetchTaskPayloads({
     selectedArrayByCountries: input.selectedArrayByCountries,
     countryMetadata,
   });
+  const countryMetadata = await metadataLoader.loadMetadata(input.dataSource, input.nodeId);
+  const payloadsFromCache = buildPayloads(countryMetadata);
+  if (payloadsFromCache.length > 0 || selectedAdminPairCount === 0) {
+    return payloadsFromCache;
+  }
+  console.warn('[shapeBatchAPI] no fetch payloads from cached metadata; retrying with force refresh', {
+    nodeId: input.nodeId,
+    dataSource: input.dataSource,
+    selectedAdminPairCount,
+  });
+  metadataLoader.clearCache(input.dataSource);
+  const refreshedMetadata = await metadataLoader.loadMetadata(input.dataSource, input.nodeId, { force: true });
+  const payloadsFromRefreshedMetadata = buildPayloads(refreshedMetadata);
+  if (payloadsFromRefreshedMetadata.length > 0) {
+    return payloadsFromRefreshedMetadata;
+  }
+  throw new Error(
+    `[shapeBatchAPI] No fetch task payloads generated for ${selectedAdminPairCount}`
+    + ' selected entries. Metadata may be stale or incompatible with the current selection.',
+  );
 };
 
 const estimatePlannedFetchTotal = async (input: {
@@ -1525,7 +1561,8 @@ export const shapeBatchAPI = {
       throw new Error(`Working copy not found: ${draftId}`);
     }
 
-    if (!downloadTaskPayloads.length && !draftEntity.selectedArrayByCountries) {
+    const selectedAdminPairCount = countSelectedAdminPairs(draftEntity.selectedArrayByCountries);
+    if (!downloadTaskPayloads.length && selectedAdminPairCount === 0) {
       throw new Error('Shape batch session requires download task payloads or selection');
     }
 
@@ -1557,6 +1594,12 @@ export const shapeBatchAPI = {
       }),
       { payloadCount: downloadTaskPayloads.length },
     );
+    if ((downloadTaskPayloads.length > 0 || selectedAdminPairCount > 0) && fetchPlan.plannedFetchTotal === 0) {
+      throw new Error(
+        '[shapeBatchAPI] Build has selected inputs but generated 0 fetch tasks.'
+        + ' Please reload country metadata and retry.',
+      );
+    }
     setFetchPlannedTotal(nodeForSession, fetchPlan.plannedFetchTotal);
     const buildStartedAt = Date.now();
     const pipelineRunId = `${nodeForSession}:${buildStartedAt}`;
@@ -1939,6 +1982,16 @@ export const shapeBatchAPI = {
           }),
           { existingTaskCount },
         );
+        const selectedAdminPairCount = countSelectedAdminPairs(draftEntity.selectedArrayByCountries);
+        if (existingTaskCount === 0 && selectedAdminPairCount === 0) {
+          throw new Error('[shapeBatchAPI] Resume requires selected countries/admin levels or existing queued tasks.');
+        }
+        if (existingTaskCount === 0 && selectedAdminPairCount > 0 && fetchPlan.plannedFetchTotal === 0) {
+          throw new Error(
+            '[shapeBatchAPI] Resume has selected inputs but generated 0 fetch tasks.'
+            + ' Please reload country metadata and retry.',
+          );
+        }
         setFetchPlannedTotal(nodeId, fetchPlan.plannedFetchTotal);
         await executeResumeStep(
           'selection-diff-cleanup',
@@ -2453,8 +2506,7 @@ export const shapeBatchAPI = {
   cleanupProcessingData: async (nodeId: NodeId): Promise<void> => {
     await shapeMutationAPIImpl.cleanupProcessingData(nodeId);
     try {
-      const store = createShapeChunkStore(bufferSerializer, bufferDeserializer);
-      await store.deleteAllForNode(nodeId);
+      await deleteRawDataDataSourceBuffersForNode(nodeId);
     } catch (error) {
       console.warn('[shapeBatchAPI] failed to clean chunk-store relations', error);
     }


### PR DESCRIPTION
## Summary
- Prevent shape build sessions from stalling before first task by hardening metadata bootstrap and task reconciliation paths.
- Keep metadata buffers when clearing fetch-stage processing data by avoiding full node-wide chunk-store deletion.
- Reduce noisy debug logs by gating them behind explicit debug config.

## Changes
- add timeout and abort handling to metadata fetch (`metadataSources.ts`)
- retry metadata refresh when selected country/admin pairs exist but fetch payload generation returns empty (`shapeFetchStage.ts`, `worker/api.ts`)
- fail fast when selected inputs exist but planned fetch tasks are zero (`worker/api.ts`)
- keep metadata chunk-store entries on fetch cleanup (`ShapeBuildAPIClient.ts`, `worker/api.ts`)
- suppress TaskUpdate100/RunningResidue logs unless `globalThis.__HDB_SHAPE_BUILD_TASK_SYNC_DEBUG__` enables them (`useShapeBuildTaskSync.ts`, `useShapeBuildTasks.ts`)
- add bootstrap cache + shared worker handle for country selection first-load behavior; reload button still forces refresh (`useShapeCountrySelectionStep.ts`)
- add unit tests for task sync and country-selection bootstrap cache behavior

## Verification
- `pnpm --filter @hierarchidb/shape-plugin exec vitest run src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx src/ui/__tests__/hooks/unit/useShapeCountrySelectionStep.unit.test.tsx` (exit 0)
- `pnpm --filter @hierarchidb/shape-plugin typecheck` (exit 2, existing readonly `vtConfig.debug.tiles` type mismatch unrelated to this change)

Closes #225
