### PR TITLE
feat(app): add speed dial/context submenu presets for shape creation

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -39,6 +39,7 @@
 
 ### Doing
 
+- #241 / `codex/feat/ui/speeddial-submenu` / start: 2026-02-13 11:13 JST
 - #239 / `codex/feat/maintenance/indexeddb-maintenance-url` / start: 2026-02-13 09:51 JST
 - #236 / `codex/fix/tree/prevent-trash-while-build-running` / start: 2026-02-13 08:01 JST
 - #235 / `ERIA-Cartograph` / start: 2026-02-13 07:30 JST
@@ -62,10 +63,24 @@
 
 ### Blocked
 
+- #241 / `codex/feat/ui/speeddial-submenu` / blocked: 2026-02-13 11:57 JST（`pnpm -w turbo run typecheck --filter @hierarchidb/ui-speeddial-submenu --filter @hierarchidb/ui-treeconsole-breadcrumb --filter @hierarchidb/app` が差分外 `@hierarchidb/shape-plugin` の既知型不整合 `vtConfig.debug.tiles` readonly/mutable 競合で exit 2）
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
 
+- blocked: 2026-02-13 11:57 JST #241 `pnpm -w turbo run typecheck --filter @hierarchidb/ui-speeddial-submenu --filter @hierarchidb/ui-treeconsole-breadcrumb --filter @hierarchidb/app` は差分外既知ブロッカー `@hierarchidb/shape-plugin`（`vtConfig.debug.tiles` readonly `[]` vs mutable `string[]`）で exit 2。`@hierarchidb/ui-speeddial-submenu` / `@hierarchidb/ui-treeconsole-breadcrumb` の typecheck 自体は cache hit で通過。
+- update: 2026-02-13 11:56 JST #241 再検証: `pnpm -w turbo run test --filter @hierarchidb/app -- --run src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx src/features/shape/__tests__/shapeCreatePresets.unit.test.ts` は exit 0（2 files / 5 tests passed）。
+- update: 2026-02-13 11:56 JST #241 再検証: `pnpm install` は exit 0、`pnpm -w turbo run build --filter @hierarchidb/ui-speeddial-submenu --filter @hierarchidb/app` も exit 0 を確認。
+- update: 2026-02-13 11:56 JST #241 追加要件（shapeプリセット選択 + i18n化）を反映。`app/src/features/shape/shapeCreatePresets.ts` を追加し、3プリセット（日本L0+1 / 世界L0 / 世界L1+中国・インドL1+2）の `name/description/template/buildConfig/processingConfig/selectedArrayByCountries` を定義。`create:shape::preset:<id>` の encode/decode と create直後の draft patch 適用を実装。
+- update: 2026-02-13 11:56 JST #241 UI統合として SpeedDial (`app/src/router/pages/tree/console/DynamicSpeedDial.tsx`) と ContextMenu (`packages/ui/treeconsole/breadcrumb/src/components/NodeContextMenu.tsx`) の create項目に `children` サブメニューを追加し、hover起点の右→左展開で shapeプリセットを選択可能にした。非shape create は従来どおり単一アクションを維持。
+- update: 2026-02-13 11:56 JST #241 i18n（ja/en）を `app/public/locales/*/common.json` と `packages/ui/i18n/public/locales/*/common.json` に追加。`treeConsole.shapePresets.*` の name/description/node template を定義し、SpeedDial/ContextMenu のラベル・tooltip・create時ノード名/説明がロケールに応じて切替されるようにした。
+- update: 2026-02-13 11:22 JST #241 で新規パッケージ `@hierarchidb/ui-speeddial-submenu`（`packages/ui/speeddial-submenu`）を追加し、`SpeedDialSubmenuActions` を実装。一次アクション hover/click で `Popper`（`left-start`）サブメニューを右→左展開し、単一表示切替・クローズ遅延・親/子クリック時の閉鎖制御を実装。
+- update: 2026-02-13 11:22 JST #241 の app 統合として `app/src/router/pages/tree/console/DynamicSpeedDial.tsx` を `SpeedDialSubmenuActions` 利用へ切替。`vmItems` の `group` が複数項目の場合のみ親アクション＋サブメニュー化し、単一項目は従来どおり `create:<nodeType>` を即時実行する後方互換挙動を維持。
+- update: 2026-02-13 11:22 JST #241 テスト追加: `app/src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx` に hover 起点サブメニュー表示と子項目クリック実行の検証を追加。`pnpm -w turbo run test --filter @hierarchidb/app -- --run src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx` は exit 0（1 file / 2 tests passed）。
+- update: 2026-02-13 11:24 JST #241 追補: Biome 整形（import order/formatter）を `DynamicSpeedDial.tsx` と `SpeedDialSubmenuActions.tsx` へ適用し、同テスト `pnpm -w turbo run test --filter @hierarchidb/app -- --run src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx` を再実行して exit 0 を再確認。
+- blocked: 2026-02-13 11:22 JST #241 `pnpm -w turbo run typecheck --filter @hierarchidb/app` は差分外既知ブロッカー `@hierarchidb/shape-plugin`（`vtConfig.debug.tiles`: readonly `[]` vs mutable `string[]`）で exit 2。補助確認として `pnpm -w turbo run typecheck --filter @hierarchidb/ui-speeddial-submenu` は exit 0。
+- update: 2026-02-13 11:22 JST #241 ビルド確認: `pnpm -w turbo run build --filter @hierarchidb/ui-speeddial-submenu` と `pnpm -w turbo run build --filter @hierarchidb/app` はともに exit 0。依存同期として `pnpm install` も exit 0。
+- update: 2026-02-13 11:13 JST Issue #241（`feat/ui/speeddial-submenu-package`）を起票し Project `hierarchidb` へ追加、Status を `In Progress` に設定したうえで、`ERIA-Cartograph` 起点の worktree `/Users/hiroya/WebstormProjects/hierarchidb-ui-speeddial-submenu` とブランチ `codex/feat/ui/speeddial-submenu` を作成して着手。
 - update: 2026-02-13 10:38 JST #239 でメンテナンス専用URLフローを実装。`packages/ui/usermenu` に「IndexedDB Maintenance」メニュー導線（ログイン時のみ表示）を追加し、`app/src/maintenance/maintenanceSession.ts` で短命ワンタイムセッション（`msid/msk`）を発行、`app/src/router/pages/maintenance/MaintenancePage.tsx` でURL検証・確認フレーズ入力・メール再確認を通過した場合のみ destructive 処理を実行する構成に変更。
 - update: 2026-02-13 10:38 JST #239 の実行系として `app/src/maintenance/maintenanceExecution.ts` を追加し、(1) maintenance lock 設定、(2) BroadcastChannel による shutdown 要求、(3) local worker shutdown/reset + Dexie close、(4) `indexedDB.deleteDatabase` の blocked リトライ削除、(5) lock解除後 worker 再初期化（upgradeトリガー）を順次実行するよう実装。`app/src/worker-runtime/client.ts` には lock 有効時の初期化拒否ガードを追加。
 - update: 2026-02-13 10:38 JST #239 の適用範囲は `app/src/maintenance/*`, `app/src/router/pages/maintenance/MaintenancePage.tsx`, `app/src/router/routes/maintenanceRoute.tsx`, `app/src/router/index.tsx`, `app/src/router/init/initializeBrowserGlobals.ts`, `app/src/router/pages/home/HomePage.tsx`, `app/src/router/routes/t.($treeId).($pageNodeId).tsx`, `packages/ui/usermenu/src/components/{UserMenu,UserLoginButton}.tsx`, `app/public/locales/*/common.json`, `packages/ui/i18n/public/locales/*/common.json`。

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,7 @@
     "@hierarchidb/ui-lru-splitview": "workspace:*",
     "@hierarchidb/ui-plugin-shell": "workspace:*",
     "@hierarchidb/ui-search-field": "workspace:*",
+    "@hierarchidb/ui-speeddial-submenu": "workspace:*",
     "@hierarchidb/ui-worker-client": "workspace:*",
     "@hierarchidb/worker-api": "workspace:*",
     "@hierarchidb/util": "workspace:*",

--- a/app/public/locales/en/common.json
+++ b/app/public/locales/en/common.json
@@ -364,6 +364,26 @@
       "preview": "Preview",
       "build": "Build"
     },
+    "shapePresets": {
+      "japanLevel01": {
+        "name": "Japan level0+1 (prefectures)",
+        "description": "Select Japan only. Include admin level 0 and level 1 boundaries.",
+        "nodeNameTemplate": "Japan L0+1 {{date}}",
+        "nodeDescriptionTemplate": "Preset: {{preset}}. Includes tuned simplify settings."
+      },
+      "worldLevel0": {
+        "name": "World countries level0",
+        "description": "Select all countries at admin level 0 for compact global coverage.",
+        "nodeNameTemplate": "World L0 {{date}}",
+        "nodeDescriptionTemplate": "Preset: {{preset}}. Prioritizes compact simplification."
+      },
+      "worldLevel1CnInLevel12": {
+        "name": "World level1, China/India level1+2",
+        "description": "Select level 1 globally; extend China and India to level 2.",
+        "nodeNameTemplate": "World L1 + CN/IN L1+2 {{date}}",
+        "nodeDescriptionTemplate": "Preset: {{preset}}. Uses balanced simplify settings."
+      }
+    },
     "errors": {
       "trashFailed": "Move to trash failed.",
       "trashReferencedByRoutes": "Cannot move to trash because routes reference this location.",

--- a/app/public/locales/ja/common.json
+++ b/app/public/locales/ja/common.json
@@ -323,6 +323,26 @@
       "preview": "プレビュー",
       "build": "ビルド"
     },
