### PR TITLE
feat(app): add secure IndexedDB maintenance URL flow

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -39,6 +39,7 @@
 
 ### Doing
 
+- #239 / `codex/feat/maintenance/indexeddb-maintenance-url` / start: 2026-02-13 09:51 JST
 - #236 / `codex/fix/tree/prevent-trash-while-build-running` / start: 2026-02-13 08:01 JST
 - #235 / `ERIA-Cartograph` / start: 2026-02-13 07:30 JST
 - #234 / `codex/fix/shape/cache-identity-gemini-followup` / start: 2026-02-13 07:10 JST
@@ -65,6 +66,15 @@
 
 ## 今日の運用ログ
 
+- update: 2026-02-13 10:38 JST #239 でメンテナンス専用URLフローを実装。`packages/ui/usermenu` に「IndexedDB Maintenance」メニュー導線（ログイン時のみ表示）を追加し、`app/src/maintenance/maintenanceSession.ts` で短命ワンタイムセッション（`msid/msk`）を発行、`app/src/router/pages/maintenance/MaintenancePage.tsx` でURL検証・確認フレーズ入力・メール再確認を通過した場合のみ destructive 処理を実行する構成に変更。
+- update: 2026-02-13 10:38 JST #239 の実行系として `app/src/maintenance/maintenanceExecution.ts` を追加し、(1) maintenance lock 設定、(2) BroadcastChannel による shutdown 要求、(3) local worker shutdown/reset + Dexie close、(4) `indexedDB.deleteDatabase` の blocked リトライ削除、(5) lock解除後 worker 再初期化（upgradeトリガー）を順次実行するよう実装。`app/src/worker-runtime/client.ts` には lock 有効時の初期化拒否ガードを追加。
+- update: 2026-02-13 10:38 JST #239 の適用範囲は `app/src/maintenance/*`, `app/src/router/pages/maintenance/MaintenancePage.tsx`, `app/src/router/routes/maintenanceRoute.tsx`, `app/src/router/index.tsx`, `app/src/router/init/initializeBrowserGlobals.ts`, `app/src/router/pages/home/HomePage.tsx`, `app/src/router/routes/t.($treeId).($pageNodeId).tsx`, `packages/ui/usermenu/src/components/{UserMenu,UserLoginButton}.tsx`, `app/public/locales/*/common.json`, `packages/ui/i18n/public/locales/*/common.json`。
+- update: 2026-02-13 10:38 JST #239 テスト: `pnpm exec turbo run test --filter @hierarchidb/app -- --run src/maintenance/__tests__/maintenanceSession.unit.test.ts src/maintenance/__tests__/maintenanceLock.unit.test.ts src/maintenance/__tests__/maintenanceExecution.unit.test.ts` は exit 0（3 files / 8 tests passed）。
+- blocked: 2026-02-13 10:38 JST #239 `pnpm exec turbo run typecheck --filter @hierarchidb/app --filter @hierarchidb/runtime-worker` は差分外ブロッカー `@hierarchidb/spreadsheet-store#build:types`（`@hierarchidb/ui-grid` 等の module 解決失敗）で exit 2。追加確認として `pnpm --filter @hierarchidb/runtime-worker typecheck` と `pnpm --filter @hierarchidb/ui-usermenu typecheck` は exit 0。`pnpm --filter @hierarchidb/app typecheck` は差分外 `@hierarchidb/tools-load-plugin-manifest` 解決失敗で exit 1。
+- update: 2026-02-13 10:54 JST #239 追補: `app/src/router/__tests__/unit/configure-router-mode.unit.test.ts` の `@tanstack/react-router` モック不足（`createRoute` / `Link`）を部分モック化で修正し、`maintenanceRoute` 追加後も単体テストが崩れないように調整。
+- update: 2026-02-13 10:56 JST #239 再検証: `pnpm exec turbo run test --filter @hierarchidb/app -- --run src/router/__tests__/unit/configure-router-mode.unit.test.ts src/maintenance/__tests__/maintenanceSession.unit.test.ts src/maintenance/__tests__/maintenanceLock.unit.test.ts src/maintenance/__tests__/maintenanceExecution.unit.test.ts` は exit 0（4 files / 25 tests passed）。
+- update: 2026-02-13 10:57 JST #239 型検証: `pnpm exec turbo run typecheck --filter @hierarchidb/ui-usermenu --filter @hierarchidb/runtime-worker` は exit 0。
+- blocked: 2026-02-13 10:58 JST #239 `pnpm exec turbo run typecheck --filter @hierarchidb/app` は差分外既知ブロッカー `@hierarchidb/shape-plugin`（`vtConfig.debug.tiles` readonly `[]` vs mutable `string[]`）で exit 2。
 - update: 2026-02-13 08:24 JST #236 PR #237 のレビュー指摘（`checkRunningBuildSessionGuard` の逐次 I/O）を反映。`TreeMutationService` で `coreDB.getNode` を `Promise.all` 並列化し、shape node 抽出後に `ephemeralShapeDB.sessions.bulkGet` で一括取得する実装へ変更。対応テスト `tree-mutation-trash-build-session-guard.unit.test.ts` も `bulkGet` モックに更新。`pnpm -w turbo run test --filter @hierarchidb/runtime-worker -- --run src/services/__tests__/unit/tree-mutation-trash-build-session-guard.unit.test.ts` は exit 0（2 tests passed）。
 - update: 2026-02-13 08:16 JST #236 の実装を `fix(treeconsole): prevent trash while build session is running` でコミットし、PR `https://github.com/kubohiroya/hierarchidb/pull/237`（base: `ERIA-Cartograph`）を作成。
 - update: 2026-02-13 08:13 JST #236 原因は、ビルドセッション実行中ノードに対するゴミ箱移動ガードが Command API 側に存在せず、UI 側でもコンテキストメニュー（InfoPanel / TreeTable / Breadcrumb）から trash/remove が操作可能だったこと。発生範囲は `packages/runtime-worker/src/services/TreeMutationService.ts` と tree console UI メニュー経路。

--- a/app/public/locales/en/common.json
+++ b/app/public/locales/en/common.json
@@ -59,6 +59,9 @@
       "confirm": "Clear All Data",
       "cancel": "Cancel",
       "error": "Failed to clear some cache data. Please try again."
