### PR TITLE
feat(shape): separate cacheKey and inputHash identities

### DIFF
--- a/docs/shape-cache-key-input-hash-spec.md
+++ b/docs/shape-cache-key-input-hash-spec.md
@@ -1,0 +1,153 @@
+# Shape Cache Key and Input Hash Specification
+
+## Status
+- Draft
+- Last updated: 2026-02-12
+
+## 1. Purpose
+This document defines how cache identity must be handled in the shape build pipeline (`fetch`, `transform`, `vt`).
+
+The design uses two separate identifiers:
+- `cacheKey`: coarse lookup key
+- `inputHash`: strict equality token
+
+`cacheKey` and `inputHash` must not be merged.
+
+## 2. Core Rules (Normative)
+1. `cacheKey` is used only for candidate lookup.
+2. `inputHash` is used only for strict match validation.
+3. Values used in `cacheKey` must not be part of `inputHash` payload.
+4. `inputHash` is computed once when the task is created and persisted.
+5. Cache hit check must not recompute `inputHash` from stored artifact payloads.
+6. Reuse is allowed only when both `cacheKey` and `inputHash` match.
+7. Cache namespace mode must be configurable:
+  - `node`: isolate cache by node
+  - `global`: share cache across nodes
+8. Artifact persistence must use upsert-by-key semantics (overwrite on same key).
+9. Recommended default namespace policy:
+  - `fetch`: `global`
+  - `transform`: `node`
+  - `vt`: `node`
+10. A dedicated `countryMetadataCache` is out of scope and must not be introduced in this design.
+
+## 3. Definitions
+- `cacheKey`: stage-specific key string for indexed retrieval.
+- `inputHash`: `sha256(canonical_json(payload))`, where payload contains only output-affecting inputs excluding `cacheKey` fields.
+- `artifactHash`: hash of stage output artifact bytes/content identity.
+- `pipelineVersion`: semantic version for stage logic affecting output bytes/geometry.
+- `cacheNamespaceMode`: config value choosing key namespace scope (`node` or `global`).
+- `namespacePrefix`:
+  - `node` mode: `node:{nodeId}`
+  - `global` mode: `global`
+
+## 4. Canonicalization Rules for `inputHash`
+- Object keys are sorted lexicographically.
+- Arrays preserve original order (no sorting).
+- ISO country codes are normalized to uppercase where applicable.
+- Numbers are normalized to canonical JSON numeric form.
+- Null/undefined policy:
+  - Undefined fields are omitted.
+  - Explicit null remains null.
+
+## 5. Stage-Specific Key and Hash Definitions
+All keys below are prefixed with `{namespacePrefix}:`.
+
+### 5.1 Fetch Stage
+#### `cacheKey`
+`{namespacePrefix}:shape:fetch:v1:{dataSource}:{iso2}:adm{adminLevel}:{endpointId}`
+
+- `endpointId` is a stable endpoint identifier (not raw query noise).
+
+#### `inputHash` payload (exclude key fields)
+- `upstreamRevision` (e.g. ETag / Last-Modified / content digest)
+- `fetchOutputShaping`:
+  - `mergePolicy`
+  - `filterZoom`
+  - `omitDetailsConfig`
+  - `excludePolygonAreaCoefficient`
+  - `minRingVertices`
+  - `geometryEngine`
+- `pipelineVersion`
+
+### 5.2 Transform Stage
+#### `cacheKey`
+`{namespacePrefix}:shape:transform:v1:{dataSource}:{iso2}:adm{adminLevel}:band{bandIndex}`
+
+#### `inputHash` payload (exclude key fields)
+- `fetchArtifactHash`
+- `bandMinZoom`
+- `bandMaxZoom`
+- `zBase`
+- `transformConfigAffectingOutput`
+- `pipelineVersion`
+
+### 5.3 VT Stage
+#### `cacheKey`
+`{namespacePrefix}:shape:vt:v1:{dataSource}:band{bandIndex}:z{z}:x{x}:y{y}`
+
+#### `inputHash` payload (exclude key fields)
+- `transformArtifactSetHash` (derived from ordered transform artifacts used for the tile)
+- `vtConfigAffectingOutput`
+- `layerSchema`
+- `geometryEngine` (if output-relevant)
+- `pipelineVersion`
+
+## 6. Persistence Requirements
+Each cacheable artifact record must store:
+- `cacheKey` (indexed)
+- `inputHash` (indexed)
+- `artifactHash` (indexed)
+- stage identity (`fetch` / `transform` / `vt`)
+- produced output metadata (size/count/timestamps)
+
+Recommended uniqueness:
+- unique(`stage`, `cacheKey`)
+
+When writing a new artifact with the same (`stage`, `cacheKey`), the record must be overwritten.
+
+## 7. Cache Hit Algorithm (No Recalculation Mode)
+1. Build task payload.
+2. Compute and persist task-side:
+  - `task.cacheKey`
+  - `task.inputHash`
+3. Lookup artifacts by `stage + cacheKey`.
+4. Select first artifact where `artifact.inputHash === task.inputHash`.
+5. If found: reuse artifact.
+6. If not found: execute task and persist new artifact with same `cacheKey` and computed `inputHash`.
+
+Important:
+- Step 4 is direct string comparison only.
+- No recomputation of `inputHash` from stored artifacts during hit check.
+
+## 8. Lifecycle Behavior
+- `Start`:
+  - Tasks are newly generated.
+  - Cache reuse is allowed via (`cacheKey`, `inputHash`) matching.
+- `Resume`:
+  - Continue existing tasks.
+  - Same cache matching rule applies.
+- `Reset`:
+  - Remove runtime/task state only.
+  - Cache artifacts and metadata remain.
+- Explicit `Reload`:
+  - Invalidate target cache domain and regenerate.
+
+Legacy policy:
+- Artifacts without `inputHash` are treated as invalid and must not be reused.
+- They may be dropped eagerly during reset/reload or lazily on first key lookup.
+
+## 9. Non-Goals
+- This spec does not define storage TTL/LRU policy details.
+- This spec does not define UI progress behavior.
+- This spec does not define a standalone country metadata cache layer.
+
+## 10. Test Requirements (for TDD)
+Minimum required tests:
+1. Same `cacheKey`, different `inputHash` -> miss.
+2. Same `cacheKey`, same `inputHash` -> hit.
+3. Different `cacheKey`, same `inputHash` -> miss.
+4. `inputHash` is persisted at task creation and reused without recomputation.
+5. Stage-specific payload changes that affect output cause `inputHash` change.
+6. Fields used only by lookup key do not affect `inputHash`.
+7. Same (`stage`, `cacheKey`) write overwrites previous artifact record.
+8. Namespace mode switch (`node` / `global`) changes key space as expected.

