### PR TITLE
refactor(vt-orchestrator): lazy-load topojson runtime modules

### DIFF
--- a/packages/vt-orchestrator/src/transform/__tests__/fetchCacheDecoder.unit.test.ts
+++ b/packages/vt-orchestrator/src/transform/__tests__/fetchCacheDecoder.unit.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import type { FeatureCollection } from 'geojson';
+import { geojson as geojsonApi } from 'flatgeobuf';
+import { decodeFetchCacheByFormat } from '../createTransformByBandHandler.js';
+import {
+  __getTopojsonRuntimeLoadCount,
+  __resetTopojsonRuntimeForTests,
+} from '../topojsonRuntimeAdapter.js';
+
+const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer => (
+  bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+);
+
+const buildFlatGeobuf = async (collection: FeatureCollection): Promise<ArrayBuffer> => {
+  const encoded = await geojsonApi.serialize(collection);
+  return toArrayBuffer(encoded);
+};
+
+const buildSimpleTopojsonBuffer = (): ArrayBuffer => {
+  const topology = {
+    type: 'Topology',
+    objects: {
+      collection: {
+        type: 'GeometryCollection',
+        geometries: [
+          {
+            type: 'Point',
+            coordinates: [0, 0],
+            properties: { id: 'p1' },
+          },
+        ],
+      },
+    },
+    arcs: [],
+    transform: {
+      scale: [1, 1],
+      translate: [0, 0],
+    },
+  };
+  return new TextEncoder().encode(JSON.stringify(topology)).buffer;
+};
+
+describe('decodeFetchCacheByFormat', () => {
+  beforeEach(() => {
+    __resetTopojsonRuntimeForTests();
+  });
+
+  it('does not load topojson runtime for non-topojson format', async () => {
+    const collection: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [139.75, 35.68],
+          },
+          properties: { id: 'tokyo' },
+        },
+      ],
+    };
+    const buffer = await buildFlatGeobuf(collection);
+    const decoded = await decodeFetchCacheByFormat({
+      buffer,
+      format: 'flatgeobuf',
+      zTarget: 5,
+      toleranceK: 0.5,
+      quantize: 1_000_000,
+    });
+    expect(decoded?.features.length).toBe(1);
+    expect(__getTopojsonRuntimeLoadCount()).toBe(0);
+  });
+
+  it('loads topojson runtime when topojson format is decoded', async () => {
+    const buffer = buildSimpleTopojsonBuffer();
+    const decoded = await decodeFetchCacheByFormat({
+      buffer,
+      format: 'topojson',
+      zTarget: 5,
+      toleranceK: 0,
+      quantize: 1_000_000,
+    });
+    expect(decoded?.features.length).toBe(1);
+    expect(__getTopojsonRuntimeLoadCount()).toBe(1);
+  });
+});
+

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts
@@ -1,8 +1,6 @@
 import type { Feature, FeatureCollection, Geometry, LineString, MultiLineString, MultiPolygon, Polygon } from 'geojson';
 import type { NodeId } from '@hierarchidb/core-types';
 import type { Topology } from 'topojson-specification';
-import { feature as topojsonFeature } from 'topojson-client';
-import { presimplify as topojsonPresimplify, simplify as topojsonSimplify } from 'topojson-simplify';
 import { geojson as geojsonApi } from 'flatgeobuf';
 import {
   applyFeatureFiltering,
@@ -26,6 +24,7 @@ import type { StageHandler, StageHandlerResult, TransformByBandTaskInput } from 
 import { VtTaskQueueDb, emitTaskUpdate, toTaskQueueRecord, updateTask, type StoredTaskRecord } from '../task/taskQueue.js';
 import { logDebug } from '../debug/persistentDebugLog.js';
 import { packTileId } from '../tiles/tileId.js';
+import { getTopojsonRuntime } from './topojsonRuntimeAdapter.js';
 
 const TASKDEBUG_BUILD_TAG = 'taskdebug-2026-02-09-0240';
 let structuredCloneLogged = false;
@@ -61,10 +60,11 @@ const resolveTopoJsonObject = (topology: Topology): Topology['objects'][string] 
   return topology.objects[key] ?? null;
 };
 