+    "shapePresets": {
+      "japanLevel01": {
+        "name": "日本レベル0+1(都道府県)",
+        "description": "日本のみを対象に、行政レベル0とレベル1(都道府県)を選択します。",
+        "nodeNameTemplate": "日本 L0+1 {{date}}",
+        "nodeDescriptionTemplate": "プリセット: {{preset}}。簡略化設定を日本向けに調整しています。"
+      },
+      "worldLevel0": {
+        "name": "世界各国レベル0",
+        "description": "全世界の国境(行政レベル0)を選択し、軽量なグローバル表示に最適化します。",
+        "nodeNameTemplate": "世界 L0 {{date}}",
+        "nodeDescriptionTemplate": "プリセット: {{preset}}。軽量化を優先した簡略化設定です。"
+      },
+      "worldLevel1CnInLevel12": {
+        "name": "世界各国レベル1、中国とインドはレベル1+2",
+        "description": "全世界は行政レベル1を選択し、中国とインドのみレベル2まで拡張します。",
+        "nodeNameTemplate": "世界 L1 + 中国/インド L1+2 {{date}}",
+        "nodeDescriptionTemplate": "プリセット: {{preset}}。詳細度とサイズのバランスを取った設定です。"
+      }
+    },
     "errors": {
       "trashFailed": "ゴミ箱への移動に失敗しました。",
       "trashReferencedByRoutes": "ルートが参照しているため、このロケーションはゴミ箱に移動できません。",

--- a/app/src/features/shape/__tests__/shapeCreatePresets.unit.test.ts
+++ b/app/src/features/shape/__tests__/shapeCreatePresets.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildShapePresetDraftDataPatch,
+  parseCreateAction,
+  resolveShapePresetNodeDefaults,
+} from '../shapeCreatePresets.ts';
+
+describe('shapeCreatePresets', () => {
+  it('parses create action with shape preset id', () => {
+    const parsed = parseCreateAction('create:shape::preset:world-level0');
+    expect(parsed).toEqual({
+      nodeType: 'shape',
+      shapePresetId: 'world-level0',
+    });
+  });
+
+  it('builds world level1 + CN/IN level2 selection matrix', () => {
+    const patch = buildShapePresetDraftDataPatch('world-level1-cn-in-level12');
+    const selection = patch.selectedArrayByCountries as Record<string, boolean[]> | undefined;
+
+    expect(selection?.US).toEqual([false, true, false]);
+    expect(selection?.CN).toEqual([false, true, true]);
+    expect(selection?.IN).toEqual([false, true, true]);
+  });
+
+  it('resolves node defaults with template replacement', () => {
+    const defaults = resolveShapePresetNodeDefaults('japan-level0-1', (_key, fallback) => fallback);
+
+    expect(defaults.name).toMatch(/^Japan L0\+1 \d{4}-\d{2}-\d{2}$/);
+    expect(defaults.description).toContain('Preset:');
+  });
+});