--- a/plugins/shape-plugin/src/__tests__/unit/shapeStageReconcile.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/shapeStageReconcile.unit.test.ts
@@ -2,46 +2,65 @@ import { describe, expect, it } from 'vitest';
 import type { TaskQueueRecord } from '@hierarchidb/batch-api';
 import { reconcileStageTasksByMetadata } from '../../services/vt/shapeStageReconcile.ts';
 
-type TestInput = { value: string };
+type TestInput = {
+  value?: string;
+  cacheKey?: string;
+  inputHash?: string;
+};
 
 type TestTask = TaskQueueRecord<TestInput, unknown>;
 
-const buildTask = (taskId: string, value: string): TestTask => ({
+const buildTask = (
+  taskId: string,
+  value: string,
+  overrides?: Partial<TestInput>,
+): TestTask => ({
   taskId,
   nodeId: 'node-1',
   stage: 'fetch',
   status: 'queued',
   index: 0,
   progress: 0,
-  inputData: { value },
+  inputData: {
+    value,
+    ...overrides,
+  },
 });
 
 describe('reconcileStageTasksByMetadata', () => {
-  it('keeps when signatures match', () => {
-    const desired = [buildTask('t1', 'a')];
-    const existing = [buildTask('t1', 'a')];
+  it('keeps when cacheKey/inputHash match', () => {
+    const desired = [buildTask('t1', 'a', { cacheKey: 'k:1', inputHash: 'h:1' })];
+    const existing = [buildTask('t1', 'b', { cacheKey: 'k:1', inputHash: 'h:1' })];
     const result = reconcileStageTasksByMetadata(desired, existing);
     expect(result.missingTasks).toEqual([]);
     expect(result.obsoleteTaskIds).toEqual([]);
   });
 
-  it('marks update when signatures differ', () => {
-    const desired = [buildTask('t1', 'b')];
-    const existing = [buildTask('t1', 'a')];
+  it('marks update when cacheKey matches and inputHash differs', () => {
+    const desired = [buildTask('t1', 'a', { cacheKey: 'k:1', inputHash: 'h:2' })];
+    const existing = [buildTask('t1', 'a', { cacheKey: 'k:1', inputHash: 'h:1' })];
     const result = reconcileStageTasksByMetadata(desired, existing);
     expect(result.missingTasks.map((task) => task.taskId)).toEqual(['t1']);
     expect(result.obsoleteTaskIds).toEqual(['t1']);
   });
 
+  it('marks create/remove when cacheKey differs even if inputHash matches', () => {
+    const desired = [buildTask('t1-new', 'a', { cacheKey: 'k:new', inputHash: 'h:1' })];
+    const existing = [buildTask('t1-old', 'a', { cacheKey: 'k:old', inputHash: 'h:1' })];
+    const result = reconcileStageTasksByMetadata(desired, existing);
+    expect(result.missingTasks.map((task) => task.taskId)).toEqual(['t1-new']);
+    expect(result.obsoleteTaskIds).toEqual(['t1-old']);
+  });
+
   it('marks missing when task does not exist', () => {
-    const desired = [buildTask('t1', 'a')];
+    const desired = [buildTask('t1', 'a', { cacheKey: 'k:1', inputHash: 'h:1' })];
     const result = reconcileStageTasksByMetadata(desired, []);
     expect(result.missingTasks.map((task) => task.taskId)).toEqual(['t1']);
     expect(result.obsoleteTaskIds).toEqual([]);
   });
 
   it('marks obsolete when source is removed', () => {
-    const existing = [buildTask('t1', 'a')];
+    const existing = [buildTask('t1', 'a', { cacheKey: 'k:1', inputHash: 'h:1' })];
     const result = reconcileStageTasksByMetadata([], existing);
     expect(result.missingTasks).toEqual([]);
     expect(result.obsoleteTaskIds).toEqual(['t1']);

--- a/plugins/shape-plugin/src/__tests__/unit/shapeTaskCacheIdentity.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/shapeTaskCacheIdentity.unit.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskQueueRecord } from '@hierarchidb/batch-api';
+import {
+  buildFetchTaskCacheIdentity,
+  buildTransformTaskCacheIdentity,
+  buildVtTaskCacheIdentity,
+  resolveTaskCacheIdentity,
+} from '../../services/vt/shapeTaskCacheIdentity.ts';
+
+describe('shapeTaskCacheIdentity', () => {
+  it('uses namespace policy to switch fetch key space', () => {
+    const nodeScoped = buildFetchTaskCacheIdentity({
+      nodeId: 'node-1',
+      dataSource: 'gadm',
+      sourceKey: 'JP:0',
+      url: 'https://example.com/a',
+      configSignature: 'sig-1',
+      namespacePolicy: { fetch: 'node' },
+    });
+    const globalScoped = buildFetchTaskCacheIdentity({
+      nodeId: 'node-1',
+      dataSource: 'gadm',
+      sourceKey: 'JP:0',
+      url: 'https://example.com/a',
+      configSignature: 'sig-1',
+      namespacePolicy: { fetch: 'global' },
+    });
+    expect(nodeScoped.cacheKey).toContain('node:node-1:shape:fetch');
+    expect(globalScoped.cacheKey).toContain('global:shape:fetch');
+  });
+
+  it('keeps fetch inputHash stable when cache-key-only fields change', () => {
+    const first = buildFetchTaskCacheIdentity({
+      nodeId: 'node-1',
+      dataSource: 'gadm',
+      sourceKey: 'JP:0',
+      url: 'https://example.com/a',
+      configSignature: 'sig-1',
+    });
+    const second = buildFetchTaskCacheIdentity({
+      nodeId: 'node-1',
+      dataSource: 'gadm',
+      sourceKey: 'JP:1',
+      url: 'https://example.com/b?token=123',
+      configSignature: 'sig-1',
+    });
+    expect(first.cacheKey).not.toEqual(second.cacheKey);
+    expect(first.inputHash).toEqual(second.inputHash);
+  });
+
+  it('changes transform inputHash when output-affecting payload changes', () => {
+    const first = buildTransformTaskCacheIdentity({
+      nodeId: 'node-1',
+      sourceKey: 'JP:0',
+      bandIndex: 2,
+      fetchCacheId: 'fetch:a',
+      bandMinZoom: 6,
+      bandMaxZoom: 8,
+      configSignature: 'sig-1',
+    });
+    const second = buildTransformTaskCacheIdentity({
+      nodeId: 'node-1',
+      sourceKey: 'JP:0',
+      bandIndex: 2,
+      fetchCacheId: 'fetch:b',
+      bandMinZoom: 6,
+      bandMaxZoom: 8,
+      configSignature: 'sig-1',
+    });
+    expect(first.cacheKey).toEqual(second.cacheKey);
+    expect(first.inputHash).not.toEqual(second.inputHash);
+  });
+
+  it('normalizes vt buffer set for stable inputHash', () => {
+    const first = buildVtTaskCacheIdentity({
+      nodeId: 'node-1',
+      bandIndex: 3,
+      zBase: 6,
+      tileId: 123,
+      bufferIds: ['b', 'a', 'a'],
+      bandMinZoom: 6,
+      bandMaxZoom: 8,
+      configSignature: 'sig-1',
+    });
+    const second = buildVtTaskCacheIdentity({
+      nodeId: 'node-1',
+      bandIndex: 3,
+      zBase: 6,
+      tileId: 123,
+      bufferIds: ['a', 'b'],
+      bandMinZoom: 6,
+      bandMaxZoom: 8,
+      configSignature: 'sig-1',
+    });
+    expect(first.inputHash).toEqual(second.inputHash);
+  });
+
+  it('prefers persisted cacheKey/inputHash on task inputData', () => {
+    const task: TaskQueueRecord = {
+      taskId: 'task-1',
+      nodeId: 'node-1',
+      stage: 'fetch',
+      status: 'queued',
+      index: 0,
+      progress: 0,
+      inputData: {
+        sourceKey: 'JP:0',
+        configSignature: 'sig-1',
+        cacheKey: 'persisted-key',
+        inputHash: 'persisted-hash',
+      },
+    };
+    const identity = resolveTaskCacheIdentity(task);
+    expect(identity).toEqual({
+      cacheKey: 'persisted-key',
+      inputHash: 'persisted-hash',
+    });
+  });
+});
+

--- a/plugins/shape-plugin/src/services/vt/shapeFetchStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapeFetchStage.ts
@@ -57,6 +57,7 @@ import { fetchRawDataWithPipeline } from '../utils/rawDataPipeline.js';
 import { buildGeoBoundariesMetadataUrl } from '../utils/geoboundariesEndpoints.js';
 import type { GeoBoundariesApiResponse } from '../datasources/GeoBoundariesStrategy.js';
 import { setFetchPlannedTotal } from './shapeProgressPlan.ts';
+import { buildFetchTaskCacheIdentity } from './shapeTaskCacheIdentity.ts';
 
 export type ShapeFetchTaskInput = {
   url: string;
@@ -67,6 +68,8 @@ export type ShapeFetchTaskInput = {
   urlCountryCode: string;
   adminLevel: number;
   configSignature?: string;
+  cacheKey?: string;
+  inputHash?: string;
 };
 
 export type ShapeFetchTaskOutput = {
@@ -709,6 +712,13 @@ const buildFetchTasks = (
       throw new Error(`[shape-fetch] Missing ISO2 for ${payload.countryCode}`);
     }
     const sourceKey = `${iso2}:${payload.adminLevel}`;
+    const cacheIdentity = buildFetchTaskCacheIdentity({
+      nodeId,
+      dataSource: payload.dataSource,
+      sourceKey,
+      url: payload.url,
+      configSignature,
+    });
     return {
       taskId: buildShapeFetchTaskId(nodeId, sourceKey),
       nodeId,
@@ -725,6 +735,8 @@ const buildFetchTasks = (
         urlCountryCode: payload.countryCode.trim().toUpperCase(),
         adminLevel: payload.adminLevel,
         configSignature,
+        cacheKey: cacheIdentity.cacheKey,
+        inputHash: cacheIdentity.inputHash,
       },
     };
   });

--- a/plugins/shape-plugin/src/services/vt/shapePipelineShared.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineShared.ts
@@ -24,6 +24,7 @@ import { extractGeometryStats } from './featureMetadataUtils.ts';
 import { buildStableSignature } from './taskSignatures.ts';
 import { deleteTasksByIds, VtTaskQueueDb } from '@hierarchidb/vt-orchestrator';
 import { ephemeralShapeDB, type EphemeralShapeDB } from '@hierarchidb/gis-sdk';
+import { buildTransformTaskCacheIdentity, buildVtTaskCacheIdentity } from './shapeTaskCacheIdentity.ts';
 
 export type ShapeTransformByBandTaskInput = {
   fetchCacheId: string;
@@ -37,6 +38,8 @@ export type ShapeTransformByBandTaskInput = {
   countryName?: string;
   adminLevel?: number;
   configSignature?: string;
+  cacheKey?: string;
+  inputHash?: string;
 };
 
 export type ShapeVtTaskInput = {
@@ -50,6 +53,8 @@ export type ShapeVtTaskInput = {
   domainType: 'shape';
   sourceKey: string;
   configSignature?: string;
+  cacheKey?: string;
+  inputHash?: string;
 };
 
 const HIGH_DETAIL_ZOOM_MIN = 9;
@@ -445,6 +450,15 @@ export const buildTransformByBandTasks = async (
           if (!enableHighDetailBands) continue;
           if (typeof adminLevel !== 'number' || adminLevel < 2) continue;
         }
+        const cacheIdentity = buildTransformTaskCacheIdentity({
+          nodeId,
+          sourceKey: buffer.sourceKey,
+          bandIndex: band.bandIndex,
+          fetchCacheId: buffer.id,
+          bandMinZoom: band.zMin,
+          bandMaxZoom: band.zMax,
+          configSignature,
+        });
         tasks.push({
           taskId: `${String(nodeId)}:transform:${band.bandIndex}:${buffer.sourceKey}`,
           nodeId,
@@ -465,6 +479,8 @@ export const buildTransformByBandTasks = async (
             countryName: countryMeta?.countryName,
             adminLevel: buffer.adminLevel,
             configSignature,
+            cacheKey: cacheIdentity.cacheKey,
+            inputHash: cacheIdentity.inputHash,
           },
         });
         index += 1;
@@ -578,6 +594,16 @@ export const buildVtTasks = async (
       const usableBufferIds = [...new Set(bufferIds)];
       if (usableBufferIds.length === 0) continue;
       const featureCount = usableBufferIds.reduce((sum, bufferId) => sum + (bufferFeatureCounts.get(bufferId) ?? 0), 0);
+      const cacheIdentity = buildVtTaskCacheIdentity({
+        nodeId,
+        bandIndex: band.bandIndex,
+        zBase: band.zBase,
+        tileId,
+        bufferIds: usableBufferIds,
+        bandMinZoom: band.zMin,
+        bandMaxZoom: band.zMax,
+        configSignature,
+      });
       tasks.push({
         taskId: `${String(nodeId)}:vt:${band.bandIndex}:${band.zBase}:${tileId}`,
         nodeId,
@@ -596,6 +622,8 @@ export const buildVtTasks = async (
           domainType: 'shape',
           sourceKey: 'mixed',
           configSignature,
+          cacheKey: cacheIdentity.cacheKey,
+          inputHash: cacheIdentity.inputHash,
         },
       });
       index += 1;

--- a/plugins/shape-plugin/src/services/vt/shapePipelineTransformStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineTransformStage.ts
@@ -23,6 +23,7 @@ import {
 } from './shapePipelineStageHelpers.ts';
 import { clearStagePlan, setTransformPlannedTotal } from './shapeProgressPlan.ts';
 import type { EphemeralShapeDB } from '@hierarchidb/gis-sdk';
+import { buildTransformTaskCacheIdentity } from './shapeTaskCacheIdentity.ts';
 
 export type ShapeTransformStageParams = {
   nodeId: NodeId;
@@ -278,6 +279,15 @@ export const runShapeTransformStageSection = async (params: ShapeTransformStageP
           continue;
         }
       }
+      const cacheIdentity = buildTransformTaskCacheIdentity({
+        nodeId: params.nodeId,
+        sourceKey: buffer.sourceKey,
+        bandIndex: band.bandIndex,
+        fetchCacheId: buffer.id,
+        bandMinZoom: band.zMin,
+        bandMaxZoom: band.zMax,
+        configSignature: transformConfigSignature,
+      });
       tasks.push({
         taskId: `${String(params.nodeId)}:transform:${band.bandIndex}:${buffer.sourceKey}`,
         nodeId: params.nodeId,
@@ -298,6 +308,8 @@ export const runShapeTransformStageSection = async (params: ShapeTransformStageP
           countryName,
           adminLevel: buffer.adminLevel,
           configSignature: transformConfigSignature,
+          cacheKey: cacheIdentity.cacheKey,
+          inputHash: cacheIdentity.inputHash,
         },
       });
       index += 1;

--- a/plugins/shape-plugin/src/services/vt/shapeStageReconcile.ts
+++ b/plugins/shape-plugin/src/services/vt/shapeStageReconcile.ts
@@ -1,6 +1,6 @@
 import type { TaskQueueRecord } from '@hierarchidb/batch-api';
 import { reconcileByMetadata, type MetadataDescriptor } from '@hierarchidb/batch';
-import { buildStableSignature } from './taskSignatures.ts';
+import { resolveTaskCacheIdentity } from './shapeTaskCacheIdentity.ts';
 
 type TaskLike = TaskQueueRecord<unknown, unknown>;
 
@@ -10,10 +10,10 @@ type ReconcileResult<TInput, TOutput> = {
 };
 
 const buildDescriptor = (task: TaskLike): MetadataDescriptor => {
-  const meta = task.inputData ? buildStableSignature(task.inputData) : undefined;
+  const identity = resolveTaskCacheIdentity(task);
   return {
-    key: task.taskId,
-    meta,
+    key: identity.cacheKey,
+    meta: identity.inputHash,
     updatedAt: task.updatedAt,
   };
 };
@@ -22,19 +22,27 @@ export const reconcileStageTasksByMetadata = <TInput, TOutput>(
   desiredTasks: Array<TaskQueueRecord<TInput, TOutput>>,
   existingTasks: Array<TaskQueueRecord<TInput, TOutput>>,
 ): ReconcileResult<TInput, TOutput> => {
-  const sources = desiredTasks.map((task) => buildDescriptor(task as TaskLike));
-  const artifacts = existingTasks.map((task) => buildDescriptor(task as TaskLike));
+  const sourceEntries = desiredTasks.map((task) => ({
+    task,
+    descriptor: buildDescriptor(task as TaskLike),
+  }));
+  const artifactEntries = existingTasks.map((task) => ({
+    task,
+    descriptor: buildDescriptor(task as TaskLike),
+  }));
+  const sources = sourceEntries.map((entry) => entry.descriptor);
+  const artifacts = artifactEntries.map((entry) => entry.descriptor);
   const diff = reconcileByMetadata(sources, artifacts);
   const createSet = new Set(diff.create);
   const updateSet = new Set(diff.update);
   const removeSet = new Set(diff.remove);
 
-  const missingTasks = desiredTasks.filter(
-    (task) => createSet.has(task.taskId) || updateSet.has(task.taskId),
-  );
-  const obsoleteTaskIds = existingTasks
-    .filter((task) => removeSet.has(task.taskId) || updateSet.has(task.taskId))
-    .map((task) => task.taskId)
+  const missingTasks = sourceEntries
+    .filter((entry) => createSet.has(entry.descriptor.key) || updateSet.has(entry.descriptor.key))
+    .map((entry) => entry.task);
+  const obsoleteTaskIds = artifactEntries
+    .filter((entry) => removeSet.has(entry.descriptor.key) || updateSet.has(entry.descriptor.key))
+    .map((entry) => entry.task.taskId)
     .sort();
 
   return { missingTasks, obsoleteTaskIds };

--- a/plugins/shape-plugin/src/services/vt/shapeTaskCacheIdentity.ts
+++ b/plugins/shape-plugin/src/services/vt/shapeTaskCacheIdentity.ts
@@ -1,0 +1,225 @@
+import type { TaskQueueRecord } from '@hierarchidb/batch-api';
+import type { NodeId } from '@hierarchidb/core-types';
+import { buildStableSignature } from './taskSignatures.ts';
+
+export type ShapeStage = 'fetch' | 'transform' | 'vt';
+export type ShapeCacheNamespaceMode = 'node' | 'global';
+
+export type ShapeStageCacheNamespacePolicy = {
+  fetch: ShapeCacheNamespaceMode;
+  transform: ShapeCacheNamespaceMode;
+  vt: ShapeCacheNamespaceMode;
+};
+
+export type ShapeTaskCacheIdentity = {
+  cacheKey: string;
+  inputHash: string;
+};
+
+type CacheIdentityEnvelope = {
+  cacheKey?: unknown;
+  inputHash?: unknown;
+};
+
+const SHAPE_CACHE_KEY_VERSION = 'v1';
+const SHAPE_FETCH_PIPELINE_VERSION = 'fetch-v1';
+const SHAPE_TRANSFORM_PIPELINE_VERSION = 'transform-v1';
+const SHAPE_VT_PIPELINE_VERSION = 'vt-v1';
+
+const DEFAULT_STAGE_CACHE_NAMESPACE_POLICY: ShapeStageCacheNamespacePolicy = {
+  fetch: 'global',
+  transform: 'node',
+  vt: 'node',
+};
+
+const normalizeString = (value: unknown): string => (
+  typeof value === 'string' ? value.trim() : ''
+);
+
+const normalizeCountryCode = (value: unknown): string => {
+  const text = normalizeString(value);
+  return text.length > 0 ? text.toUpperCase() : 'XX';
+};
+
+const normalizeInteger = (value: unknown, fallback: number): number => (
+  typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : fallback
+);
+
+const normalizeEndpointId = (urlLike: unknown): string => {
+  const value = normalizeString(urlLike);
+  if (!value) return 'endpoint';
+  try {
+    const parsed = new URL(value);
+    return `${parsed.origin}${parsed.pathname}`.toLowerCase();
+  } catch {
+    return value.toLowerCase();
+  }
+};
+
+const resolveNamespacePrefix = (
+  nodeId: NodeId,
+  mode: ShapeCacheNamespaceMode,
+): string => (mode === 'global' ? 'global' : `node:${String(nodeId)}`);
+
+const resolveNamespaceMode = (
+  stage: ShapeStage,
+  namespacePolicy?: Partial<ShapeStageCacheNamespacePolicy>,
+): ShapeCacheNamespaceMode => {
+  const override = namespacePolicy?.[stage];
+  if (override === 'node' || override === 'global') {
+    return override;
+  }
+  return DEFAULT_STAGE_CACHE_NAMESPACE_POLICY[stage];
+};
+
+const normalizeBufferIds = (bufferIds: unknown): string[] => {
+  if (!Array.isArray(bufferIds)) return [];
+  const normalized = bufferIds
+    .map((value) => normalizeString(value))
+    .filter((value) => value.length > 0);
+  return Array.from(new Set(normalized)).sort((a, b) => a.localeCompare(b));
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => (
+  value && typeof value === 'object' ? value as Record<string, unknown> : null
+);
+
+const readPersistedIdentity = (inputData: unknown): ShapeTaskCacheIdentity | null => {
+  const envelope = asRecord(inputData) as CacheIdentityEnvelope | null;
+  const cacheKey = normalizeString(envelope?.cacheKey);
+  const inputHash = normalizeString(envelope?.inputHash);
+  if (!cacheKey || !inputHash) return null;
+  return { cacheKey, inputHash };
+};
+
+export const buildFetchTaskCacheIdentity = (params: {
+  nodeId: NodeId;
+  dataSource: string;
+  sourceKey: string;
+  url: string;
+  configSignature?: string;
+  namespacePolicy?: Partial<ShapeStageCacheNamespacePolicy>;
+}): ShapeTaskCacheIdentity => {
+  const namespacePrefix = resolveNamespacePrefix(
+    params.nodeId,
+    resolveNamespaceMode('fetch', params.namespacePolicy),
+  );
+  const dataSource = normalizeString(params.dataSource) || 'unknown';
+  const sourceKey = normalizeString(params.sourceKey) || 'unknown:0';
+  const endpointId = encodeURIComponent(normalizeEndpointId(params.url));
+  const cacheKey = `${namespacePrefix}:shape:fetch:${SHAPE_CACHE_KEY_VERSION}:${dataSource}:${sourceKey}:${endpointId}`;
+  const inputHash = buildStableSignature({
+    fetchOutputShapingSignature: normalizeString(params.configSignature) || null,
+    pipelineVersion: SHAPE_FETCH_PIPELINE_VERSION,
+  });
+  return { cacheKey, inputHash };
+};
+
+export const buildTransformTaskCacheIdentity = (params: {
+  nodeId: NodeId;
+  sourceKey: string;
+  bandIndex: number;
+  fetchCacheId: string;
+  bandMinZoom?: number;
+  bandMaxZoom?: number;
+  configSignature?: string;
+  namespacePolicy?: Partial<ShapeStageCacheNamespacePolicy>;
+}): ShapeTaskCacheIdentity => {
+  const namespacePrefix = resolveNamespacePrefix(
+    params.nodeId,
+    resolveNamespaceMode('transform', params.namespacePolicy),
+  );
+  const sourceKey = normalizeString(params.sourceKey) || 'unknown:0';
+  const bandIndex = normalizeInteger(params.bandIndex, 0);
+  const cacheKey = `${namespacePrefix}:shape:transform:${SHAPE_CACHE_KEY_VERSION}:${sourceKey}:band${bandIndex}`;
+  const inputHash = buildStableSignature({
+    fetchArtifactRef: normalizeString(params.fetchCacheId),
+    bandMinZoom: normalizeInteger(params.bandMinZoom, 0),
+    bandMaxZoom: normalizeInteger(params.bandMaxZoom, 0),
+    transformConfigSignature: normalizeString(params.configSignature) || null,
+    pipelineVersion: SHAPE_TRANSFORM_PIPELINE_VERSION,
+  });
+  return { cacheKey, inputHash };
+};
+
+export const buildVtTaskCacheIdentity = (params: {
+  nodeId: NodeId;
+  bandIndex: number;
+  zBase: number;
+  tileId: number;
+  bufferIds: string[];
+  bandMinZoom?: number;
+  bandMaxZoom?: number;
+  configSignature?: string;
+  namespacePolicy?: Partial<ShapeStageCacheNamespacePolicy>;
+}): ShapeTaskCacheIdentity => {
+  const namespacePrefix = resolveNamespacePrefix(
+    params.nodeId,
+    resolveNamespaceMode('vt', params.namespacePolicy),
+  );
+  const bandIndex = normalizeInteger(params.bandIndex, 0);
+  const zBase = normalizeInteger(params.zBase, 0);
+  const tileId = normalizeInteger(params.tileId, 0);
+  const cacheKey = `${namespacePrefix}:shape:vt:${SHAPE_CACHE_KEY_VERSION}:band${bandIndex}:z${zBase}:tile${tileId}`;
+  const transformArtifactSet = normalizeBufferIds(params.bufferIds);
+  const inputHash = buildStableSignature({
+    transformArtifactSet,
+    bandMinZoom: normalizeInteger(params.bandMinZoom, 0),
+    bandMaxZoom: normalizeInteger(params.bandMaxZoom, 0),
+    vtConfigSignature: normalizeString(params.configSignature) || null,
+    pipelineVersion: SHAPE_VT_PIPELINE_VERSION,
+  });
+  return { cacheKey, inputHash };
+};
+
+export const resolveTaskCacheIdentity = (
+  task: TaskQueueRecord,
+  namespacePolicy?: Partial<ShapeStageCacheNamespacePolicy>,
+): ShapeTaskCacheIdentity => {
+  const persisted = readPersistedIdentity(task.inputData);
+  if (persisted) {
+    return persisted;
+  }
+
+  const input = asRecord(task.inputData) ?? {};
+  const stage = task.stage;
+  if (stage === 'fetch') {
+    return buildFetchTaskCacheIdentity({
+      nodeId: task.nodeId,
+      dataSource: normalizeString(input.dataSource) || 'unknown',
+      sourceKey: normalizeString(input.sourceKey) || `${normalizeCountryCode(input.countryCode)}:${normalizeInteger(input.adminLevel, 0)}`,
+      url: normalizeString(input.url),
+      configSignature: normalizeString(input.configSignature) || undefined,
+      namespacePolicy,
+    });
+  }
+  if (stage === 'transform') {
+    return buildTransformTaskCacheIdentity({
+      nodeId: task.nodeId,
+      sourceKey: normalizeString(input.sourceKey) || `${normalizeCountryCode(input.countryCode)}:${normalizeInteger(input.adminLevel, 0)}`,
+      bandIndex: normalizeInteger(input.bandIndex, 0),
+      fetchCacheId: normalizeString(input.fetchCacheId),
+      bandMinZoom: normalizeInteger(input.bandMinZoom, 0),
+      bandMaxZoom: normalizeInteger(input.bandMaxZoom, 0),
+      configSignature: normalizeString(input.configSignature) || undefined,
+      namespacePolicy,
+    });
+  }
+  if (stage === 'vt') {
+    return buildVtTaskCacheIdentity({
+      nodeId: task.nodeId,
+      bandIndex: normalizeInteger(input.bandIndex, 0),
+      zBase: normalizeInteger(input.zBase, 0),
+      tileId: normalizeInteger(input.tileId, 0),
+      bufferIds: normalizeBufferIds(input.bufferIds),
+      bandMinZoom: normalizeInteger(input.bandMinZoom, 0),
+      bandMaxZoom: normalizeInteger(input.bandMaxZoom, 0),
+      configSignature: normalizeString(input.configSignature) || undefined,
+      namespacePolicy,
+    });
+  }
+  return {
+    cacheKey: `node:${String(task.nodeId)}:shape:legacy:${task.taskId}`,
+    inputHash: buildStableSignature(input),
+  };
+};


### PR DESCRIPTION
## Summary
- Implement `cacheKey` (lookup) and `inputHash` (strict equality) separation for shape fetch/transform/vt tasks.
- Add stage-specific identity builders and reconcile logic based on `cacheKey + inputHash`.
- Document the specification in `docs/shape-cache-key-input-hash-spec.md`.

## Changes
- add `shapeTaskCacheIdentity.ts` for stage identity generation and persisted identity resolution
- persist `cacheKey` / `inputHash` when building fetch/transform/vt tasks
- update stage reconcile from taskId/signature matching to `cacheKey/inputHash` matching
- add unit tests for identity behavior and reconcile behavior
- add spec document for key/hash separation and namespace policy

## Verification
- `pnpm --filter @hierarchidb/shape-plugin exec vitest run src/__tests__/unit/shapeTaskCacheIdentity.unit.test.ts src/__tests__/unit/shapeStageReconcile.unit.test.ts` (exit 0)
- `pnpm --filter @hierarchidb/shape-plugin typecheck` (exit 2, existing readonly `vtConfig.debug.tiles` type mismatch unrelated to this change)

Closes #226
Depends on #225