-const normalizeTopoJsonCollection = (topology: Topology): FeatureCollection => {
+const normalizeTopoJsonCollection = async (topology: Topology): Promise<FeatureCollection> => {
   const object = resolveTopoJsonObject(topology);
   if (!object) return { type: 'FeatureCollection', features: [] };
-  const geojson = topojsonFeature(topology, object);
+  const runtime = await getTopojsonRuntime();
+  const geojson = runtime.feature(topology, object);
   if (geojson.type === 'FeatureCollection') {
     const features = Array.isArray(geojson.features) ? geojson.features : [];
     return { ...geojson, features };
@@ -144,11 +144,11 @@ const decodeTopoJsonFetchCache = async (params: {
     ? await decompressGzip(params.buffer)
     : params.buffer;
   const topology = decodeTopoJson(decompressed);
-  const snappedTopology = quantizeTopoJsonToGrid(topology, {
+  const snappedTopology = await quantizeTopoJsonToGrid(topology, {
     zTarget: params.zTarget,
     quantize: params.quantize,
   });
-  let { collection, appliedToleranceK } = simplifyTopoJsonByZoom({
+  let { collection, appliedToleranceK } = await simplifyTopoJsonByZoom({
     topology: snappedTopology,
     zTarget: params.zTarget,
     toleranceK: params.toleranceK,
@@ -156,7 +156,7 @@ const decodeTopoJsonFetchCache = async (params: {
   let maxVertices = maxVerticesInCollection(collection);
   if (maxVertices > MAX_VERTICES_PER_FEATURE) {
     const retryToleranceK = appliedToleranceK * 1.5;
-    const retry = simplifyTopoJsonByZoom({
+    const retry = await simplifyTopoJsonByZoom({
       topology,
       zTarget: params.zTarget,
       toleranceK: retryToleranceK,
@@ -278,21 +278,42 @@ const resolveTransformTolerance = (
   return baseTolerance;
 };
 
-const simplifyTopoJsonByZoom = (params: {
+const simplifyTopoJsonByZoom = async (params: {
   topology: Topology;
   zTarget: number;
   toleranceK: number;
-}): { topology: Topology; collection: FeatureCollection; appliedToleranceK: number } => {
-  const baseCollection = normalizeTopoJsonCollection(params.topology);
+}): Promise<{ topology: Topology; collection: FeatureCollection; appliedToleranceK: number }> => {
+  const baseCollection = await normalizeTopoJsonCollection(params.topology);
   const appliedToleranceK = params.toleranceK;
   const tolerance = resolveSimplifyToleranceDegrees(params.zTarget, appliedToleranceK);
   if (!Number.isFinite(tolerance) || tolerance <= 0) {
     return { topology: params.topology, collection: baseCollection, appliedToleranceK };
   }
-  const presimplified = topojsonPresimplify(params.topology);
-  const simplified = topojsonSimplify(presimplified, tolerance);
-  const simplifiedCollection = normalizeTopoJsonCollection(simplified);
+  const runtime = await getTopojsonRuntime();
+  const presimplified = runtime.presimplify(params.topology);
+  const simplified = runtime.simplify(presimplified, tolerance);
+  const simplifiedCollection = await normalizeTopoJsonCollection(simplified);
   return { topology: simplified, collection: simplifiedCollection, appliedToleranceK };
+};
+
+export const decodeFetchCacheByFormat = async (params: {
+  buffer: ArrayBuffer;
+  format?: string;
+  compression?: string;
+  zTarget: number;
+  toleranceK: number;
+  quantize?: number;
+}): Promise<FeatureCollection | null> => {
+  if (params.format === 'topojson') {
+    return decodeTopoJsonFetchCache({
+      buffer: params.buffer,
+      compression: params.compression,
+      zTarget: params.zTarget,
+      toleranceK: params.toleranceK,
+      quantize: params.quantize,
+    });
+  }
+  return decodeFetchCache(params.buffer);
 };
 
 const simplifyOnlyCollection = (
@@ -1598,18 +1619,14 @@ export const createTransformByBandHandler = (
       });
       await updateTaskPhase(taskId, 'decode:start', taskProgressRange.decodeStart);
       assertNotAborted(abortSignal);
-      let collection = await runStageWithLabel('decode', () => {
-        if (fetchCache.format === 'topojson') {
-          return decodeTopoJsonFetchCache({
-            buffer: fetchCache.data,
-            compression: fetchCache.compression,
-            zTarget: band.zMax,
-            toleranceK: baseTolerance,
-            quantize: transformConfig.quantize,
-          });
-        }
-        return decodeFetchCache(fetchCache.data);
-      });
+      let collection = await runStageWithLabel('decode', () => decodeFetchCacheByFormat({
+        buffer: fetchCache.data,
+        format: fetchCache.format,
+        compression: fetchCache.compression,
+        zTarget: band.zMax,
+        toleranceK: baseTolerance,
+        quantize: transformConfig.quantize,
+      }));
       if (!collection || collection.features.length === 0) {
         return { status: 'failed', errorMessage: 'transform failed: empty fetch cache' };
       }

--- a/packages/vt-orchestrator/src/transform/topojsonGrid.ts
+++ b/packages/vt-orchestrator/src/transform/topojsonGrid.ts
@@ -1,8 +1,7 @@
 import type { Feature, FeatureCollection, Geometry } from 'geojson';
 import type { Topology } from 'topojson-specification';
-import { feature as topojsonFeature } from 'topojson-client';
-import { topology as topojsonTopology } from 'topojson-server';
 import { snapGeometryToGrid } from './geometry.js';
+import { getTopojsonRuntime } from './topojsonRuntimeAdapter.js';
 
 type ZoomGridConfig = {
   zTarget: number;
@@ -29,18 +28,19 @@ const snapFeatureCollectionToGrid = (
   return { ...collection, features: snapped };
 };
 
-export const quantizeTopoJsonToGrid = (
+export const quantizeTopoJsonToGrid = async (
   topology: Topology,
   config: ZoomGridConfig,
-): Topology => {
+): Promise<Topology> => {
   const objects = topology.objects ?? {};
   const entries = Object.entries(objects);
   if (entries.length === 0) return topology;
 
+  const runtime = await getTopojsonRuntime();
   const snappedObjects: Record<string, FeatureCollection> = {};
   for (const [key, object] of entries) {
     if (!object) continue;
-    const geojson = topojsonFeature(topology, object) as FeatureCollection | Feature;
+    const geojson = runtime.feature(topology, object) as FeatureCollection | Feature;
     const collection = normalizeFeatureCollection(geojson);
     const snapped = snapFeatureCollectionToGrid(collection, config);
     snappedObjects[key] = snapped;
@@ -50,5 +50,5 @@ export const quantizeTopoJsonToGrid = (
     return topology;
   }
 
-  return topojsonTopology(snappedObjects);
+  return runtime.topology(snappedObjects);
 };

--- a/packages/vt-orchestrator/src/transform/topojsonRuntimeAdapter.ts
+++ b/packages/vt-orchestrator/src/transform/topojsonRuntimeAdapter.ts
@@ -1,0 +1,56 @@
+import type { Feature, FeatureCollection } from 'geojson';
+import type { Topology } from 'topojson-specification';
+
+type TopojsonClientModule = {
+  feature: (topology: Topology, object: Topology['objects'][string]) => FeatureCollection | Feature;
+};
+
+type TopojsonServerModule = {
+  topology: (objects: Record<string, unknown>) => Topology;
+};
+
+type TopojsonSimplifyModule = {
+  presimplify: (topology: Topology) => Topology;
+  simplify: (topology: Topology, minWeight?: number) => Topology;
+};
+
+export type TopojsonRuntime = {
+  feature: TopojsonClientModule['feature'];
+  topology: TopojsonServerModule['topology'];
+  presimplify: TopojsonSimplifyModule['presimplify'];
+  simplify: TopojsonSimplifyModule['simplify'];
+};
+
+let topojsonRuntimePromise: Promise<TopojsonRuntime> | null = null;
+let topojsonRuntimeLoadCount = 0;
+
+const loadTopojsonRuntime = async (): Promise<TopojsonRuntime> => {
+  if (!topojsonRuntimePromise) {
+    topojsonRuntimeLoadCount += 1;
+    topojsonRuntimePromise = (async () => {
+      const [client, server, simplify] = await Promise.all([
+        import('topojson-client') as Promise<TopojsonClientModule>,
+        import('topojson-server') as Promise<TopojsonServerModule>,
+        import('topojson-simplify') as Promise<TopojsonSimplifyModule>,
+      ]);
+      return {
+        feature: client.feature,
+        topology: server.topology,
+        presimplify: simplify.presimplify,
+        simplify: simplify.simplify,
+      };
+    })();
+  }
+  return topojsonRuntimePromise;
+};
+
+export const getTopojsonRuntime = async (): Promise<TopojsonRuntime> => (
+  loadTopojsonRuntime()
+);
+
+export const __getTopojsonRuntimeLoadCount = (): number => topojsonRuntimeLoadCount;
+
+export const __resetTopojsonRuntimeForTests = (): void => {
+  topojsonRuntimePromise = null;
+  topojsonRuntimeLoadCount = 0;
+};

--- a/packages/vt-orchestrator/src/types/topojson-modules.d.mts
+++ b/packages/vt-orchestrator/src/types/topojson-modules.d.mts
@@ -1,0 +1,11 @@
+declare module 'topojson-server' {
+  import type { Topology } from 'topojson-specification';
+  export function topology(objects: Record<string, unknown>): Topology;
+}
+
+declare module 'topojson-simplify' {
+  import type { Topology } from 'topojson-specification';
+  export function presimplify(topology: Topology): Topology;
+  export function simplify(topology: Topology, minWeight?: number): Topology;
+}
+


### PR DESCRIPTION
## Summary
- Move TopoJSON runtime usage behind a dedicated adapter and load modules via dynamic import only when needed.

## Changes
- add `topojsonRuntimeAdapter.ts` to lazily load:
  - `topojson-client`
  - `topojson-server`
  - `topojson-simplify`
- refactor transform decode/simplify/grid paths to call adapter APIs
- remove direct static imports from transform code paths
- add module declarations for `topojson-server` / `topojson-simplify`
- add unit test to ensure non-topojson decode path does not load TopoJSON runtime

## Verification
- `pnpm --filter @hierarchidb/vt-orchestrator typecheck` (exit 0)
- `pnpm --filter @hierarchidb/vt-orchestrator exec vitest run src/transform/__tests__/fetchCacheDecoder.unit.test.ts` (exit 0)
- `pnpm --filter @hierarchidb/vt-orchestrator build` (exit 0)

Refs #227