--- a/app/src/features/shape/shapeCreatePresets.ts
+++ b/app/src/features/shape/shapeCreatePresets.ts
@@ -1,0 +1,460 @@
+import type { TreeNodeData } from '@hierarchidb/tree-api';
+
+export const SHAPE_CREATE_PRESET_IDS = [
+  'japan-level0-1',
+  'world-level0',
+  'world-level1-cn-in-level12',
+] as const;
+
+export type ShapeCreatePresetId = (typeof SHAPE_CREATE_PRESET_IDS)[number];
+
+export type TranslateWithFallback = (key: string, fallback: string) => string;
+
+type ShapeCreatePresetDefinition = {
+  id: ShapeCreatePresetId;
+  labelKey: string;
+  labelFallback: string;
+  descriptionKey: string;
+  descriptionFallback: string;
+  nodeNameTemplateKey: string;
+  nodeNameTemplateFallback: string;
+  nodeDescriptionKey: string;
+  nodeDescriptionFallback: string;
+  buildConfigPatch: Record<string, unknown>;
+  processingConfigPatch: Record<string, unknown>;
+  buildSelection: () => Record<string, boolean[]>;
+};
+
+export interface ShapePresetMenuEntry {
+  key: string;
+  nodeType: 'shape';
+  createType: string;
+  labelKey: string;
+  label: string;
+  descriptionKey: string;
+  description: string;
+}
+
+const CREATE_ACTION_PREFIX = 'create:';
+const SHAPE_PRESET_MARKER = '::preset:';
+
+const WORLD_ISO2_CODES = [
+  'AD',
+  'AE',
+  'AF',
+  'AG',
+  'AL',
+  'AM',
+  'AO',
+  'AR',
+  'AT',
+  'AU',
+  'AZ',
+  'BA',
+  'BB',
+  'BD',
+  'BE',
+  'BF',
+  'BG',
+  'BH',
+  'BI',
+  'BJ',
+  'BN',
+  'BO',
+  'BR',
+  'BS',
+  'BT',
+  'BW',
+  'BY',
+  'BZ',
+  'CA',
+  'CF',
+  'CG',
+  'CH',
+  'CI',
+  'CL',
+  'CM',
+  'CN',
+  'CO',
+  'CR',
+  'CU',
+  'CV',
+  'CY',
+  'CZ',
+  'DE',
+  'DJ',
+  'DK',
+  'DM',
+  'DO',
+  'DZ',
+  'EC',
+  'EE',
+  'EG',
+  'ER',
+  'ES',
+  'ET',
+  'FI',
+  'FJ',
+  'FM',
+  'FR',
+  'GA',
+  'GB',
+  'GD',
+  'GE',
+  'GH',
+  'GL',
+  'GM',
+  'GN',
+  'GQ',
+  'GR',
+  'GT',
+  'GW',
+  'GY',
+  'HN',
+  'HR',
+  'HT',
+  'HU',
+  'ID',
+  'IE',
+  'IL',
+  'IN',
+  'IQ',
+  'IR',
+  'IS',
+  'IT',
+  'JM',
+  'JO',
+  'JP',
+  'KE',
+  'KG',
+  'KH',
+  'KI',
+  'KM',
+  'KN',
+  'KP',
+  'KR',
+  'KW',
+  'KZ',
+  'LA',
+  'LB',
+  'LC',
+  'LI',
+  'LK',
+  'LR',
+  'LS',
+  'LT',
+  'LU',
+  'LV',
+  'LY',
+  'MA',
+  'MC',
+  'ME',
+  'MG',
+  'MH',
+  'MK',
+  'ML',
+  'MM',
+  'MN',
+  'MR',
+  'MT',
+  'MU',
+  'MV',
+  'MW',
+  'MX',
+  'MY',
+  'MZ',
+  'NA',
+  'NE',
+  'NG',
+  'NI',
+  'NL',
+  'NO',
+  'NP',
+  'NR',
+  'NZ',
+  'OM',
+  'PA',
+  'PE',
+  'PG',
+  'PH',
+  'PK',
+  'PL',
+  'PT',
+  'PW',
+  'PY',
+  'QA',
+  'RO',
+  'RS',
+  'RU',
+  'RW',
+  'SA',
+  'SB',
+  'SC',
+  'SD',
+  'SE',
+  'SG',
+  'SI',
+  'SK',
+  'SL',
+  'SN',
+  'SO',
+  'SR',
+  'SS',
+  'ST',
+  'SV',
+  'SY',
+  'SZ',
+  'TD',
+  'TG',
+  'TH',
+  'TJ',
+  'TL',
+  'TM',
+  'TN',
+  'TO',
+  'TR',
+  'TT',
+  'TV',
+  'UA',
+  'UG',
+  'UM',
+  'US',
+  'UY',
+  'UZ',
+  'VC',
+  'VE',
+  'VN',
+  'VU',
+  'WF',
+  'WS',
+  'YE',
+  'ZA',
+  'ZM',
+  'ZW',
+] as const;
+
+const createSelectionRow = (
+  level0: boolean,
+  level1: boolean,
+  level2 = false
+): boolean[] => [level0, level1, level2];
+
+const buildJapanLevel01Selection = (): Record<string, boolean[]> => ({
+  JP: createSelectionRow(true, true, false),
+});
+
+const buildWorldLevel0Selection = (): Record<string, boolean[]> => {
+  const selection: Record<string, boolean[]> = {};
+  for (const code of WORLD_ISO2_CODES) {
+    selection[code] = createSelectionRow(true, false, false);
+  }
+  return selection;
+};
+
+const buildWorldLevel1CnInLevel12Selection = (): Record<string, boolean[]> => {
+  const selection: Record<string, boolean[]> = {};
+  for (const code of WORLD_ISO2_CODES) {
+    selection[code] = createSelectionRow(false, true, false);
+  }
+  selection.CN = createSelectionRow(false, true, true);
+  selection.IN = createSelectionRow(false, true, true);
+  return selection;
+};
+
+const SHAPE_CREATE_PRESET_DEFINITIONS: readonly ShapeCreatePresetDefinition[] = [
+  {
+    id: 'japan-level0-1',
+    labelKey: 'treeConsole.shapePresets.japanLevel01.name',
+    labelFallback: 'Japan level0+1 (prefectures)',
+    descriptionKey: 'treeConsole.shapePresets.japanLevel01.description',
+    descriptionFallback:
+      'Select Japan only. Include admin level 0 and level 1 boundaries.',
+    nodeNameTemplateKey: 'treeConsole.shapePresets.japanLevel01.nodeNameTemplate',
+    nodeNameTemplateFallback: 'Japan L0+1 {{date}}',
+    nodeDescriptionKey: 'treeConsole.shapePresets.japanLevel01.nodeDescriptionTemplate',
+    nodeDescriptionFallback:
+      'Preset: Japan level 0+1 (prefectures). Includes tuned simplify settings.',
+    buildConfigPatch: {
+      dataSourceName: 'geoboundaries',
+      transformConfig: {
+        tolerance: 0.12,
+        omitDetailsConfig: { level: 'none' },
+        boundaryDisableAtZoomOrAbove: 5,
+      },
+      vtConfig: {
+        tolerance: 0,
+        tileExpandFactor: 1,
+      },
+    },
+    processingConfigPatch: {
+      transform: { maxConcurrent: 3 },
+      vt: { maxConcurrent: 2 },
+    },
+    buildSelection: buildJapanLevel01Selection,
+  },
+  {
+    id: 'world-level0',
+    labelKey: 'treeConsole.shapePresets.worldLevel0.name',
+    labelFallback: 'World countries level0',
+    descriptionKey: 'treeConsole.shapePresets.worldLevel0.description',
+    descriptionFallback:
+      'Select all countries at admin level 0 for compact global coverage.',
+    nodeNameTemplateKey: 'treeConsole.shapePresets.worldLevel0.nodeNameTemplate',
+    nodeNameTemplateFallback: 'World L0 {{date}}',
+    nodeDescriptionKey: 'treeConsole.shapePresets.worldLevel0.nodeDescriptionTemplate',
+    nodeDescriptionFallback:
+      'Preset: world countries level 0. Prioritizes compact simplification.',
+    buildConfigPatch: {
+      dataSourceName: 'geoboundaries',
+      transformConfig: {
+        tolerance: 0.9,
+        omitDetailsConfig: { level: 'strong' },
+        boundaryDisableAtZoomOrAbove: 2,
+      },
+      vtConfig: {
+        tolerance: 1,
+        tileExpandFactor: 1,
+      },
+    },
+    processingConfigPatch: {
+      transform: { maxConcurrent: 4 },
+      vt: { maxConcurrent: 2 },
+    },
+    buildSelection: buildWorldLevel0Selection,
+  },
+  {
+    id: 'world-level1-cn-in-level12',
+    labelKey: 'treeConsole.shapePresets.worldLevel1CnInLevel12.name',
+    labelFallback: 'World level1, China/India level1+2',
+    descriptionKey: 'treeConsole.shapePresets.worldLevel1CnInLevel12.description',
+    descriptionFallback:
+      'Select level 1 globally; extend China and India to level 2.',
+    nodeNameTemplateKey: 'treeConsole.shapePresets.worldLevel1CnInLevel12.nodeNameTemplate',
+    nodeNameTemplateFallback: 'World L1 + CN/IN L1+2 {{date}}',
+    nodeDescriptionKey: 'treeConsole.shapePresets.worldLevel1CnInLevel12.nodeDescriptionTemplate',
+    nodeDescriptionFallback:
+      'Preset: world level 1, plus China/India level 2 with balanced simplify settings.',
+    buildConfigPatch: {
+      dataSourceName: 'geoboundaries',
+      transformConfig: {
+        tolerance: 0.45,
+        omitDetailsConfig: { level: 'moderate' },
+        boundaryDisableAtZoomOrAbove: 3,
+      },
+      vtConfig: {
+        tolerance: 0,
+        tileExpandFactor: 1,
+      },
+    },
+    processingConfigPatch: {
+      transform: { maxConcurrent: 3 },
+      vt: { maxConcurrent: 1 },
+    },
+    buildSelection: buildWorldLevel1CnInLevel12Selection,
+  },
+] as const;
+
+const SHAPE_CREATE_PRESET_MAP = new Map<ShapeCreatePresetId, ShapeCreatePresetDefinition>(
+  SHAPE_CREATE_PRESET_DEFINITIONS.map((preset) => [preset.id, preset])
+);
+
+export function isShapeCreatePresetId(value: string): value is ShapeCreatePresetId {
+  return SHAPE_CREATE_PRESET_MAP.has(value as ShapeCreatePresetId);
+}
+
+export function buildCreateType(nodeType: string, presetId?: ShapeCreatePresetId): string {
+  if (presetId && nodeType === 'shape') {
+    return `${nodeType}${SHAPE_PRESET_MARKER}${presetId}`;
+  }
+  return nodeType;
+}
+
+export function buildCreateAction(nodeType: string, presetId?: ShapeCreatePresetId): string {
+  return `${CREATE_ACTION_PREFIX}${buildCreateType(nodeType, presetId)}`;
+}
+
+export function parseCreateAction(action: string): {
+  nodeType: string;
+  shapePresetId?: ShapeCreatePresetId;
+} | null {
+  if (!action.startsWith(CREATE_ACTION_PREFIX)) return null;
+  const createType = action.slice(CREATE_ACTION_PREFIX.length).trim();
+  if (!createType) return null;
+
+  const [nodeType, presetRaw] = createType.split(SHAPE_PRESET_MARKER);
+  const normalizedNodeType = nodeType?.trim().toLowerCase();
+  if (!normalizedNodeType) return null;
+
+  if (!presetRaw) {
+    return { nodeType: normalizedNodeType };
+  }
+  if (normalizedNodeType !== 'shape') {
+    return null;
+  }
+  const presetId = presetRaw.trim();
+  if (!isShapeCreatePresetId(presetId)) {
+    return null;
+  }
+  return { nodeType: normalizedNodeType, shapePresetId: presetId };
+}
+
+export function getShapePresetMenuEntries(): readonly ShapePresetMenuEntry[] {
+  return SHAPE_CREATE_PRESET_DEFINITIONS.map((preset) => ({
+    key: `shape-preset-${preset.id}`,
+    nodeType: 'shape',
+    createType: buildCreateType('shape', preset.id),
+    labelKey: preset.labelKey,
+    label: preset.labelFallback,
+    descriptionKey: preset.descriptionKey,
+    description: preset.descriptionFallback,
+  }));
+}
+
+export function buildShapePresetDraftDataPatch(
+  presetId: ShapeCreatePresetId
+): Partial<TreeNodeData> {
+  const preset = SHAPE_CREATE_PRESET_MAP.get(presetId);
+  if (!preset) {
+    return {};
+  }
+  return {
+    buildConfig: preset.buildConfigPatch,
+    processingConfig: preset.processingConfigPatch,
+    selectedArrayByCountries: preset.buildSelection(),
+  };
+}
+
+function applyTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/\{\{\s*([a-zA-Z0-9_-]+)\s*}}/g, (_, key: string) => values[key] ?? '');
+}
+
+function buildDateStamp(now: Date = new Date()): string {
+  const yyyy = `${now.getFullYear()}`;
+  const mm = `${now.getMonth() + 1}`.padStart(2, '0');
+  const dd = `${now.getDate()}`.padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export function resolveShapePresetNodeDefaults(
+  presetId: ShapeCreatePresetId,
+  translateWithFallback: TranslateWithFallback
+): { name: string; description: string } {
+  const preset = SHAPE_CREATE_PRESET_MAP.get(presetId);
+  if (!preset) {
+    return { name: '', description: '' };
+  }
+  const date = buildDateStamp();
+  const presetName = translateWithFallback(preset.labelKey, preset.labelFallback);
+  const nameTemplate = translateWithFallback(
+    preset.nodeNameTemplateKey,
+    preset.nodeNameTemplateFallback
+  );
+  const descriptionTemplate = translateWithFallback(
+    preset.nodeDescriptionKey,
+    preset.nodeDescriptionFallback
+  );
+  return {
+    name: applyTemplate(nameTemplate, { date, preset: presetName }).trim(),
+    description: applyTemplate(descriptionTemplate, { date, preset: presetName }).trim(),
+  };
+}

--- a/app/src/hooks/treeconsole/actions/contextMenu.ts
+++ b/app/src/hooks/treeconsole/actions/contextMenu.ts
@@ -7,6 +7,11 @@ import type { TreeNode } from '@hierarchidb/tree-api';
 import { notify } from '@hierarchidb/components';
 import { isFolderNodeType } from '@hierarchidb/ui-plugin-shell/ui-treeconsole-breadcrumb';
 import type { HierarchicalTreeNode } from '@hierarchidb/ui-treeconsole-base';
+import {
+  buildShapePresetDraftDataPatch,
+  parseCreateAction,
+  resolveShapePresetNodeDefaults,
+} from '~/features/shape/shapeCreatePresets.ts';
 import { loadUIPlugin } from '../../../plugin-loaders/ui-plugin-loader.js';
 import { startBuildFlow } from '../../../router/pages/tree/console/buildFlow.ts';
 import type { ContextAction, TreeConsoleActionDeps } from '../types.js';
@@ -63,8 +68,11 @@ export const createContextMenuAction = (
     setSSOT,
     loadChildrenOf,
     refreshUndoRedo,
+    translateWithFallback,
   } = deps;
   const { applyClipboard, openEditDialog, resolvePreviewGuardState, navigation } = helpers;
+  const translate = (key: string, fallback: string) =>
+    translateWithFallback ? translateWithFallback(key, fallback) : fallback;
 
   return {
     handleContextMenuAction: (
@@ -124,7 +132,13 @@ export const createContextMenuAction = (
         if (normalizedAction.startsWith('create:')) {
           if (!client || !treeId) return;
           const source = options?.source ?? 'speedDial';
-          const newType = normalizedAction.replace('create:', '') as NodeType;
+          const parsedCreate = parseCreateAction(normalizedAction);
+          if (!parsedCreate) {
+            showCommandError('INVALID_OPERATION', `Invalid create action: ${normalizedAction}`);
+            return;
+          }
+          const newType = parsedCreate.nodeType as NodeType;
+          const shapePreset = parsedCreate.nodeType === 'shape' ? parsedCreate.shapePresetId : undefined;
           try {
             const mutationAPI = await client.getMutationAPI();
             const queryAPI = await client.getQueryAPI();
@@ -132,14 +146,19 @@ export const createContextMenuAction = (
             const siblingNames = siblings
               .map((node) => (typeof node?.metadata?.name === 'string' ? node.metadata.name : ''))
               .filter((name): name is string => Boolean(name));
-            const displayName = newType.charAt(0).toUpperCase() + newType.slice(1);
-            const baseName = `New ${displayName}`;
+            const displayName = translate(`plugins.${newType}.name`, newType);
+            const defaultBaseName = `New ${displayName}`;
+            const presetNodeDefaults = shapePreset
+              ? resolveShapePresetNodeDefaults(shapePreset, translate)
+              : undefined;
+            const baseName = presetNodeDefaults?.name || defaultBaseName;
             const resolvedName = createUniqueName(siblingNames, baseName);
             const res = await mutationAPI.createNode({
               nodeType: newType,
               treeId: treeId as TreeId,
               parentId: targetNodeId,
               name: resolvedName,
+              description: presetNodeDefaults?.description,
               isTemporary: true,
             });
             if (!res?.success) {
@@ -148,6 +167,14 @@ export const createContextMenuAction = (
               return;
             }
             const wcNodeId = res.nodeId as NodeId;
+
+            if (shapePreset) {
+              const updaterAPI = await client.getTreeNodeUpdaterAPI();
+              await updaterAPI.updateTreeNodeDraftData(
+                wcNodeId,
+                buildShapePresetDraftDataPatch(shapePreset)
+              );
+            }
 
             const navigateToCreateDialog = () => {
               const nodeTypePath = String(newType);

--- a/app/src/hooks/usePluginMenuItems.ts
+++ b/app/src/hooks/usePluginMenuItems.ts
@@ -27,6 +27,17 @@ const globalMenuBuilders = globalThis as typeof globalThis & {
   __HDB_MENU_BUILDERS__?: MenuBuildersCache;
 };
 
+const collectIconNames = (list: PluginMenuItem[]): string[] =>
+  list.flatMap((item) => {
+    const own = item.icon?.muiIconName ? [item.icon.muiIconName] : [];
+    const childIcons = Array.isArray(item.children)
+      ? item.children
+        .map((child) => child.icon?.muiIconName)
+        .filter((name): name is string => Boolean(name))
+      : [];
+    return [...own, ...childIcons];
+  });
+
 export function usePluginMenuItems(treeId?: TreeId): PluginMenuItem[] {
   const [items, setItems] = useState<PluginMenuItem[]>([]);
 
@@ -44,7 +55,7 @@ export function usePluginMenuItems(treeId?: TreeId): PluginMenuItem[] {
                 cached.normalizeContextFromTreeId?.(treeId) ?? 'projects'
               ) ?? []);
           if (active) setItems(list);
-          await prefetchMuiIcons(list.map((i) => i.icon?.muiIconName).filter(Boolean));
+          await prefetchMuiIcons(collectIconNames(list));
           return;
         }
       }
@@ -64,7 +75,7 @@ export function usePluginMenuItems(treeId?: TreeId): PluginMenuItem[] {
               cache.normalizeContextFromTreeId?.(treeId) ?? 'projects'
             ) ?? []);
         if (active) setItems(list);
-        await prefetchMuiIcons(list.map((i) => i.icon?.muiIconName).filter(Boolean));
+        await prefetchMuiIcons(collectIconNames(list));
         return;
       } catch (err) {
         console.warn('[usePluginMenuItems] Failed to load menu-builders:', err);

--- a/app/src/plugin-loaders/menu-builders.ts
+++ b/app/src/plugin-loaders/menu-builders.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TreeId } from '@hierarchidb/core-types';
+import { getShapePresetMenuEntries } from '../features/shape/shapeCreatePresets.ts';
 import { getPresentation, prefetchAllIcons } from '../plugin-runtime/plugin-presentation.ts';
 import { getInstalledPlugins, type InstalledPlugin } from '../plugin-runtime/plugin-registry.ts';
 import { getMenuSpec, type MenuGroup } from './menu-spec.ts';
@@ -13,7 +14,9 @@ export type TreeContext = 'resources' | 'projects';
 export interface PluginMenuItem {
   key: string;
   nodeType: string;
+  createType?: string;
   label: string;
+  labelKey?: string;
   icon?: {
     muiIconName?: string;
     emoji?: string;
@@ -22,15 +25,18 @@ export interface PluginMenuItem {
   group?: MenuGroup | string;
   priority: number;
   description: string;
+  descriptionKey?: string;
   backgroundColor: string;
+  children?: PluginMenuItem[];
 }
 
 function createMenuItem(plugin: InstalledPlugin, group: string, priority: number): PluginMenuItem {
   const presentation = getPresentation(plugin.nodeType);
   const localizedDescription = presentation?.description?.trim();
-  return {
+  const item: PluginMenuItem = {
     key: plugin.nodeType,
     nodeType: plugin.nodeType,
+    createType: plugin.nodeType,
     label: presentation?.label ?? plugin.label,
     icon: presentation?.icon ?? plugin.icon,
     group,
@@ -41,6 +47,23 @@ function createMenuItem(plugin: InstalledPlugin, group: string, priority: number
         : plugin.description,
     backgroundColor: plugin.backgroundColor,
   };
+  if (plugin.nodeType === 'shape') {
+    const shapePresetChildren = getShapePresetMenuEntries().map((preset, index) => ({
+      key: preset.key,
+      nodeType: preset.nodeType,
+      createType: preset.createType,
+      label: preset.label,
+      labelKey: preset.labelKey,
+      description: preset.description,
+      descriptionKey: preset.descriptionKey,
+      icon: item.icon,
+      group,
+      priority: priority + index + 1,
+      backgroundColor: plugin.backgroundColor,
+    }));
+    item.children = shapePresetChildren;
+  }
+  return item;
 }
 
 export function buildMenuItemsForContext(treeContext: TreeContext): PluginMenuItem[] {

--- a/app/src/router/pages/tree/console/DynamicSpeedDial.tsx
+++ b/app/src/router/pages/tree/console/DynamicSpeedDial.tsx
@@ -6,14 +6,24 @@
  */
 
 import type { TreeId } from '@hierarchidb/core-types';
+import {
+  type SpeedDialSubmenuAction,
+  SpeedDialSubmenuActions,
+  type SpeedDialSubmenuItem,
+} from '@hierarchidb/ui-speeddial-submenu';
 import type { HierarchicalTreeNode } from '@hierarchidb/ui-treeconsole-base';
-import { Box, Portal, SpeedDial, SpeedDialAction, SpeedDialIcon } from '@mui/material';
+import { Box, Portal, SpeedDial, SpeedDialIcon } from '@mui/material';
+import { useMemo } from 'react';
 import type { PluginMenuItem, TreeContext } from '~/plugin-loaders/menu-builders.js';
 import { useDynamicSpeedDial } from './useDynamicSpeedDial.js';
 
 interface DynamicSpeedDialProps {
   treeId: TreeId | undefined;
-  onCreateAction: (action: string, node: HierarchicalTreeNode, options?: { openInNewTab?: boolean }) => void;
+  onCreateAction: (
+    action: string,
+    node: HierarchicalTreeNode,
+    options?: { openInNewTab?: boolean }
+  ) => void;
   position?: { bottom?: number; right?: number; left?: number; top?: number };
   hidden?: boolean;
   menuContext?: TreeContext; // Optional explicit context to stage items from VM
@@ -46,6 +56,79 @@ export function DynamicSpeedDial({
   } = useDynamicSpeedDial({ treeId, hidden, onCreateAction, onSuppress });
   const createLabel = translateWithFallback('treeConsole.contextMenu.create', 'Create');
   const effectiveHidden = hidden || dialogOpen;
+  const submenuActions = useMemo<SpeedDialSubmenuAction[]>(() => {
+    if (!useVM) return [];
+
+    const actions: SpeedDialSubmenuAction[] = [];
+
+    const buildItemLabel = (item: PluginMenuItem) => {
+      if (item.labelKey) {
+        return translateWithFallback(item.labelKey, item.label);
+      }
+      return translateWithFallback(`plugins.${item.nodeType}.name`, item.label);
+    };
+
+    const buildTooltipLabel = (item: PluginMenuItem) => {
+      const localizedLabel = buildItemLabel(item);
+      const localizedDescription = item.descriptionKey
+        ? translateWithFallback(item.descriptionKey, (item.description ?? '').trim()).trim()
+        : translateWithFallback(`plugins.${item.nodeType}.description`, (item.description ?? '').trim()).trim();
+      const tooltipTemplate = translateWithFallback(
+        'treeConsole.contextMenu.createTooltip',
+        '{{label}}: {{description}}'
+      );
+      if (localizedDescription.length === 0) {
+        return localizedLabel;
+      }
+      return tooltipTemplate
+        .replace('{{label}}', localizedLabel)
+        .replace('{{description}}', localizedDescription);
+    };
+
+    const toCreateType = (item: PluginMenuItem) => item.createType ?? item.nodeType;
+
+    const buildLeafAction = (item: PluginMenuItem, testId: string): SpeedDialSubmenuItem => ({
+      id: `create:${toCreateType(item)}:${language}`,
+      label: buildItemLabel(item),
+      icon: resolveIcon({ nodeType: item.nodeType, icon: item.icon }),
+      onClick: (event) => handleVMActionClick(toCreateType(item), { openInNewTab: event.shiftKey }),
+      testId,
+    });
+
+    for (const item of vmItems) {
+      const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+      const testIdBase = `create-${item.nodeType}`;
+      if (hasChildren) {
+        actions.push({
+          id: `create:${toCreateType(item)}:${language}`,
+          label: buildItemLabel(item),
+          icon: resolveIcon({ nodeType: item.nodeType, icon: item.icon }),
+          tooltipTitle: buildTooltipLabel(item),
+          backgroundColor: item.backgroundColor,
+          hoverBackgroundColor: item.icon?.color ? `${item.icon.color}33` : item.backgroundColor,
+          testId: `${testIdBase}-action`,
+          submenuTestId: `${testIdBase}-submenu`,
+          children: item.children!.map((child, childIndex) =>
+            buildLeafAction(child, `${testIdBase}-submenu-action-${childIndex + 1}`)
+          ),
+        });
+      } else {
+        actions.push({
+          id: `create:${toCreateType(item)}:${language}`,
+          label: buildItemLabel(item),
+          icon: resolveIcon({ nodeType: item.nodeType, icon: item.icon }),
+          tooltipTitle: buildTooltipLabel(item),
+          onClick: (event) =>
+            handleVMActionClick(toCreateType(item), { openInNewTab: event.shiftKey }),
+          backgroundColor: item.backgroundColor,
+          hoverBackgroundColor: item.icon?.color ? `${item.icon.color}33` : item.backgroundColor,
+          testId: `${testIdBase}-action`,
+        });
+      }
+    }
+
+    return actions;
+  }, [handleVMActionClick, language, resolveIcon, translateWithFallback, useVM, vmItems]);
 
   // Don't render if hidden
   if (effectiveHidden) {
@@ -119,60 +202,18 @@ export function DynamicSpeedDial({
             'aria-label': createLabel,
           }}
         >
-          {useVM
-            ? vmItems.map((item: PluginMenuItem) => {
-                const localizedLabel = translateWithFallback(
-                  `plugins.${item.nodeType}.name`,
-                  item.label
-                );
-                const localizedDescription = translateWithFallback(
-                  `plugins.${item.nodeType}.description`,
-                  (item.description ?? '').trim()
-                ).trim();
-                const tooltipTemplate = translateWithFallback(
-                  'treeConsole.contextMenu.createTooltip',
-                  '{{label}}: {{description}}'
-                );
-                const tooltipLabel =
-                  localizedDescription.length > 0
-                    ? tooltipTemplate
-                        .replace('{{label}}', localizedLabel)
-                        .replace('{{description}}', localizedDescription)
-                    : localizedLabel;
-
-                return (
-                  <SpeedDialAction
-                    key={`${item.key}-${language}`}
-                    icon={resolveIcon({ nodeType: item.nodeType, icon: item.icon })}
-                    tooltipTitle={tooltipLabel}
-                    onClick={(event) =>
-                      handleVMActionClick(item.nodeType, { openInNewTab: event.shiftKey })
-                    }
-                    sx={{
-                      '& .MuiTooltip-tooltip': {
-                        maxWidth: 300,
-                        fontSize: '0.875rem',
-                      },
-                    }}
-                    FabProps={{
-                      size: 'medium',
-                      color: 'default',
-                      sx: {
-                        pointerEvents: 'auto',
-                        touchAction: 'manipulation',
-                        transform: 'translate3d(0,0,0)',
-                        bgcolor: item.backgroundColor,
-                        '&:hover': {
-                          bgcolor: item.icon?.color ? `${item.icon.color}33` : item.backgroundColor,
-                        },
-                      },
-                    }}
-                    tooltipPlacement="left"
-                    data-testid={`create-${item.nodeType}-action`}
-                  />
-                );
-              })
-            : null}
+          {useVM ? (
+            <SpeedDialSubmenuActions
+              actions={submenuActions}
+              open={open}
+              onRequestClose={handleClose}
+              actionFabSx={{
+                pointerEvents: 'auto',
+                touchAction: 'manipulation',
+                transform: 'translate3d(0,0,0)',
+              }}
+            />
+          ) : null}
         </SpeedDial>
 
         {/* Debug overlays: fixed boxes showing current hitboxes and top element at FAB center */}

--- a/app/src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx
+++ b/app/src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx
@@ -37,22 +37,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 const menuItemsModule = vi.hoisted(() => ({
-  usePluginMenuItems: vi.fn((): PluginMenuItem[] => [
-    {
-      key: 'basemap',
-      nodeType: 'basemap',
-      label: 'Basemap',
-      icon: {
-        muiIconName: 'Public',
-        emoji: '🗺️',
-        color: '#123456',
-      },
-      group: 'base',
-      priority: 10,
-      description: 'Basemap',
-      backgroundColor: '#12345622',
-    },
-  ]),
+  usePluginMenuItems: vi.fn<() => PluginMenuItem[]>(),
 }));
 
 vi.mock('~/hooks/usePluginMenuItems.js', () => menuItemsModule);
@@ -61,6 +46,22 @@ describe('DynamicSpeedDial', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="root"></div>';
     vi.clearAllMocks();
+    menuItemsModule.usePluginMenuItems.mockReturnValue([
+      {
+        key: 'basemap',
+        nodeType: 'basemap',
+        label: 'Basemap',
+        icon: {
+          muiIconName: 'Public',
+          emoji: '🗺️',
+          color: '#123456',
+        },
+        group: 'base',
+        priority: 10,
+        description: 'Basemap',
+        backgroundColor: '#12345622',
+      },
+    ]);
   });
 
   it('renders SpeedDial actions with manifest-provided icon metadata', () => {
@@ -84,5 +85,78 @@ describe('DynamicSpeedDial', () => {
       },
     });
     expect(screen.getByTestId('speed-dial-icon')).toBeInTheDocument();
+  });
+
+  it('opens right-to-left submenu on hover and triggers child action click', () => {
+    menuItemsModule.usePluginMenuItems.mockReturnValue([
+      {
+        key: 'shape',
+        nodeType: 'shape',
+        label: 'Shape',
+        icon: {
+          muiIconName: 'Polyline',
+          emoji: '🟦',
+          color: '#334455',
+        },
+        priority: 10,
+        description: 'Shape data',
+        backgroundColor: '#33445522',
+        children: [
+          {
+            key: 'shape-preset-japan-level0-1',
+            nodeType: 'shape',
+            createType: 'shape::preset:japan-level0-1',
+            label: 'Japan level0+1 (prefectures)',
+            description: 'Select Japan only. Include admin level 0 and level 1 boundaries.',
+            icon: {
+              muiIconName: 'Polyline',
+              emoji: '🟦',
+              color: '#334455',
+            },
+            priority: 11,
+            backgroundColor: '#33445522',
+          },
+          {
+            key: 'shape-preset-world-level0',
+            nodeType: 'shape',
+            createType: 'shape::preset:world-level0',
+            label: 'World countries level0',
+            description: 'Select all countries at admin level 0 for compact global coverage.',
+            icon: {
+              muiIconName: 'Polyline',
+              emoji: '🟦',
+              color: '#334455',
+            },
+            priority: 12,
+            backgroundColor: '#33445522',
+          },
+        ],
+      },
+    ]);
+
+    const onCreateAction = vi.fn();
+    render(<DynamicSpeedDial treeId={'r' as TreeId} onCreateAction={onCreateAction} />);
+
+    const fab = document.body.querySelector('.MuiSpeedDial-fab') as HTMLElement | null;
+    expect(fab).not.toBeNull();
+    if (!fab) {
+      throw new Error('SpeedDial fab not found');
+    }
+    fireEvent.click(fab);
+
+    const shapeAction = screen.getByTestId('create-shape-action');
+    fireEvent.mouseEnter(shapeAction);
+
+    const submenu = screen.getByTestId('create-shape-submenu');
+    expect(submenu).toBeInTheDocument();
+    const popperRoot = submenu.closest('[data-popper-placement]');
+    expect(popperRoot?.getAttribute('data-popper-placement')).toBe('left-start');
+
+    fireEvent.click(screen.getByTestId('create-shape-submenu-action-2'));
+    expect(onCreateAction).toHaveBeenCalledWith(
+      'create:shape::preset:world-level0',
+      expect.any(Object),
+      expect.objectContaining({ openInNewTab: false })
+    );
   });
 });

--- a/app/src/router/pages/tree/console/useDynamicSpeedDial.ts
+++ b/app/src/router/pages/tree/console/useDynamicSpeedDial.ts
@@ -36,7 +36,7 @@ export interface UseDynamicSpeedDialResult extends DynamicSpeedDialState {
   translateWithFallback: (key: string, fallback: string) => string;
   handleClose: () => void;
   toggleOpen: () => void;
-  handleVMActionClick: (nodeType: string, options?: { openInNewTab?: boolean }) => void;
+  handleVMActionClick: (createType: string, options?: { openInNewTab?: boolean }) => void;
   transitionDuration: number;
 }
 
@@ -125,8 +125,8 @@ export function useDynamicSpeedDial(params: {
   }, []);
 
   const handleVMActionClick = useCallback(
-    (nodeType: string, options?: { openInNewTab?: boolean }) => {
-      const action = `create:${nodeType}`;
+    (createType: string, options?: { openInNewTab?: boolean }) => {
+      const action = `create:${createType}`;
       onSuppress?.();
       handleClose();
       onCreateAction(action, {} as HierarchicalTreeNode, options);

--- a/packages/ui/i18n/public/locales/en/common.json
+++ b/packages/ui/i18n/public/locales/en/common.json
@@ -369,6 +369,26 @@
       "preview": "Preview",
       "build": "Build"
     },
+    "shapePresets": {
+      "japanLevel01": {
+        "name": "Japan level0+1 (prefectures)",
+        "description": "Select Japan only. Include admin level 0 and level 1 boundaries.",
+        "nodeNameTemplate": "Japan L0+1 {{date}}",
+        "nodeDescriptionTemplate": "Preset: {{preset}}. Includes tuned simplify settings."
+      },
+      "worldLevel0": {
+        "name": "World countries level0",
+        "description": "Select all countries at admin level 0 for compact global coverage.",
+        "nodeNameTemplate": "World L0 {{date}}",
+        "nodeDescriptionTemplate": "Preset: {{preset}}. Prioritizes compact simplification."
+      },
+      "worldLevel1CnInLevel12": {
+        "name": "World level1, China/India level1+2",
+        "description": "Select level 1 globally; extend China and India to level 2.",
+        "nodeNameTemplate": "World L1 + CN/IN L1+2 {{date}}",
+        "nodeDescriptionTemplate": "Preset: {{preset}}. Uses balanced simplify settings."
+      }
+    },
     "content": {
       "loading": "Loading...",
       "empty": {

--- a/packages/ui/i18n/public/locales/ja/common.json
+++ b/packages/ui/i18n/public/locales/ja/common.json
@@ -369,6 +369,26 @@
       "preview": "プレビュー",
       "build": "ビルド"
     },
+    "shapePresets": {
+      "japanLevel01": {
+        "name": "日本レベル0+1(都道府県)",
+        "description": "日本のみを対象に、行政レベル0とレベル1(都道府県)を選択します。",
+        "nodeNameTemplate": "日本 L0+1 {{date}}",
+        "nodeDescriptionTemplate": "プリセット: {{preset}}。簡略化設定を日本向けに調整しています。"
+      },
+      "worldLevel0": {
+        "name": "世界各国レベル0",
+        "description": "全世界の国境(行政レベル0)を選択し、軽量なグローバル表示に最適化します。",
+        "nodeNameTemplate": "世界 L0 {{date}}",
+        "nodeDescriptionTemplate": "プリセット: {{preset}}。軽量化を優先した簡略化設定です。"
+      },
+      "worldLevel1CnInLevel12": {
+        "name": "世界各国レベル1、中国とインドはレベル1+2",
+        "description": "全世界は行政レベル1を選択し、中国とインドのみレベル2まで拡張します。",
+        "nodeNameTemplate": "世界 L1 + 中国/インド L1+2 {{date}}",
+        "nodeDescriptionTemplate": "プリセット: {{preset}}。詳細度とサイズのバランスを取った設定です。"
+      }
+    },
     "content": {
       "loading": "読み込み中...",
       "empty": {

--- a/packages/ui/speeddial-submenu/package.json
+++ b/packages/ui/speeddial-submenu/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@hierarchidb/ui-speeddial-submenu",
+  "version": "0.1.0",
+  "description": "MUI SpeedDial actions with hover-triggered nested submenu support",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit --project tsconfig.json"
+  },
+  "peerDependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
+    "@mui/material": "^7.3.6",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
+    "@mui/material": "^7.3.6",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0",
+    "typescript": "workspace:^5.9.3"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/ui/speeddial-submenu/src/SpeedDialSubmenuActions.tsx
+++ b/packages/ui/speeddial-submenu/src/SpeedDialSubmenuActions.tsx
@@ -1,0 +1,230 @@
+import {
+  Grow,
+  MenuItem,
+  MenuList,
+  Paper,
+  Popper,
+  type PopperProps,
+  SpeedDialAction,
+} from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export interface SpeedDialSubmenuItem {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  onClick: (event: ReactMouseEvent<HTMLElement>) => void;
+  testId?: string;
+}
+
+export interface SpeedDialSubmenuAction {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  tooltipTitle?: string;
+  onClick?: (event: ReactMouseEvent<HTMLElement>) => void;
+  children?: SpeedDialSubmenuItem[];
+  backgroundColor?: string;
+  hoverBackgroundColor?: string;
+  testId?: string;
+  submenuTestId?: string;
+}
+
+export interface SpeedDialSubmenuActionsProps {
+  actions: SpeedDialSubmenuAction[];
+  open: boolean;
+  onRequestClose: () => void;
+  submenuPlacement?: PopperProps['placement'];
+  submenuOffsetPx?: number;
+  submenuCloseDelayMs?: number;
+  actionFabSx?: SxProps<Theme>;
+}
+
+const DEFAULT_SUBMENU_OFFSET_PX = 4;
+const DEFAULT_SUBMENU_CLOSE_DELAY_MS = 140;
+
+function hasChildren(action: SpeedDialSubmenuAction): action is SpeedDialSubmenuAction & {
+  children: SpeedDialSubmenuItem[];
+} {
+  return Array.isArray(action.children) && action.children.length > 0;
+}
+
+export function SpeedDialSubmenuActions({
+  actions,
+  open,
+  onRequestClose,
+  submenuPlacement = 'left-start',
+  submenuOffsetPx = DEFAULT_SUBMENU_OFFSET_PX,
+  submenuCloseDelayMs = DEFAULT_SUBMENU_CLOSE_DELAY_MS,
+  actionFabSx,
+}: SpeedDialSubmenuActionsProps) {
+  const [activeParentId, setActiveParentId] = useState<string | null>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const closeSubmenu = useCallback(() => {
+    clearCloseTimer();
+    setActiveParentId(null);
+    setAnchorEl(null);
+  }, [clearCloseTimer]);
+
+  const scheduleCloseSubmenu = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = setTimeout(() => {
+      setActiveParentId(null);
+      setAnchorEl(null);
+      closeTimerRef.current = null;
+    }, submenuCloseDelayMs);
+  }, [clearCloseTimer, submenuCloseDelayMs]);
+
+  useEffect(() => {
+    return () => clearCloseTimer();
+  }, [clearCloseTimer]);
+
+  useEffect(() => {
+    if (!open) {
+      closeSubmenu();
+    }
+  }, [closeSubmenu, open]);
+
+  const activeParent = useMemo(() => {
+    if (!activeParentId) return null;
+    const candidate = actions.find((action) => action.id === activeParentId);
+    if (!candidate || !hasChildren(candidate)) return null;
+    return candidate;
+  }, [actions, activeParentId]);
+
+  const submenuOpen = Boolean(open && anchorEl && activeParent);
+
+  const handlePrimaryActionEnter = useCallback(
+    (action: SpeedDialSubmenuAction, currentTarget: HTMLElement) => {
+      if (!hasChildren(action)) {
+        closeSubmenu();
+        return;
+      }
+      clearCloseTimer();
+      setActiveParentId(action.id);
+      setAnchorEl(currentTarget);
+    },
+    [clearCloseTimer, closeSubmenu]
+  );
+
+  const handlePrimaryActionClick = useCallback(
+    (action: SpeedDialSubmenuAction, event: ReactMouseEvent<HTMLElement>) => {
+      if (hasChildren(action)) {
+        handlePrimaryActionEnter(action, event.currentTarget as HTMLElement);
+        return;
+      }
+      action.onClick?.(event);
+      closeSubmenu();
+      onRequestClose();
+    },
+    [closeSubmenu, handlePrimaryActionEnter, onRequestClose]
+  );
+
+  const handleSubmenuItemClick = useCallback(
+    (item: SpeedDialSubmenuItem, event: ReactMouseEvent<HTMLElement>) => {
+      item.onClick(event);
+      closeSubmenu();
+      onRequestClose();
+    },
+    [closeSubmenu, onRequestClose]
+  );
+
+  return (
+    <>
+      {actions.map((action) => {
+        const parentOpen = submenuOpen && action.id === activeParentId;
+        const tooltipTitle = action.tooltipTitle ?? action.label;
+        return (
+          <SpeedDialAction
+            key={action.id}
+            icon={action.icon}
+            tooltipTitle={tooltipTitle}
+            onMouseEnter={(event) =>
+              handlePrimaryActionEnter(action, event.currentTarget as HTMLElement)
+            }
+            onMouseLeave={() => {
+              if (hasChildren(action)) scheduleCloseSubmenu();
+            }}
+            onClick={(event) => handlePrimaryActionClick(action, event)}
+            FabProps={{
+              size: 'medium',
+              color: 'default',
+              'aria-haspopup': hasChildren(action) ? 'menu' : undefined,
+              'aria-expanded': hasChildren(action) ? parentOpen : undefined,
+              onMouseEnter: (event) =>
+                handlePrimaryActionEnter(action, event.currentTarget as HTMLElement),
+              onMouseLeave: () => {
+                if (hasChildren(action)) scheduleCloseSubmenu();
+              },
+              sx: {
+                pointerEvents: 'auto',
+                touchAction: 'manipulation',
+                transform: 'translate3d(0,0,0)',
+                bgcolor: action.backgroundColor,
+                '&:hover': {
+                  bgcolor: action.hoverBackgroundColor ?? action.backgroundColor,
+                },
+                ...actionFabSx,
+              },
+            }}
+            tooltipPlacement="left"
+            data-testid={action.testId}
+          />
+        );
+      })}
+      <Popper
+        open={submenuOpen}
+        anchorEl={anchorEl}
+        placement={submenuPlacement}
+        transition
+        modifiers={[
+          {
+            name: 'offset',
+            options: {
+              offset: [0, submenuOffsetPx],
+            },
+          },
+        ]}
+        sx={{
+          zIndex: 2147483001,
+          pointerEvents: 'auto',
+        }}
+      >
+        {({ TransitionProps }) => (
+          <Grow {...TransitionProps} style={{ transformOrigin: 'right top' }}>
+            <Paper
+              elevation={8}
+              onMouseEnter={clearCloseTimer}
+              onMouseLeave={scheduleCloseSubmenu}
+              data-testid={activeParent?.submenuTestId}
+            >
+              <MenuList dense>
+                {activeParent?.children.map((item) => (
+                  <MenuItem
+                    key={item.id}
+                    onClick={(event) => handleSubmenuItemClick(item, event)}
+                    data-testid={item.testId}
+                  >
+                    {item.icon}
+                    <span style={{ marginLeft: 8 }}>{item.label}</span>
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+}

--- a/packages/ui/speeddial-submenu/src/index.ts
+++ b/packages/ui/speeddial-submenu/src/index.ts
@@ -1,0 +1,6 @@
+export type {
+  SpeedDialSubmenuAction,
+  SpeedDialSubmenuActionsProps,
+  SpeedDialSubmenuItem,
+} from './SpeedDialSubmenuActions.js';
+export { SpeedDialSubmenuActions } from './SpeedDialSubmenuActions.js';

--- a/packages/ui/speeddial-submenu/tsconfig.json
+++ b/packages/ui/speeddial-submenu/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "~/*": [
+        "./src/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/ui/treeconsole/breadcrumb/src/components/NodeContextMenu.tsx
+++ b/packages/ui/treeconsole/breadcrumb/src/components/NodeContextMenu.tsx
@@ -24,7 +24,17 @@ import {
 import { useIconRegistry } from '@hierarchidb/ui-icon';
 import { useGlobalI18nTranslator } from '@hierarchidb/ui-i18n';
 import { isFolderNodeType } from '../utils/nodeTypeIconColor.js';
-type CreateMenuEntry = { key: string; nodeType: string; label: string; description?: string; icon?: { muiIconName?: string; emoji?: string; color?: string } };
+type CreateMenuEntry = {
+  key: string;
+  nodeType: string;
+  createType?: string;
+  label: string;
+  labelKey?: string;
+  description?: string;
+  descriptionKey?: string;
+  icon?: { muiIconName?: string; emoji?: string; color?: string };
+  children?: CreateMenuEntry[];
+};
 type CreateMenuBuilder = (treeId?: string) => CreateMenuEntry[];
 type GlobalMenuBuilders = { buildMenuItemsForTreeId?: CreateMenuBuilder; buildMenuItemsForContext?: CreateMenuBuilder };
 const buildableNodeTypes = new Set(['styler', 'shape', 'route']);
@@ -75,7 +85,24 @@ export interface NodeContextMenuProps {
   onRestoreToOriginal?: () => void;
   onRestoreToCurrent?: () => void;
   /** Optional explicit create items list; if omitted, tries to stage from global builders */
-  createItems?: Array<{ type: string; label: string; description?: string }>;
+  createItems?: Array<{
+    type: string;
+    createType?: string;
+    label: string;
+    labelKey?: string;
+    description?: string;
+    descriptionKey?: string;
+    icon?: { muiIconName?: string; emoji?: string; color?: string };
+    children?: Array<{
+      type: string;
+      createType?: string;
+      label: string;
+      labelKey?: string;
+      description?: string;
+      descriptionKey?: string;
+      icon?: { muiIconName?: string; emoji?: string; color?: string };
+    }>;
+  }>;
   /** Optional step options for "Open" submenu */
   openSteps?: OpenStepOption[];
   /** Optional loading flag for async step options */
@@ -124,6 +151,9 @@ export function NodeContextMenu(props: NodeContextMenuProps): ReactElement | nul
 
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [addMenuAnchor, setAddMenuAnchor] = useState<HTMLElement | null>(null);
+  const [createSubmenuOpen, setCreateSubmenuOpen] = useState(false);
+  const [createSubmenuAnchor, setCreateSubmenuAnchor] = useState<HTMLElement | null>(null);
+  const [createSubmenuItems, setCreateSubmenuItems] = useState<CreateMenuEntry[]>([]);
   const [openStepMenuOpen, setOpenStepMenuOpen] = useState(false);
   const [openStepMenuAnchor, setOpenStepMenuAnchor] = useState<HTMLElement | null>(null);
   const [localInvisible, setLocalInvisible] = useState<boolean | null>(null);
@@ -223,6 +253,16 @@ export function NodeContextMenu(props: NodeContextMenuProps): ReactElement | nul
     }
   },[]);
 
+  const openCreateSubmenu = useCallback((event: MouseEvent<HTMLElement>, children: CreateMenuEntry[]) => {
+    event.stopPropagation();
+    event.preventDefault();
+    const menuItem = event.currentTarget.closest('li');
+    if (!menuItem) return;
+    setCreateSubmenuAnchor(menuItem as HTMLElement);
+    setCreateSubmenuItems(children);
+    setCreateSubmenuOpen(true);
+  }, []);
+
   const handleOpenStepMenuClick = useCallback((event: MouseEvent<HTMLElement>) => {
     event.stopPropagation();
     event.preventDefault();
@@ -237,6 +277,9 @@ export function NodeContextMenu(props: NodeContextMenuProps): ReactElement | nul
     // Close all submenus as well
     setAddMenuOpen(false);
     setAddMenuAnchor(null);
+    setCreateSubmenuOpen(false);
+    setCreateSubmenuAnchor(null);
+    setCreateSubmenuItems([]);
     setOpenStepMenuOpen(false);
     setOpenStepMenuAnchor(null);
     onClose();
@@ -355,6 +398,9 @@ export function NodeContextMenu(props: NodeContextMenuProps): ReactElement | nul
     if (!anchorEl) {
       setAddMenuOpen(false);
       setAddMenuAnchor(null);
+      setCreateSubmenuOpen(false);
+      setCreateSubmenuAnchor(null);
+      setCreateSubmenuItems([]);
       setOpenStepMenuOpen(false);
       setOpenStepMenuAnchor(null);
     }
@@ -388,23 +434,62 @@ export function NodeContextMenu(props: NodeContextMenuProps): ReactElement | nul
   const hasOpenSteps = Boolean(_onOpenStep && (openSteps.length > 0 || openStepsLoading));
 
   // Build Create submenu items
-  type BuiltItem = { type: string; label: string; description?: string; icon?: { muiIconName?: string; emoji?: string; color?: string } };
-  const builtCreateItems: Array<BuiltItem> = (() => {
-    if (props.createItems?.length) return props.createItems;
+  const builtCreateItems: Array<CreateMenuEntry> = (() => {
+    if (props.createItems?.length) {
+      return props.createItems.map((item) => ({
+        key: item.createType ?? item.type,
+        nodeType: item.type,
+        createType: item.createType,
+        label: item.label,
+        labelKey: item.labelKey,
+        description: item.description,
+        descriptionKey: item.descriptionKey,
+        icon: item.icon,
+        children: (item.children ?? []).map((child) => ({
+          key: child.createType ?? child.type,
+          nodeType: child.type,
+          createType: child.createType,
+          label: child.label,
+          labelKey: child.labelKey,
+          description: child.description,
+          descriptionKey: child.descriptionKey,
+          icon: child.icon,
+        })),
+      }));
+    }
     try {
       const g = (globalThis as unknown as { __HDB_MENU_BUILDERS__?: GlobalMenuBuilders }).__HDB_MENU_BUILDERS__;
       const builder: CreateMenuBuilder | undefined = g?.buildMenuItemsForTreeId || g?.buildMenuItemsForContext;
       if (typeof builder === 'function') {
         const items = builder(treeId) as CreateMenuEntry[];
-        return (items || []).map((i) => ({ type: i.nodeType, label: i.label, description: i.description, icon: i.icon }));
+        return (items || []).map((i) => ({
+          key: i.key ?? (i.createType ?? i.nodeType),
+          nodeType: i.nodeType,
+          createType: i.createType,
+          label: i.label,
+          labelKey: i.labelKey,
+          description: i.description,
+          descriptionKey: i.descriptionKey,
+          icon: i.icon,
+          children: (i.children ?? []).map((child) => ({
+            key: child.key ?? (child.createType ?? child.nodeType),
+            nodeType: child.nodeType,
+            createType: child.createType,
+            label: child.label,
+            labelKey: child.labelKey,
+            description: child.description,
+            descriptionKey: child.descriptionKey,
+            icon: child.icon,
+          })),
+        }));
       }
     } catch (error) {
       logNodeContextMenuWarning('Failed to stage dynamic create menu items', error);
     }
     // Fallback minimal entries
     return [
-      { type: 'folder', label: 'Folder', description: undefined, icon: { muiIconName: 'Folder' } },
-      { type: 'note', label: 'Note', description: undefined, icon: { muiIconName: 'Extension' } },
+      { key: 'folder', nodeType: 'folder', label: 'Folder', description: undefined, icon: { muiIconName: 'Folder' } },
+      { key: 'note', nodeType: 'note', label: 'Note', description: undefined, icon: { muiIconName: 'Extension' } },
     ];
   })();
 
@@ -615,15 +700,36 @@ export function NodeContextMenu(props: NodeContextMenuProps): ReactElement | nul
         }}
       >
         {builtCreateItems.map((ci) => {
-          const IconEl = resolveIcon({ nodeType: ci.type, icon: ci.icon });
-          const localizedLabel = translateWithFallback(`plugins.${ci.type}.name`, ci.label);
-          const localizedDescription = translateWithFallback(`plugins.${ci.type}.description`, ci.description ?? '').trim();
+          const createType = ci.createType ?? ci.nodeType;
+          const hasChildren = Array.isArray(ci.children) && ci.children.length > 0;
+          const IconEl = resolveIcon({ nodeType: ci.nodeType, icon: ci.icon });
+          const localizedLabel = ci.labelKey
+            ? translateWithFallback(ci.labelKey, ci.label)
+            : translateWithFallback(`plugins.${ci.nodeType}.name`, ci.label);
+          const localizedDescription = (ci.descriptionKey
+            ? translateWithFallback(ci.descriptionKey, ci.description ?? '')
+            : translateWithFallback(`plugins.${ci.nodeType}.description`, ci.description ?? '')).trim();
+
+          if (hasChildren) {
+            return (
+              <MenuItem
+                key={`${createType}-${language}`}
+                onMouseEnter={(event) => openCreateSubmenu(event, ci.children ?? [])}
+                onClick={(event) => openCreateSubmenu(event, ci.children ?? [])}
+                aria-label={localizedLabel}
+              >
+                <ListItemIcon>{IconEl}</ListItemIcon>
+                <ListItemText>{localizedLabel}</ListItemText>
+                <ChevronRightIcon sx={{ marginLeft: 'auto' }} />
+              </MenuItem>
+            );
+          }
 
           if (localizedDescription.length === 0) {
             return (
               <MenuItem
-                key={`${ci.type}-${language}`}
-                onClick={(event) => handleCreateClick(ci.type, event)}
+                key={`${createType}-${language}`}
+                onClick={(event) => handleCreateClick(createType, event)}
                 aria-label={localizedLabel}
               >
                 <ListItemIcon>{IconEl}</ListItemIcon>
@@ -634,9 +740,91 @@ export function NodeContextMenu(props: NodeContextMenuProps): ReactElement | nul
           }
 
           return (
-            <Tooltip key={`${ci.type}-${language}`} title={localizedDescription} placement="right" enterDelay={300} arrow>
+            <Tooltip key={`${createType}-${language}`} title={localizedDescription} placement="right" enterDelay={300} arrow>
               <span style={{ display: 'block' }}>
-                <MenuItem onClick={(event) => handleCreateClick(ci.type, event)} aria-label={localizedLabel}>
+                <MenuItem onClick={(event) => handleCreateClick(createType, event)} aria-label={localizedLabel}>
+                  <ListItemIcon>{IconEl}</ListItemIcon>
+                  <ListItemText>{localizedLabel}</ListItemText>
+                  {openInNewAdornment ? <span style={{ marginLeft: 'auto' }}>{openInNewAdornment}</span> : null}
+                </MenuItem>
+              </span>
+            </Tooltip>
+          );
+        })}
+      </Menu>
+
+      <Menu
+        anchorEl={createSubmenuAnchor}
+        open={createSubmenuOpen}
+        onClose={() => {
+          setCreateSubmenuOpen(false);
+          setCreateSubmenuAnchor(null);
+          setCreateSubmenuItems([]);
+        }}
+        disablePortal={false}
+        disableScrollLock={true}
+        keepMounted={false}
+        disableAutoFocus
+        disableAutoFocusItem
+        disableEnforceFocus
+        disableRestoreFocus
+        MenuListProps={{
+          autoFocusItem: false,
+          dense: true,
+          disablePadding: false,
+        }}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        slotProps={{
+          paper: {
+            elevation: 8,
+            sx: {
+              zIndex: 9999,
+              minWidth: 180,
+            },
+          },
+        }}
+      >
+        {createSubmenuItems.map((item) => {
+          const createType = item.createType ?? item.nodeType;
+          const IconEl = resolveIcon({ nodeType: item.nodeType, icon: item.icon });
+          const localizedLabel = item.labelKey
+            ? translateWithFallback(item.labelKey, item.label)
+            : translateWithFallback(`plugins.${item.nodeType}.name`, item.label);
+          const localizedDescription = (item.descriptionKey
+            ? translateWithFallback(item.descriptionKey, item.description ?? '')
+            : translateWithFallback(`plugins.${item.nodeType}.description`, item.description ?? '')).trim();
+
+          if (localizedDescription.length === 0) {
+            return (
+              <MenuItem
+                key={`${createType}-submenu-${language}`}
+                onClick={(event) => handleCreateClick(createType, event)}
+                aria-label={localizedLabel}
+              >
+                <ListItemIcon>{IconEl}</ListItemIcon>
+                <ListItemText>{localizedLabel}</ListItemText>
+                {openInNewAdornment ? <span style={{ marginLeft: 'auto' }}>{openInNewAdornment}</span> : null}
+              </MenuItem>
+            );
+          }
+
+          return (
+            <Tooltip
+              key={`${createType}-submenu-${language}`}
+              title={localizedDescription}
+              placement="right"
+              enterDelay={300}
+              arrow
+            >
+              <span style={{ display: 'block' }}>
+                <MenuItem onClick={(event) => handleCreateClick(createType, event)} aria-label={localizedLabel}>
                   <ListItemIcon>{IconEl}</ListItemIcon>
                   <ListItemText>{localizedLabel}</ListItemText>
                   {openInNewAdornment ? <span style={{ marginLeft: 'auto' }}>{openInNewAdornment}</span> : null}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,9 @@ importers:
       '@hierarchidb/ui-search-field':
         specifier: workspace:*
         version: link:../packages/ui/search-field
+      '@hierarchidb/ui-speeddial-submenu':
+        specifier: workspace:*
+        version: link:../packages/ui/speeddial-submenu
       '@hierarchidb/ui-worker-client':
         specifier: workspace:*
         version: link:../packages/ui/worker-client
@@ -2427,6 +2430,27 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+
+  packages/ui/speeddial-submenu:
+    devDependencies:
+      '@emotion/react':
+        specifier: 11.14.0
+        version: 11.14.0(@types/react@18.3.27)(react@18.3.1)
+      '@emotion/styled':
+        specifier: 11.14.0
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+      '@mui/material':
+        specifier: ^7.3.6
+        version: 7.3.6(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: '>=18.0.0'
+        version: 18.3.1
+      react-dom:
+        specifier: '>=18.0.0'
+        version: 18.3.1(react@18.3.1)
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
 
   packages/ui/tabular-extract:
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -604,6 +604,12 @@
       "@hierarchidb/ui-search-field/*": [
         "packages/ui/search-field/dist/*"
       ],
+      "@hierarchidb/ui-speeddial-submenu": [
+        "packages/ui/speeddial-submenu/dist/index.d.ts"
+      ],
+      "@hierarchidb/ui-speeddial-submenu/*": [
+        "packages/ui/speeddial-submenu/dist/*"
+      ],
       "@hierarchidb/ui-treeconsole-treetable": [
         "packages/ui/treeconsole/treetable/dist/index.d.ts"
       ],


### PR DESCRIPTION
## Summary
- add new package `@hierarchidb/ui-speeddial-submenu` for hover-driven nested SpeedDial actions
- extend TreeConsole create menus (SpeedDial + ContextMenu) to support submenu items via app-level menu definitions
- add shape creation presets (3 variants) with create action encoding `create:shape::preset:<id>`
- apply selected preset defaults (node name/description templates, build/processing config patch, country-level selection) immediately after create
- add i18n keys (ja/en) for preset labels/descriptions/templates in both app and shared ui-i18n locale bundles

## Verification
- `pnpm install` (exit 0)
- `pnpm -w turbo run build --filter @hierarchidb/ui-speeddial-submenu --filter @hierarchidb/app` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/app -- --run src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx src/features/shape/__tests__/shapeCreatePresets.unit.test.ts` (exit 0, 2 files / 5 tests)
- `pnpm -w turbo run typecheck --filter @hierarchidb/ui-speeddial-submenu --filter @hierarchidb/ui-treeconsole-breadcrumb --filter @hierarchidb/app` (known external blocker: `@hierarchidb/shape-plugin` readonly vs mutable `vtConfig.debug.tiles`)

## Issue
- Refs #241