+    },
+    "maintenance": {
+      "label": "IndexedDB Maintenance"
     }
   },
   "dialogs": {

--- a/app/public/locales/ja/common.json
+++ b/app/public/locales/ja/common.json
@@ -59,6 +59,9 @@
       "confirm": "全データを削除",
       "cancel": "キャンセル",
       "error": "キャッシュの削除に失敗しました。もう一度お試しください。"
+    },
+    "maintenance": {
+      "label": "IndexedDB メンテナンス"
     }
   },
   "dialogs": {

--- a/app/src/maintenance/__tests__/maintenanceExecution.unit.test.ts
+++ b/app/src/maintenance/__tests__/maintenanceExecution.unit.test.ts
@@ -1,0 +1,57 @@
+import {
+  executeIndexedDbMaintenance,
+  type MaintenanceDeleteResult,
+} from '~/maintenance/maintenanceExecution.js';
+import { getMaintenanceLock } from '~/maintenance/maintenanceLock.js';
+
+describe('executeIndexedDbMaintenance', () => {
+  it('returns failure when delete reports blocked databases', async () => {
+    const initializeWorker = vi.fn(async () => undefined);
+
+    const blockedResult: MaintenanceDeleteResult = {
+      deleted: ['core'],
+      blocked: ['shape-ephemeral'],
+      failed: [],
+    };
+
+    const result = await executeIndexedDbMaintenance({
+      sessionId: 'session-blocked',
+      initializeWorker,
+      broadcastShutdown: vi.fn(),
+      shutdownRuntime: vi.fn(async () => ({ warnings: [] })),
+      deleteDatabases: vi.fn(async () => blockedResult),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.blockedDatabases).toEqual(['shape-ephemeral']);
+    expect(result.upgradeAttempted).toBe(false);
+    expect(initializeWorker).not.toHaveBeenCalled();
+    expect(getMaintenanceLock()).toBeNull();
+  });
+
+  it('reinitializes worker after successful delete', async () => {
+    const initializeWorker = vi.fn(async () => undefined);
+    const steps: string[] = [];
+
+    const result = await executeIndexedDbMaintenance({
+      sessionId: 'session-success',
+      initializeWorker,
+      broadcastShutdown: vi.fn(),
+      shutdownRuntime: vi.fn(async () => ({ warnings: ['warn-1'] })),
+      deleteDatabases: vi.fn(async () => ({ deleted: ['core'], blocked: [], failed: [] })),
+      onStep: (event) => {
+        steps.push(event.step);
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.deletedDatabases).toEqual(['core']);
+    expect(result.shutdownWarnings).toEqual(['warn-1']);
+    expect(result.upgradeAttempted).toBe(true);
+    expect(result.upgradeSucceeded).toBe(true);
+    expect(initializeWorker).toHaveBeenCalledTimes(1);
+    expect(steps).toContain('set-lock');
+    expect(steps).toContain('worker-upgrade');
+    expect(getMaintenanceLock()).toBeNull();
+  });
+});

--- a/app/src/maintenance/__tests__/maintenanceLock.unit.test.ts
+++ b/app/src/maintenance/__tests__/maintenanceLock.unit.test.ts
@@ -1,0 +1,34 @@
+import {
+  clearMaintenanceLock,
+  getMaintenanceLock,
+  isMaintenanceLockActive,
+  setMaintenanceLock,
+} from '~/maintenance/maintenanceLock.js';
+
+describe('maintenanceLock', () => {
+  beforeEach(() => {
+    clearMaintenanceLock();
+  });
+
+  it('sets and reads active lock', () => {
+    setMaintenanceLock({
+      sessionId: 'session-1',
+      createdAt: 1_000,
+      expiresAt: 2_000,
+    });
+
+    expect(isMaintenanceLockActive(1_500)).toBe(true);
+    expect(getMaintenanceLock(1_500)?.sessionId).toBe('session-1');
+  });
+
+  it('clears expired lock automatically', () => {
+    setMaintenanceLock({
+      sessionId: 'session-2',
+      createdAt: 1_000,
+      expiresAt: 1_100,
+    });
+
+    expect(isMaintenanceLockActive(1_200)).toBe(false);
+    expect(getMaintenanceLock(1_200)).toBeNull();
+  });
+});

--- a/app/src/maintenance/__tests__/maintenanceSession.unit.test.ts
+++ b/app/src/maintenance/__tests__/maintenanceSession.unit.test.ts
@@ -1,0 +1,59 @@
+import {
+  createMaintenanceSession,
+  createMaintenanceSessionUrl,
+  markMaintenanceSessionConsumed,
+  validateMaintenanceSession,
+  clearMaintenanceSession,
+} from '~/maintenance/maintenanceSession.js';
+
+describe('maintenanceSession', () => {
+  beforeEach(() => {
+    clearMaintenanceSession();
+  });
+
+  it('creates and validates session from generated URL', () => {
+    const { session, url } = createMaintenanceSessionUrl({
+      expectedEmail: 'user@example.com',
+      now: 1_000,
+      ttlMs: 60_000,
+    });
+
+    const parsed = new URL(url);
+    const result = validateMaintenanceSession({
+      sessionId: parsed.searchParams.get('msid'),
+      sessionSecret: parsed.searchParams.get('msk'),
+    }, 30_000);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.session.sessionId).toBe(session.sessionId);
+    expect(result.session.expectedEmail).toBe('user@example.com');
+  });
+
+  it('rejects missing params', () => {
+    createMaintenanceSession();
+    const result = validateMaintenanceSession({ sessionId: null, sessionSecret: null });
+    expect(result).toEqual({ ok: false, reason: 'missing-params' });
+  });
+
+  it('rejects expired session', () => {
+    const session = createMaintenanceSession({ now: 1_000, ttlMs: 500 });
+    const result = validateMaintenanceSession(
+      { sessionId: session.sessionId, sessionSecret: session.sessionSecret },
+      2_000
+    );
+
+    expect(result).toEqual({ ok: false, reason: 'session-expired' });
+  });
+
+  it('rejects consumed session', () => {
+    const session = createMaintenanceSession();
+    markMaintenanceSessionConsumed(session.sessionId, 100);
+    const result = validateMaintenanceSession({
+      sessionId: session.sessionId,
+      sessionSecret: session.sessionSecret,
+    }, 101);
+
+    expect(result).toEqual({ ok: false, reason: 'session-consumed' });
+  });
+});

--- a/app/src/maintenance/maintenanceChannel.ts
+++ b/app/src/maintenance/maintenanceChannel.ts
@@ -1,0 +1,57 @@
+import { shutdownRuntimeHandles } from './runtimeShutdown.js';
+
+const MAINTENANCE_CHANNEL_NAME = 'hdb:maintenance:channel:v1';
+
+type ShutdownRequestMessage = {
+  type: 'shutdown-request';
+  sessionId: string;
+  requestedAt: number;
+};
+
+type MaintenanceChannelMessage = ShutdownRequestMessage;
+
+let initialized = false;
+let persistentChannel: BroadcastChannel | null = null;
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const isShutdownRequestMessage = (value: unknown): value is ShutdownRequestMessage => {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<ShutdownRequestMessage>;
+  return (
+    candidate.type === 'shutdown-request' &&
+    typeof candidate.sessionId === 'string' &&
+    typeof candidate.requestedAt === 'number'
+  );
+};
+
+export const broadcastMaintenanceShutdownRequest = (sessionId: string): void => {
+  if (!isBrowser() || typeof BroadcastChannel === 'undefined') return;
+  const channel = new BroadcastChannel(MAINTENANCE_CHANNEL_NAME);
+  const payload: MaintenanceChannelMessage = {
+    type: 'shutdown-request',
+    sessionId,
+    requestedAt: Date.now(),
+  };
+  channel.postMessage(payload);
+  channel.close();
+};
+
+export const initializeMaintenanceChannel = (): void => {
+  if (!isBrowser() || typeof BroadcastChannel === 'undefined' || initialized) {
+    return;
+  }
+  initialized = true;
+  persistentChannel = new BroadcastChannel(MAINTENANCE_CHANNEL_NAME);
+  persistentChannel.onmessage = (event: MessageEvent<unknown>) => {
+    const payload = event.data;
+    if (!isShutdownRequestMessage(payload)) return;
+    void shutdownRuntimeHandles().catch((error) => {
+      if (import.meta.env.DEV) {
+        console.warn('[maintenance-channel] shutdown request failed', error);
+      }
+    });
+  };
+};
+
+export const getMaintenanceChannelName = (): string => MAINTENANCE_CHANNEL_NAME;

--- a/app/src/maintenance/maintenanceExecution.ts
+++ b/app/src/maintenance/maintenanceExecution.ts
@@ -1,0 +1,271 @@
+import {
+  clearMaintenanceLock,
+  setMaintenanceLock,
+  type MaintenanceLockRecord,
+} from './maintenanceLock.js';
+import { broadcastMaintenanceShutdownRequest } from './maintenanceChannel.js';
+import { shutdownRuntimeHandles, type RuntimeShutdownResult } from './runtimeShutdown.js';
+
+const DEFAULT_LOCK_DURATION_MS = 120_000;
+const DEFAULT_DELETE_RETRIES = 2;
+const DEFAULT_DELETE_TIMEOUT_MS = 2_500;
+const DEFAULT_DELETE_RETRY_DELAY_MS = 600;
+
+export interface MaintenanceDeleteResult {
+  deleted: string[];
+  blocked: string[];
+  failed: Array<{ name: string; errorMessage: string }>;
+}
+
+export interface MaintenanceExecutionResult {
+  success: boolean;
+  deletedDatabases: string[];
+  blockedDatabases: string[];
+  failedDatabases: Array<{ name: string; errorMessage: string }>;
+  shutdownWarnings: string[];
+  upgradeAttempted: boolean;
+  upgradeSucceeded: boolean;
+  message: string;
+}
+
+export interface MaintenanceStepEvent {
+  step:
+    | 'set-lock'
+    | 'broadcast-shutdown'
+    | 'local-shutdown'
+    | 'delete-indexeddb'
+    | 'clear-lock'
+    | 'worker-upgrade';
+  message: string;
+}
+
+export interface ExecuteIndexedDbMaintenanceOptions {
+  sessionId: string;
+  initializeWorker: () => Promise<void>;
+  lockDurationMs?: number;
+  now?: () => number;
+  onStep?: (event: MaintenanceStepEvent) => void;
+  broadcastShutdown?: (sessionId: string) => void;
+  shutdownRuntime?: () => Promise<RuntimeShutdownResult>;
+  deleteDatabases?: () => Promise<MaintenanceDeleteResult>;
+}
+
+type IndexedDbFactoryWithDatabases = IDBFactory & {
+  databases?: () => Promise<Array<{ name?: string }>>;
+};
+
+const wait = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+const resolveIndexedDbFactory = (): IndexedDbFactoryWithDatabases | null => {
+  if (typeof window === 'undefined' || typeof window.indexedDB === 'undefined') {
+    return null;
+  }
+  return window.indexedDB as IndexedDbFactoryWithDatabases;
+};
+
+const listDatabaseNames = async (factory: IndexedDbFactoryWithDatabases): Promise<string[]> => {
+  if (typeof factory.databases !== 'function') {
+    return [];
+  }
+  const databases = await factory.databases();
+  return Array.from(
+    new Set(
+      databases
+        .map((db) => db.name)
+        .filter((name): name is string => typeof name === 'string' && name.length > 0)
+    )
+  );
+};
+
+const deleteDatabaseOnce = async (
+  factory: IndexedDbFactoryWithDatabases,
+  name: string,
+  timeoutMs: number
+): Promise<{ status: 'deleted' | 'blocked' | 'failed'; errorMessage?: string }> => {
+  return await new Promise((resolve) => {
+    const request = factory.deleteDatabase(name);
+    let settled = false;
+    let blocked = false;
+
+    const finish = (
+      status: 'deleted' | 'blocked' | 'failed',
+      errorMessage?: string
+    ): void => {
+      if (settled) return;
+      settled = true;
+      resolve({ status, errorMessage });
+    };
+
+    const timer = setTimeout(() => {
+      finish(blocked ? 'blocked' : 'failed', blocked ? 'delete-blocked-timeout' : 'delete-timeout');
+    }, timeoutMs);
+
+    request.onblocked = () => {
+      blocked = true;
+    };
+
+    request.onsuccess = () => {
+      clearTimeout(timer);
+      finish('deleted');
+    };
+
+    request.onerror = () => {
+      clearTimeout(timer);
+      if (blocked) {
+        finish('blocked', request.error?.message || 'delete-blocked');
+      } else {
+        finish('failed', request.error?.message || 'delete-failed');
+      }
+    };
+  });
+};
+
+export const deleteAllIndexedDbDatabases = async (options?: {
+  retries?: number;
+  timeoutMs?: number;
+  retryDelayMs?: number;
+}): Promise<MaintenanceDeleteResult> => {
+  const factory = resolveIndexedDbFactory();
+  if (!factory) {
+    return {
+      deleted: [],
+      blocked: [],
+      failed: [{ name: '__all__', errorMessage: 'indexeddb-unavailable' }],
+    };
+  }
+
+  const retries = options?.retries ?? DEFAULT_DELETE_RETRIES;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_DELETE_TIMEOUT_MS;
+  const retryDelayMs = options?.retryDelayMs ?? DEFAULT_DELETE_RETRY_DELAY_MS;
+
+  const names = await listDatabaseNames(factory);
+  if (names.length === 0) {
+    return { deleted: [], blocked: [], failed: [] };
+  }
+
+  const deleted = new Set<string>();
+  const failed = new Map<string, string>();
+  let pending = [...names];
+
+  for (let attempt = 0; attempt <= retries && pending.length > 0; attempt += 1) {
+    const results = await Promise.all(
+      pending.map(async (name) => {
+        const outcome = await deleteDatabaseOnce(factory, name, timeoutMs);
+        return { name, ...outcome };
+      })
+    );
+
+    const blockedNext: string[] = [];
+
+    for (const result of results) {
+      if (result.status === 'deleted') {
+        deleted.add(result.name);
+        failed.delete(result.name);
+        continue;
+      }
+      if (result.status === 'blocked') {
+        blockedNext.push(result.name);
+        continue;
+      }
+      failed.set(result.name, result.errorMessage || 'delete-failed');
+    }
+
+    pending = blockedNext;
+    if (pending.length > 0 && attempt < retries) {
+      await wait(retryDelayMs);
+    }
+  }
+
+  return {
+    deleted: Array.from(deleted),
+    blocked: pending,
+    failed: Array.from(failed.entries()).map(([name, errorMessage]) => ({ name, errorMessage })),
+  };
+};
+
+export const executeIndexedDbMaintenance = async (
+  options: ExecuteIndexedDbMaintenanceOptions
+): Promise<MaintenanceExecutionResult> => {
+  const now = options.now ?? (() => Date.now());
+  const lockRecord: MaintenanceLockRecord = {
+    sessionId: options.sessionId,
+    createdAt: now(),
+    expiresAt: now() + (options.lockDurationMs ?? DEFAULT_LOCK_DURATION_MS),
+  };
+
+  const onStep = options.onStep;
+  const broadcastShutdown = options.broadcastShutdown ?? broadcastMaintenanceShutdownRequest;
+  const shutdownRuntime = options.shutdownRuntime ?? shutdownRuntimeHandles;
+  const deleteDatabases = options.deleteDatabases ?? (() => deleteAllIndexedDbDatabases());
+
+  let shutdownWarnings: string[] = [];
+  let deleteResult: MaintenanceDeleteResult = { deleted: [], blocked: [], failed: [] };
+  let upgradeAttempted = false;
+  let upgradeSucceeded = false;
+
+  onStep?.({ step: 'set-lock', message: 'Maintenance lock enabled.' });
+  setMaintenanceLock(lockRecord);
+
+  try {
+    onStep?.({ step: 'broadcast-shutdown', message: 'Sent shutdown request to open tabs.' });
+    broadcastShutdown(options.sessionId);
+
+    onStep?.({ step: 'local-shutdown', message: 'Shutting down local workers and closing handles.' });
+    const shutdownResult = await shutdownRuntime();
+    shutdownWarnings = shutdownResult.warnings;
+
+    onStep?.({ step: 'delete-indexeddb', message: 'Deleting IndexedDB databases.' });
+    deleteResult = await deleteDatabases();
+
+    if (deleteResult.blocked.length > 0 || deleteResult.failed.length > 0) {
+      const blockedCount = deleteResult.blocked.length;
+      const failedCount = deleteResult.failed.length;
+      return {
+        success: false,
+        deletedDatabases: deleteResult.deleted,
+        blockedDatabases: deleteResult.blocked,
+        failedDatabases: deleteResult.failed,
+        shutdownWarnings,
+        upgradeAttempted,
+        upgradeSucceeded,
+        message: `Database delete incomplete (blocked=${blockedCount}, failed=${failedCount}).`,
+      };
+    }
+
+    onStep?.({ step: 'clear-lock', message: 'Clearing maintenance lock before worker upgrade.' });
+    clearMaintenanceLock(options.sessionId);
+
+    onStep?.({ step: 'worker-upgrade', message: 'Re-initializing worker to trigger DB upgrade.' });
+    upgradeAttempted = true;
+    await options.initializeWorker();
+    upgradeSucceeded = true;
+
+    return {
+      success: true,
+      deletedDatabases: deleteResult.deleted,
+      blockedDatabases: [],
+      failedDatabases: [],
+      shutdownWarnings,
+      upgradeAttempted,
+      upgradeSucceeded,
+      message: 'IndexedDB maintenance completed successfully.',
+    };
+  } catch (error) {
+    return {
+      success: false,
+      deletedDatabases: deleteResult.deleted,
+      blockedDatabases: deleteResult.blocked,
+      failedDatabases: deleteResult.failed,
+      shutdownWarnings,
+      upgradeAttempted,
+      upgradeSucceeded,
+      message: `Maintenance execution failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  } finally {
+    clearMaintenanceLock(options.sessionId);
+  }
+};

--- a/app/src/maintenance/maintenanceLock.ts
+++ b/app/src/maintenance/maintenanceLock.ts
@@ -1,0 +1,83 @@
+const MAINTENANCE_LOCK_STORAGE_KEY = 'hdb:maintenance:lock:v1';
+let inMemoryLockRaw: string | null = null;
+
+export interface MaintenanceLockRecord {
+  sessionId: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const parseLock = (raw: string | null): MaintenanceLockRecord | null => {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<MaintenanceLockRecord>;
+    if (
+      typeof parsed.sessionId !== 'string' ||
+      typeof parsed.createdAt !== 'number' ||
+      typeof parsed.expiresAt !== 'number'
+    ) {
+      return null;
+    }
+    return {
+      sessionId: parsed.sessionId,
+      createdAt: parsed.createdAt,
+      expiresAt: parsed.expiresAt,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const readRawLock = (): MaintenanceLockRecord | null => {
+  if (!isBrowser()) return null;
+  try {
+    const localValue = window.localStorage.getItem(MAINTENANCE_LOCK_STORAGE_KEY);
+    const raw = localValue ?? inMemoryLockRaw;
+    return parseLock(raw);
+  } catch {
+    return parseLock(inMemoryLockRaw);
+  }
+};
+
+export const getMaintenanceLock = (now = Date.now()): MaintenanceLockRecord | null => {
+  const lock = readRawLock();
+  if (!lock) return null;
+  if (lock.expiresAt <= now) {
+    clearMaintenanceLock();
+    return null;
+  }
+  return lock;
+};
+
+export const isMaintenanceLockActive = (now = Date.now()): boolean => {
+  return getMaintenanceLock(now) !== null;
+};
+
+export const setMaintenanceLock = (record: MaintenanceLockRecord): void => {
+  const raw = JSON.stringify(record);
+  inMemoryLockRaw = raw;
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(MAINTENANCE_LOCK_STORAGE_KEY, raw);
+  } catch {
+    // best-effort lock; ignore storage failures
+  }
+};
+
+export const clearMaintenanceLock = (sessionId?: string): void => {
+  if (sessionId) {
+    const current = readRawLock();
+    if (!current || current.sessionId !== sessionId) return;
+  }
+  inMemoryLockRaw = null;
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.removeItem(MAINTENANCE_LOCK_STORAGE_KEY);
+  } catch {
+    // ignore storage failures
+  }
+};
+
+export const getMaintenanceLockStorageKey = (): string => MAINTENANCE_LOCK_STORAGE_KEY;

--- a/app/src/maintenance/maintenanceSession.ts
+++ b/app/src/maintenance/maintenanceSession.ts
@@ -1,0 +1,181 @@
+const MAINTENANCE_SESSION_STORAGE_KEY = 'hdb:maintenance:session:v1';
+let inMemorySessionRaw: string | null = null;
+
+const DEFAULT_SESSION_TTL_MS = 90_000;
+const CONFIRMATION_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+export interface MaintenanceSessionRecord {
+  sessionId: string;
+  sessionSecret: string;
+  confirmationCode: string;
+  expectedEmail: string | null;
+  createdAt: number;
+  expiresAt: number;
+  consumedAt: number | null;
+}
+
+export type MaintenanceSessionValidationResult =
+  | { ok: true; session: MaintenanceSessionRecord }
+  | {
+      ok: false;
+      reason:
+        | 'missing-params'
+        | 'missing-session'
+        | 'session-mismatch'
+        | 'session-expired'
+        | 'session-consumed';
+    };
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const randomToken = (bytes: number): string => {
+  const values = new Uint8Array(bytes);
+  crypto.getRandomValues(values);
+  return Array.from(values)
+    .map((value) => value.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+const randomCode = (length = 6): string => {
+  const values = new Uint8Array(length);
+  crypto.getRandomValues(values);
+  return Array.from(values)
+    .map((value) => CONFIRMATION_CODE_CHARS[value % CONFIRMATION_CODE_CHARS.length])
+    .join('');
+};
+
+const parseSession = (raw: string | null): MaintenanceSessionRecord | null => {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<MaintenanceSessionRecord>;
+    if (
+      typeof parsed.sessionId !== 'string' ||
+      typeof parsed.sessionSecret !== 'string' ||
+      typeof parsed.confirmationCode !== 'string' ||
+      typeof parsed.createdAt !== 'number' ||
+      typeof parsed.expiresAt !== 'number'
+    ) {
+      return null;
+    }
+    return {
+      sessionId: parsed.sessionId,
+      sessionSecret: parsed.sessionSecret,
+      confirmationCode: parsed.confirmationCode,
+      expectedEmail: typeof parsed.expectedEmail === 'string' ? parsed.expectedEmail : null,
+      createdAt: parsed.createdAt,
+      expiresAt: parsed.expiresAt,
+      consumedAt: typeof parsed.consumedAt === 'number' ? parsed.consumedAt : null,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const writeSession = (record: MaintenanceSessionRecord): void => {
+  const raw = JSON.stringify(record);
+  inMemorySessionRaw = raw;
+  if (!isBrowser()) return;
+  window.sessionStorage.setItem(MAINTENANCE_SESSION_STORAGE_KEY, raw);
+};
+
+export const clearMaintenanceSession = (): void => {
+  inMemorySessionRaw = null;
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.removeItem(MAINTENANCE_SESSION_STORAGE_KEY);
+  } catch {
+    // ignore storage failures
+  }
+};
+
+export const getStoredMaintenanceSession = (): MaintenanceSessionRecord | null => {
+  if (!isBrowser()) return parseSession(inMemorySessionRaw);
+  try {
+    const sessionValue = window.sessionStorage.getItem(MAINTENANCE_SESSION_STORAGE_KEY);
+    return parseSession(sessionValue ?? inMemorySessionRaw);
+  } catch {
+    return parseSession(inMemorySessionRaw);
+  }
+};
+
+export const createMaintenanceSession = (options?: {
+  expectedEmail?: string | null;
+  ttlMs?: number;
+  now?: number;
+}): MaintenanceSessionRecord => {
+  const now = options?.now ?? Date.now();
+  const ttlMs = options?.ttlMs ?? DEFAULT_SESSION_TTL_MS;
+  const record: MaintenanceSessionRecord = {
+    sessionId: randomToken(12),
+    sessionSecret: randomToken(16),
+    confirmationCode: randomCode(6),
+    expectedEmail: options?.expectedEmail?.trim() || null,
+    createdAt: now,
+    expiresAt: now + ttlMs,
+    consumedAt: null,
+  };
+  writeSession(record);
+  return record;
+};
+
+export const buildMaintenanceUrl = (record: MaintenanceSessionRecord): string => {
+  if (!isBrowser()) return '/maintenance';
+  const basePath = import.meta.env.BASE_URL || '/';
+  const relativePath = `${basePath.replace(/\/+$/, '')}/maintenance`;
+  const url = new URL(relativePath, window.location.origin);
+  url.searchParams.set('msid', record.sessionId);
+  url.searchParams.set('msk', record.sessionSecret);
+  return url.toString();
+};
+
+export const createMaintenanceSessionUrl = (options?: {
+  expectedEmail?: string | null;
+  ttlMs?: number;
+  now?: number;
+}): { session: MaintenanceSessionRecord; url: string } => {
+  const session = createMaintenanceSession(options);
+  return { session, url: buildMaintenanceUrl(session) };
+};
+
+export const validateMaintenanceSession = (
+  params: { sessionId?: string | null; sessionSecret?: string | null },
+  now = Date.now()
+): MaintenanceSessionValidationResult => {
+  const sessionId = params.sessionId ?? null;
+  const sessionSecret = params.sessionSecret ?? null;
+
+  if (!sessionId || !sessionSecret) {
+    return { ok: false, reason: 'missing-params' };
+  }
+
+  const stored = getStoredMaintenanceSession();
+  if (!stored) {
+    return { ok: false, reason: 'missing-session' };
+  }
+
+  if (stored.expiresAt <= now) {
+    clearMaintenanceSession();
+    return { ok: false, reason: 'session-expired' };
+  }
+
+  if (stored.sessionId !== sessionId || stored.sessionSecret !== sessionSecret) {
+    return { ok: false, reason: 'session-mismatch' };
+  }
+
+  if (stored.consumedAt !== null) {
+    return { ok: false, reason: 'session-consumed' };
+  }
+
+  return { ok: true, session: stored };
+};
+
+export const markMaintenanceSessionConsumed = (sessionId: string, now = Date.now()): void => {
+  const stored = getStoredMaintenanceSession();
+  if (!stored || stored.sessionId !== sessionId) return;
+  writeSession({
+    ...stored,
+    consumedAt: now,
+  });
+};
+
+export const getMaintenanceSessionStorageKey = (): string => MAINTENANCE_SESSION_STORAGE_KEY;

--- a/app/src/maintenance/runtimeShutdown.ts
+++ b/app/src/maintenance/runtimeShutdown.ts
@@ -1,0 +1,56 @@
+import { Dexie } from 'dexie';
+import { geosWorkerClient } from '~/geos/geosWorkerClient.js';
+
+type WorkerClientRefLike = {
+  client?: {
+    shutdown?: () => Promise<void>;
+  } | null;
+  reset?: () => void;
+};
+type MaintenanceWindow = Window & {
+  __HDB_WORKER_CLIENT_REF__?: WorkerClientRefLike;
+};
+
+export interface RuntimeShutdownResult {
+  warnings: string[];
+}
+
+export async function shutdownRuntimeHandles(): Promise<RuntimeShutdownResult> {
+  const warnings: string[] = [];
+
+  if (typeof window !== 'undefined') {
+    const ref = (window as MaintenanceWindow).__HDB_WORKER_CLIENT_REF__;
+    try {
+      if (typeof ref?.client?.shutdown === 'function') {
+        await ref.client.shutdown();
+      }
+    } catch (error) {
+      warnings.push(
+        `worker-shutdown-failed:${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    try {
+      if (typeof ref?.reset === 'function') {
+        ref.reset();
+      }
+    } catch (error) {
+      warnings.push(`worker-reset-failed:${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  try {
+    const closeAll = (Dexie as unknown as { closeAll?: () => void }).closeAll;
+    closeAll?.();
+  } catch (error) {
+    warnings.push(`dexie-close-failed:${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  try {
+    geosWorkerClient.shutdown();
+  } catch (error) {
+    warnings.push(`geos-shutdown-failed:${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return { warnings };
+}

--- a/app/src/router/__tests__/unit/configure-router-mode.unit.test.ts
+++ b/app/src/router/__tests__/unit/configure-router-mode.unit.test.ts
@@ -16,12 +16,17 @@ vi.mock('../../loaders/uiPlugins.js', () => ({
   }),
 }));
 
-vi.mock('@tanstack/react-router', () => ({
-  createRouter: vi.fn(({ history }) => ({ history })),
-  createBrowserHistory: vi.fn(() => ({ location: {} })),
-  createHashHistory: vi.fn(() => ({ location: {} })),
-  createMemoryHistory: vi.fn(() => ({ location: {} })),
-}));
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    createRoute: vi.fn(() => createMockRoute()),
+    createRouter: vi.fn(({ history }) => ({ history })),
+    createBrowserHistory: vi.fn(() => ({ location: {} })),
+    createHashHistory: vi.fn(() => ({ location: {} })),
+    createMemoryHistory: vi.fn(() => ({ location: {} })),
+  };
+});
 
 vi.mock('../../routes/rootRoute.js', () => ({
   rootRoute: createMockRoute(),
@@ -37,6 +42,10 @@ vi.mock('../../routes/infoRoute.js', () => ({
 
 vi.mock('../../routes/mapRoute.js', () => ({
   mapRoute: createMockRoute(),
+}));
+
+vi.mock('../../routes/maintenanceRoute.js', () => ({
+  maintenanceRoute: createMockRoute(),
 }));
 
 vi.mock('../../routes/auth/index.js', () => ({

--- a/app/src/router/index.tsx
+++ b/app/src/router/index.tsx
@@ -38,6 +38,7 @@ export async function createHierarchiRouter(config: RouterConfig) {
   const { indexRoute } = await import('./routes/indexRoute.js');
   const { infoRoute } = await import('./routes/infoRoute.js');
   const { mapRoute } = await import('./routes/mapRoute.js');
+  const { maintenanceRoute } = await import('./routes/maintenanceRoute.js');
   const { authLoginRoute, authCallbackRoute, authSilentRenewRoute } = await import(
     './routes/auth/index.js'
   );
@@ -80,6 +81,7 @@ export async function createHierarchiRouter(config: RouterConfig) {
     indexRoute,
     infoRoute,
     mapRoute,
+    maintenanceRoute,
     authLoginRoute,
     authCallbackRoute,
     authSilentRenewRoute,

--- a/app/src/router/init/initializeBrowserGlobals.ts
+++ b/app/src/router/init/initializeBrowserGlobals.ts
@@ -1,4 +1,5 @@
 import { getWorkerClientHook, registerWorkerClientHook } from '@hierarchidb/ui-worker-provider';
+import { initializeMaintenanceChannel } from '~/maintenance/maintenanceChannel.js';
 import { pluginRegistry } from '~/plugin-loaders/index.ts';
 import { useWorker } from '../../contexts/WorkerProvider.js';
 import { bootLog } from '../../utils/bootLog.ts';
@@ -105,6 +106,7 @@ export function initializeBrowserGlobals(): void {
   if (initialized) return;
   initialized = true;
 
+  initializeMaintenanceChannel();
   registerWorkerClientHook(useWorker);
 
   const localBuildTime = (() => {

--- a/app/src/router/pages/home/HomePage.tsx
+++ b/app/src/router/pages/home/HomePage.tsx
@@ -1,6 +1,9 @@
 import type { TreeConfig } from '@hierarchidb/ui-plugin-shell/components';
 import { TreeToggleButtonGroup } from '@hierarchidb/ui-plugin-shell/components';
-import { UserLoginButton } from '@hierarchidb/ui-plugin-shell/ui-usermenu';
+import {
+  type OpenMaintenanceContext,
+  UserLoginButton,
+} from '@hierarchidb/ui-plugin-shell/ui-usermenu';
 import {
   Extension as ExtensionIcon,
   Folder,
@@ -11,6 +14,7 @@ import {
 import { Box, Button, IconButton, Tooltip } from '@mui/material';
 import { useMemo } from 'react';
 import { loadAppConfig, resolveAssetHref } from '~/loadAppConfig.js';
+import { createMaintenanceSessionUrl } from '~/maintenance/maintenanceSession.js';
 import { APP_VERSION, BUILD_TIME } from '../../../version.ts';
 import { TitleLogo } from './TitleLogo.js';
 import { TopPageGuidedTour } from './tour/TopPageGuidedTour.js';
@@ -86,6 +90,14 @@ export default function HomePage() {
     );
   }, [githubHref]);
 
+  const handleOpenMaintenance = (context: OpenMaintenanceContext) => {
+    if (typeof window === 'undefined') return;
+    const { url } = createMaintenanceSessionUrl({
+      expectedEmail: context.userEmail,
+    });
+    window.location.assign(url);
+  };
+
   return (
     <>
       <Box
@@ -120,7 +132,7 @@ export default function HomePage() {
           </div>
           {isUserMenuReady ? (
             <Box data-tour-id="home-user-menu">
-              <UserLoginButton />
+              <UserLoginButton onOpenMaintenance={handleOpenMaintenance} />
             </Box>
           ) : null}
         </div>

--- a/app/src/router/pages/maintenance/MaintenancePage.tsx
+++ b/app/src/router/pages/maintenance/MaintenancePage.tsx
@@ -1,0 +1,210 @@
+import { useAuth } from '@hierarchidb/ui-plugin-shell/ui-auth';
+import {
+  Alert,
+  Box,
+  Button,
+  Container,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useLocation, useNavigate } from '@tanstack/react-router';
+import { useMemo, useState } from 'react';
+import { useWorker } from '~/contexts/WorkerProvider.js';
+import {
+  executeIndexedDbMaintenance,
+  type MaintenanceExecutionResult,
+  type MaintenanceStepEvent,
+} from '~/maintenance/maintenanceExecution.js';
+import {
+  clearMaintenanceSession,
+  markMaintenanceSessionConsumed,
+  validateMaintenanceSession,
+} from '~/maintenance/maintenanceSession.js';
+
+const invalidReasonMessage = (reason: string): string => {
+  switch (reason) {
+    case 'missing-params':
+      return 'Maintenance URL is missing required parameters.';
+    case 'missing-session':
+      return 'Maintenance session was not found. Start again from the user menu.';
+    case 'session-mismatch':
+      return 'Maintenance session did not match this browser session.';
+    case 'session-expired':
+      return 'Maintenance session expired. Start again from the user menu.';
+    case 'session-consumed':
+      return 'This maintenance session has already been used.';
+    default:
+      return 'Maintenance session is invalid.';
+  }
+};
+
+export default function MaintenancePage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const worker = useWorker();
+  const { user } = useAuth();
+
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const sessionId = searchParams.get('msid');
+  const sessionSecret = searchParams.get('msk');
+
+  const validation = useMemo(
+    () => validateMaintenanceSession({ sessionId, sessionSecret }),
+    [sessionId, sessionSecret]
+  );
+
+  const [confirmationInput, setConfirmationInput] = useState('');
+  const [emailInput, setEmailInput] = useState('');
+  const [execution, setExecution] = useState<MaintenanceExecutionResult | null>(null);
+  const [executionSteps, setExecutionSteps] = useState<MaintenanceStepEvent[]>([]);
+  const [running, setRunning] = useState(false);
+
+  const expectedPhrase = validation.ok ? `DELETE ${validation.session.confirmationCode}` : '';
+  const expectedEmail = validation.ok ? validation.session.expectedEmail : null;
+  const loggedInEmail = user?.profile?.email?.trim() || '';
+
+  const emailMatched =
+    !expectedEmail || emailInput.trim().toLowerCase() === expectedEmail.trim().toLowerCase();
+  const confirmationMatched =
+    validation.ok && confirmationInput.trim().toUpperCase() === expectedPhrase;
+
+  const canExecute = validation.ok && confirmationMatched && emailMatched && !running;
+
+  const startExecution = async () => {
+    if (!validation.ok || !canExecute) return;
+
+    markMaintenanceSessionConsumed(validation.session.sessionId);
+    setRunning(true);
+    setExecution(null);
+    setExecutionSteps([]);
+
+    const result = await executeIndexedDbMaintenance({
+      sessionId: validation.session.sessionId,
+      initializeWorker: worker.initialize,
+      onStep: (step) => {
+        setExecutionSteps((prev) => [...prev, step]);
+      },
+    });
+
+    if (result.success) {
+      clearMaintenanceSession();
+    }
+
+    setExecution(result);
+    setRunning(false);
+  };
+
+  if (!validation.ok) {
+    return (
+      <Container maxWidth="sm" sx={{ py: 6 }}>
+        <Paper sx={{ p: 3 }}>
+          <Typography variant="h5" gutterBottom>
+            IndexedDB Maintenance
+          </Typography>
+          <Alert severity="error" sx={{ mb: 3 }}>
+            {invalidReasonMessage(validation.reason)}
+          </Alert>
+          <Button variant="contained" onClick={() => navigate({ to: '/' })}>
+            Back to Home
+          </Button>
+        </Paper>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 5 }}>
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="h5" gutterBottom>
+          IndexedDB Maintenance
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          This flow stops worker runtimes, deletes IndexedDB databases, and reinitializes worker
+          services to run schema upgrades. This action is destructive.
+        </Typography>
+
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Continue only if you explicitly intend to reset local IndexedDB state.
+        </Alert>
+
+        <Stack spacing={2} sx={{ mb: 2 }}>
+          <TextField
+            label="Confirmation phrase"
+            value={confirmationInput}
+            onChange={(event) => setConfirmationInput(event.target.value)}
+            placeholder={expectedPhrase}
+            helperText={`Type exactly: ${expectedPhrase}`}
+            fullWidth
+          />
+
+          {expectedEmail ? (
+            <TextField
+              label="Account email confirmation"
+              value={emailInput}
+              onChange={(event) => setEmailInput(event.target.value)}
+              placeholder={expectedEmail}
+              helperText={`Type the account email to continue${
+                loggedInEmail ? ` (signed-in: ${loggedInEmail})` : ''
+              }.`}
+              fullWidth
+            />
+          ) : null}
+        </Stack>
+
+        <Stack direction="row" spacing={1.5} sx={{ mb: 2 }}>
+          <Button variant="contained" color="error" disabled={!canExecute} onClick={startExecution}>
+            {running ? 'Running…' : 'Run Maintenance'}
+          </Button>
+          <Button variant="outlined" onClick={() => navigate({ to: '/' })} disabled={running}>
+            Cancel
+          </Button>
+        </Stack>
+
+        {executionSteps.length > 0 ? (
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>
+              Progress
+            </Typography>
+            <List dense>
+              {executionSteps.map((step, index) => (
+                <ListItem key={`${step.step}-${index}`} disableGutters>
+                  <ListItemText primary={step.message} secondary={step.step} />
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        ) : null}
+
+        {execution ? (
+          <Alert severity={execution.success ? 'success' : 'error'} sx={{ mb: 2 }}>
+            {execution.message}
+          </Alert>
+        ) : null}
+
+        {execution && execution.blockedDatabases.length > 0 ? (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            Blocked databases: {execution.blockedDatabases.join(', ')}. Close other tabs and retry
+            from the user menu.
+          </Alert>
+        ) : null}
+
+        {execution && execution.failedDatabases.length > 0 ? (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            Failed databases: {execution.failedDatabases.map((item) => item.name).join(', ')}
+          </Alert>
+        ) : null}
+
+        {execution && execution.success ? (
+          <Button variant="contained" onClick={() => navigate({ to: '/' })}>
+            Return to Home
+          </Button>
+        ) : null}
+      </Paper>
+    </Container>
+  );
+}

--- a/app/src/router/routes/maintenanceRoute.tsx
+++ b/app/src/router/routes/maintenanceRoute.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import MaintenancePage from '~/router/pages/maintenance/MaintenancePage.js';
+import { rootRoute } from './rootRoute.js';
+
+export const maintenanceRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/maintenance',
+  component: MaintenancePage,
+});

--- a/app/src/router/routes/t.($treeId).($pageNodeId).tsx
+++ b/app/src/router/routes/t.($treeId).($pageNodeId).tsx
@@ -7,7 +7,10 @@ import {
   TargetNodeContextProvider,
   TreeContextProvider,
 } from '@hierarchidb/ui-batch-progress';
-import { UserLoginButton } from '@hierarchidb/ui-plugin-shell/ui-usermenu';
+import {
+  type OpenMaintenanceContext,
+  UserLoginButton,
+} from '@hierarchidb/ui-plugin-shell/ui-usermenu';
 import {
   AppBar,
   Box,
@@ -30,6 +33,7 @@ import AppLogoIcon from '~/components/AppLogoIcon.js';
 import { BuildSessionLauncherButtons } from '~/components/BuildSessionLauncherButtons.js';
 import { useOptionalBootProgress } from '~/contexts/BootProgressProvider.js';
 import { useWorker } from '~/contexts/WorkerProvider.js';
+import { createMaintenanceSessionUrl } from '~/maintenance/maintenanceSession.js';
 import type { TreeConsoleIntegrationProps } from '~/router/pages/tree/console/TreeConsoleIntegration.js';
 import type {
   LoadNodeActionReturn,
@@ -173,6 +177,14 @@ export function TreeLayoutBody({ data }: TreeLayoutBodyProps) {
   }, [workerClient]);
 
   const pageName = data.pageNode?.metadata?.name || data.tree?.name || 'TreeTypes Console';
+  const handleOpenMaintenance = (context: OpenMaintenanceContext) => {
+    if (typeof window === 'undefined') return;
+    const { url } = createMaintenanceSessionUrl({
+      expectedEmail: context.userEmail,
+    });
+    window.location.assign(url);
+  };
+
   const targetContext = useMemo<TargetContextState>(() => {
     const dialogData = dialogMatch?.loaderData as TreeDialogMatchData | undefined;
     if (dialogData?.kind === 'plugin') {
@@ -236,7 +248,7 @@ export function TreeLayoutBody({ data }: TreeLayoutBodyProps) {
                         ) : null}
                         {isUserMenuReady ? (
                           <Box sx={{ ml: '8px' }}>
-                            <UserLoginButton />
+                            <UserLoginButton onOpenMaintenance={handleOpenMaintenance} />
                           </Box>
                         ) : null}
                       </Stack>

--- a/app/src/worker-runtime/client.ts
+++ b/app/src/worker-runtime/client.ts
@@ -6,6 +6,7 @@ import type { WorkerAPI } from '~/types/worker-api.js';
 import type { Remote } from 'comlink';
 import { bootLog } from '~/utils/bootLog.ts';
 import { APP_VERSION } from '~/version.ts';
+import { isMaintenanceLockActive } from '~/maintenance/maintenanceLock.js';
 import workerScriptUrl from './worker.ts?worker&url';
 import sharedWorkerScriptUrl from './shared-worker.ts?sharedworker&url';
 
@@ -205,7 +206,14 @@ const cleanupWorkerHandles = () => {
   workerInitCompleted = false;
 };
 
+const ensureMaintenanceUnlocked = (): void => {
+  if (!isMaintenanceLockActive()) return;
+  cleanupWorkerHandles();
+  throw new Error('maintenance-lock-active');
+};
+
 export async function initializeWorker(): Promise<Remote<WorkerAPI>> {
+  ensureMaintenanceUnlocked();
   const RETRY_DELAYS = [2000, 3000, 7000];
   for (let attempt = 0; attempt <= RETRY_DELAYS.length; attempt++) {
     // Reduce console noise; log only via bootLog when explicitly enabled
@@ -256,6 +264,7 @@ export async function initializeWorker(): Promise<Remote<WorkerAPI>> {
 }
 
 export async function getWorkerClient(): Promise<Remote<WorkerAPI>> {
+  ensureMaintenanceUnlocked();
   if (!workerInstance) return await initializeWorker();
   return workerInstance;
 }

--- a/packages/ui/i18n/public/locales/en/common.json
+++ b/packages/ui/i18n/public/locales/en/common.json
@@ -49,6 +49,9 @@
       "confirm": "Clear All Data",
       "cancel": "Cancel",
       "error": "Failed to clear some cache data. Please try again."
+    },
+    "maintenance": {
+      "label": "IndexedDB Maintenance"
     }
   },
   "common": {

--- a/packages/ui/i18n/public/locales/ja/common.json
+++ b/packages/ui/i18n/public/locales/ja/common.json
@@ -49,6 +49,9 @@
       "confirm": "全データを削除",
       "cancel": "キャンセル",
       "error": "キャッシュの削除に失敗しました。もう一度お試しください。"
+    },
+    "maintenance": {
+      "label": "IndexedDB メンテナンス"
     }
   },
   "common": {

--- a/packages/ui/usermenu/src/components/UserLoginButton.tsx
+++ b/packages/ui/usermenu/src/components/UserLoginButton.tsx
@@ -10,6 +10,15 @@ import { ThemeMenu } from './ThemeMenu.js';
 import { UserMenu } from './UserMenu.js';
 import { useUserMenu } from './useUserMenu.js';
 
+export interface OpenMaintenanceContext {
+  userEmail: string | null;
+  isAuthenticated: boolean;
+}
+
+interface UserLoginButtonProps {
+  onOpenMaintenance?: (context: OpenMaintenanceContext) => void;
+}
+
 const buildLanguageOptions = (
   supportedLanguages: Array<{ code: string; name?: string; nativeName?: string; flag?: string }>,
   t: (key: string, defaultValue?: string) => string
@@ -30,7 +39,7 @@ const buildLanguageOptions = (
   return [systemOption, ...mapped];
 };
 
-export const UserLoginButton: React.FC = () => {
+export const UserLoginButton: React.FC<UserLoginButtonProps> = ({ onOpenMaintenance }) => {
   const { t } = useTranslation('common');
   const [pendingAuthDialogOpen, setPendingAuthDialogOpen] = useState(false);
 
@@ -94,6 +103,14 @@ export const UserLoginButton: React.FC = () => {
     menu.openAuthDialog();
   };
 
+  const handleOpenMaintenance = () => {
+    onOpenMaintenance?.({
+      userEmail: menu.userEmail || null,
+      isAuthenticated: menu.isAuthenticated,
+    });
+    handleMenuClose();
+  };
+
   return (
     <>
       <IconButton
@@ -132,6 +149,7 @@ export const UserLoginButton: React.FC = () => {
         onOpenThemeMenu={menu.openThemeMenu}
         onOpenLanguageMenu={menu.openLanguageMenu}
         onOpenClearDialog={menu.openClearDatabaseDialog}
+        onOpenMaintenance={onOpenMaintenance ? handleOpenMaintenance : undefined}
         onLogin={handleLogin}
         onMenuExited={handleMenuExited}
         onLogout={menu.handleLogout}

--- a/packages/ui/usermenu/src/components/UserMenu.tsx
+++ b/packages/ui/usermenu/src/components/UserMenu.tsx
@@ -1,6 +1,7 @@
 import type { ThemeMode } from '@hierarchidb/ui-theme';
 import {
   DarkMode as DarkModeIcon,
+  Engineering as EngineeringIcon,
   DeleteForever as DeleteForeverIcon,
   Language as LanguageIcon,
   LightMode as LightModeIcon,
@@ -27,6 +28,7 @@ interface UserMenuProps {
   onOpenThemeMenu: (anchor: HTMLElement) => void;
   onOpenLanguageMenu: (anchor: HTMLElement) => void;
   onOpenClearDialog: () => void;
+  onOpenMaintenance?: () => void;
   onLogin: () => void;
   onMenuExited?: () => void;
   onLogout: () => void;
@@ -54,6 +56,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({
   onOpenThemeMenu,
   onOpenLanguageMenu,
   onOpenClearDialog,
+  onOpenMaintenance,
   onLogin,
   onMenuExited,
   onLogout,
@@ -145,6 +148,20 @@ export const UserMenu: React.FC<UserMenuProps> = ({
         </ListItemIcon>
         <ListItemText>{t('userMenu.clear.label', 'Clear All Data')}</ListItemText>
       </MenuItem>
+
+      {onOpenMaintenance && isAuthenticated ? (
+        <MenuItem
+          onClick={onOpenMaintenance}
+          aria-label={String(t('userMenu.maintenance.label', 'IndexedDB Maintenance'))}
+        >
+          <ListItemIcon>
+            <EngineeringIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>
+            {t('userMenu.maintenance.label', 'IndexedDB Maintenance')}
+          </ListItemText>
+        </MenuItem>
+      ) : null}
 
       <Divider />
 

--- a/plans/indexeddb-maintenance-url-execplan.md
+++ b/plans/indexeddb-maintenance-url-execplan.md
@@ -1,0 +1,168 @@
+# Secure IndexedDB Maintenance URL With Explicit User Consent
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document follows `/Users/hiroya/WebstormProjects/hierarchidb/PLANS.md` and must be maintained in accordance with that file.
+
+## Purpose / Big Picture
+
+After this change, users can open a dedicated maintenance URL that is valid only when initiated from the in-app user menu. On that page, they must complete explicit consent before destructive operations run. The maintenance execution then shuts down active worker clients, prevents new worker initialization during the operation, deletes app IndexedDB databases with blocked-state handling, and re-initializes the worker runtime so database upgrades can run cleanly.
+
+The behavior is observable: open the user menu, start maintenance, confirm on `/maintenance`, and verify that deletion succeeds (or shows blocked databases with actionable guidance) and worker re-initialization completes.
+
+## Progress
+
+- [x] (2026-02-13 00:56Z) Investigated current clear-data behavior in `@hierarchidb/ui-usermenu` and confirmed it deletes IndexedDB directly without a dedicated maintenance route.
+- [x] (2026-02-13 01:02Z) Confirmed worker lifecycle controls available via `WorkerAPI.shutdown()` and `WorkerProvider.reset()` (`app/src/contexts/WorkerProvider.tsx`, `packages/worker-api/src/WorkerAPI.ts`).
+- [x] (2026-02-13 01:05Z) Confirmed route wiring points in `app/src/router/index.tsx` and top-level user-menu consumers in home/tree layouts.
+- [x] (2026-02-13 01:24Z) Implemented maintenance session issuance/validation utilities under `app/src/maintenance/maintenanceSession.ts`.
+- [x] (2026-02-13 01:26Z) Implemented maintenance lock and enforced it in `app/src/worker-runtime/client.ts`.
+- [x] (2026-02-13 01:28Z) Implemented maintenance execution orchestration (`maintenanceExecution.ts`, `maintenanceChannel.ts`, `runtimeShutdown.ts`).
+- [x] (2026-02-13 01:31Z) Added `/maintenance` route and page with explicit consent UI (`maintenanceRoute.tsx`, `MaintenancePage.tsx`).
+- [x] (2026-02-13 01:33Z) Added user-menu entry and app callbacks to open maintenance URL from home/tree layouts.
+- [x] (2026-02-13 01:34Z) Added localization strings for maintenance entry in app/package locale bundles.
+- [x] (2026-02-13 01:36Z) Added unit tests for session, lock, and execution blocked/success behavior.
+- [x] (2026-02-13 01:38Z) Ran test/typecheck commands, updated `TASKS.md`, and documented external blockers.
+- [x] (2026-02-13 01:57Z) Fixed router unit-test mock compatibility (`configure-router-mode`) for `maintenanceRoute` addition and re-ran targeted app tests.
+
+## Surprises & Discoveries
+
+- Observation: There are two clear-data implementations (`packages/ui/auth` legacy and active `packages/ui/usermenu` path). The app uses `UserLoginButton` from `ui-usermenu`.
+  Evidence: `app/src/router/pages/home/HomePage.tsx` and `app/src/router/routes/t.($treeId).($pageNodeId).tsx` import `@hierarchidb/ui-plugin-shell/ui-usermenu`.
+- Observation: A developer-only IndexedDB reset path already exists and uses plugin-aware clearing (`app/src/router/pages/tree/console/useIndexedDbReset.ts`, `app/src/plugin-runtime/clearIndexedDb.ts`).
+  Evidence: existing `clearAppIndexedDBsViaPlugins()` implementation and toolbar integration.
+- Observation: localStorage/sessionStorage can be unavailable in test/runtime contexts, causing lock/session writes to no-op.
+  Evidence: Vitest output included `--localstorage-file` warnings and initial lock test failed until memory fallback was added.
+- Observation: Turbo typecheck graph currently fails in unrelated packages even when filtering app/runtime-worker in this worktree.
+  Evidence: `@hierarchidb/spreadsheet-store#build:types` cannot resolve `@hierarchidb/ui-grid` and `@hierarchidb/ui-modal-select`.
+- Observation: `configure-router-mode` test used a full mock for `@tanstack/react-router`, which broke `Link` export resolution after route graph changes.
+  Evidence: Vitest error `No "Link" export is defined on the "@tanstack/react-router" mock` until partial mock (`importOriginal`) was applied.
+
+## Decision Log
+
+- Decision: Keep the existing “Clear All Data” path untouched and add a separate maintenance flow entry.
+  Rationale: We need a safer gated path without regressing existing user behavior.
+  Date/Author: 2026-02-13 / Codex
+- Decision: Implement short-lived session token validation in browser storage for maintenance route access control.
+  Rationale: This blocks direct-link execution unless the flow was initiated intentionally in-app.
+  Date/Author: 2026-02-13 / Codex
+- Decision: Enforce a maintenance lock in worker initialization (`client.ts`) so new worker DB usage is blocked during destructive operations.
+  Rationale: Requirement explicitly asks to terminate worker usage and prevent DB re-open races while deleting.
+  Date/Author: 2026-02-13 / Codex
+- Decision: Show maintenance menu only for authenticated users.
+  Rationale: Reduces accidental/unauthenticated invocation and aligns with user-identity confirmation intent.
+  Date/Author: 2026-02-13 / Codex
+- Decision: Add in-memory fallback for maintenance lock/session storage.
+  Rationale: Keeps behavior deterministic when browser storage is unavailable or restricted.
+  Date/Author: 2026-02-13 / Codex
+
+## Outcomes & Retrospective
+
+Implemented the full maintenance URL flow with explicit consent and one-time session gating, integrated from avatar menu to a new `/maintenance` route. The route now validates short-lived session credentials, requires typed destructive confirmation (and email confirmation when available), executes worker shutdown/reset plus IndexedDB deletion with blocked handling, and re-initializes the worker runtime to trigger upgrades.
+
+New unit tests (`maintenanceSession`, `maintenanceLock`, `maintenanceExecution`) all pass, and router compatibility test (`configure-router-mode`) also passes after mock adjustment. Runtime-worker and ui-usermenu typechecks pass. Full `@hierarchidb/app` turbo typecheck remains blocked by pre-existing `@hierarchidb/shape-plugin` readonly/mutable mismatch (`vtConfig.debug.tiles`), which was logged in `TASKS.md`.
+
+## Context and Orientation
+
+The active user menu is implemented in `packages/ui/usermenu/src/components/UserLoginButton.tsx` and `packages/ui/usermenu/src/components/useUserMenu.ts`. Today it exposes a dialog that directly clears caches, IndexedDB, and localStorage. The app mounts this menu in `app/src/router/pages/home/HomePage.tsx` and `app/src/router/routes/t.($treeId).($pageNodeId).tsx`.
+
+The worker runtime is globally managed by `app/src/contexts/WorkerProvider.tsx` using `WorkerAPIClient` and state helpers in `app/src/worker-runtime/`. Worker APIs include `shutdown()` (`packages/worker-api/src/WorkerAPI.ts`), and `WorkerService.shutdown()` closes DB handles in the worker (`packages/runtime-worker/src/WorkerService.ts`).
+
+Routing is manually assembled in `app/src/router/index.tsx` from route modules in `app/src/router/routes/`. A new route must be added there.
+
+Localization strings for user menu are duplicated in both app and package locale bundles (`app/public/locales/{en,ja}/common.json`, `packages/ui/i18n/public/locales/{en,ja}/common.json`) and should be updated consistently.
+
+## Plan of Work
+
+First, add maintenance domain utilities under `app/src/maintenance/`:
+
+- `maintenanceSession.ts`: create short-lived one-time sessions using cryptographically random values, persist in `sessionStorage`, and validate against URL parameters.
+- `maintenanceLock.ts`: set/check/clear a lock record in `localStorage` with expiration so the app can reject new worker initialization during maintenance.
+- `maintenanceExecution.ts`: orchestrate shutdown/reset, IndexedDB deletion with blocked retries, and worker re-initialization.
+
+Second, wire lock enforcement in worker bootstrap (`app/src/worker-runtime/client.ts`) so `initializeWorker()` fails fast while maintenance lock is active.
+
+Third, add a maintenance route and page:
+
+- `app/src/router/routes/maintenanceRoute.tsx` for `/maintenance`.
+- `app/src/router/pages/maintenance/MaintenancePage.tsx` to validate session URL params, show explicit consent form (typed confirmation text and optional email confirmation if authenticated), execute maintenance, and display outcome.
+- Register route in `app/src/router/index.tsx`.
+
+Fourth, integrate menu entry:
+
+- Extend `UserLoginButton`/`UserMenu` in `packages/ui/usermenu` with an optional callback for “Open DB Maintenance”.
+- In app-level consumers (`HomePage.tsx` and tree layout route), pass a callback that creates a maintenance session and navigates to `/maintenance` with session credentials.
+
+Fifth, add tests:
+
+- Session utility tests (valid, expired, mismatch token, consumed cases).
+- Lock utility or worker-init guard test ensuring lock blocks initialization behavior.
+
+Finally, run required checks and update tracking logs.
+
+## Concrete Steps
+
+Run from `/Users/hiroya/WebstormProjects/hierarchidb-maintenance-url`.
+
+1. Implement utilities and route/page files as described in Plan of Work.
+2. Wire user-menu callback and app route registration.
+3. Add tests under `app/src/maintenance/__tests__/`.
+4. Execute:
+   - `pnpm -w turbo run typecheck --filter @hierarchidb/app --filter @hierarchidb/runtime-worker`
+   - `pnpm -w turbo run test --filter @hierarchidb/app --filter @hierarchidb/runtime-worker`
+5. Record results in Issue #239 and `TASKS.md`.
+
+Expected terminal signals (abridged): successful commands exit with code `0`; failing command output must be captured and logged as blocked if unrelated external failures appear.
+
+## Validation and Acceptance
+
+Acceptance is behavioral and test-based.
+
+- Behavioral:
+  - Opening `/maintenance` directly without a valid session token shows an invalid-session state and does not run deletion.
+  - Starting maintenance from user menu generates a valid short-lived URL.
+  - Executing maintenance with valid explicit consent runs worker shutdown/reset, IndexedDB delete attempts, then worker re-initialization.
+  - If DB delete is blocked, UI reports blocked DB names and does not claim success.
+- Tests:
+  - New tests for session and lock behavior pass.
+  - `app` and `runtime-worker` typecheck/test commands complete with exit `0` (or clearly documented pre-existing blockers).
+
+## Idempotence and Recovery
+
+Session creation is idempotent by design (new session overwrites stale ones). Expired sessions are rejected and can be recreated from user menu. Maintenance lock includes expiration so stale lock records self-heal. If deletion is blocked, rerunning after closing other tabs is safe because shutdown/reset + delete are repeatable.
+
+Rollback path is straightforward: remove the maintenance route integration and menu callback, and revert lock enforcement in worker init. Existing clear-data path remains available throughout.
+
+## Artifacts and Notes
+
+Key files expected to change:
+
+- `plans/indexeddb-maintenance-url-execplan.md`
+- `app/src/maintenance/maintenanceSession.ts` (new)
+- `app/src/maintenance/maintenanceLock.ts` (new)
+- `app/src/maintenance/maintenanceExecution.ts` (new)
+- `app/src/router/pages/maintenance/MaintenancePage.tsx` (new)
+- `app/src/router/routes/maintenanceRoute.tsx` (new)
+- `app/src/router/index.tsx`
+- `app/src/worker-runtime/client.ts`
+- `packages/ui/usermenu/src/components/UserLoginButton.tsx`
+- `packages/ui/usermenu/src/components/UserMenu.tsx`
+- `app/src/router/pages/home/HomePage.tsx`
+- `app/src/router/routes/t.($treeId).($pageNodeId).tsx`
+- localization files under app/package `common.json`
+
+## Interfaces and Dependencies
+
+The feature relies on existing interfaces:
+
+- `WorkerAPI.shutdown()` (`packages/worker-api/src/WorkerAPI.ts`)
+- `WorkerProvider` context methods `reset()` / `initialize()` and client access (`app/src/contexts/WorkerProvider.tsx`)
+- Browser IndexedDB APIs (`indexedDB.databases()`, `indexedDB.deleteDatabase()`)
+
+New interfaces to introduce:
+
+- `createMaintenanceSession()` returning URL-safe session credentials.
+- `validateMaintenanceSessionFromUrl()` returning validated session metadata or structured failure reason.
+- `executeIndexedDbMaintenance()` returning structured step-by-step result with blocked/failed DB lists.
+
+Revision note: Updated after implementation to record completed milestones, storage fallback discovery, authenticated-menu decision, test outcomes, and current typecheck blockers.


### PR DESCRIPTION
## Summary
- add authenticated user-menu entry for `IndexedDB Maintenance`
- add `/maintenance` route with one-time short-lived session validation
- require explicit user consent (typed confirmation phrase + optional email re-confirmation)
- implement maintenance orchestration:
  - maintenance lock on/off
  - cross-tab shutdown request via `BroadcastChannel`
  - local worker shutdown/reset + Dexie close
  - IndexedDB delete with blocked retry handling
  - worker re-initialize to trigger upgrade path
- block worker initialization while maintenance lock is active
- add maintenance unit tests and fix router unit test mocking for new route addition

## Why
Current UI-based clear-data flow cannot reliably delete open IndexedDB databases when worker/DB handles remain active. This PR introduces a dedicated, explicitly-consented maintenance flow suitable for destructive local reset and subsequent DB upgrade initialization.

## Changes
- new maintenance modules:
  - `app/src/maintenance/maintenanceSession.ts`
  - `app/src/maintenance/maintenanceLock.ts`
  - `app/src/maintenance/maintenanceChannel.ts`
  - `app/src/maintenance/runtimeShutdown.ts`
  - `app/src/maintenance/maintenanceExecution.ts`
- new route/page:
  - `app/src/router/routes/maintenanceRoute.tsx`
  - `app/src/router/pages/maintenance/MaintenancePage.tsx`
- app wiring:
  - `app/src/router/index.tsx`
  - `app/src/router/init/initializeBrowserGlobals.ts`
  - `app/src/router/pages/home/HomePage.tsx`
  - `app/src/router/routes/t.($treeId).($pageNodeId).tsx`
  - `app/src/worker-runtime/client.ts`
- user menu entry:
  - `packages/ui/usermenu/src/components/UserMenu.tsx`
  - `packages/ui/usermenu/src/components/UserLoginButton.tsx`
- i18n updates (app + ui package)
- tests:
  - `app/src/maintenance/__tests__/maintenanceSession.unit.test.ts`
  - `app/src/maintenance/__tests__/maintenanceLock.unit.test.ts`
  - `app/src/maintenance/__tests__/maintenanceExecution.unit.test.ts`
  - `app/src/router/__tests__/unit/configure-router-mode.unit.test.ts`

## Validation
- ✅ `pnpm exec turbo run test --filter @hierarchidb/app -- --run src/router/__tests__/unit/configure-router-mode.unit.test.ts src/maintenance/__tests__/maintenanceSession.unit.test.ts src/maintenance/__tests__/maintenanceLock.unit.test.ts src/maintenance/__tests__/maintenanceExecution.unit.test.ts`
- ✅ `pnpm exec turbo run typecheck --filter @hierarchidb/ui-usermenu --filter @hierarchidb/runtime-worker`
- ⚠️ `pnpm exec turbo run typecheck --filter @hierarchidb/app`
  - blocked by pre-existing unrelated `@hierarchidb/shape-plugin` readonly/mutable type mismatch on `vtConfig.debug.tiles`

## Rollback
- remove `/maintenance` route registration and maintenance menu callback wiring
- revert maintenance lock guard in `app/src/worker-runtime/client.ts`
- remove `app/src/maintenance/*`

Refs #239
