### PR TITLE
chore(i18n): ゴミ箱関連文言をアーカイブ表現へ変更

### DIFF
--- a/app/public/locales/ja/common.json
+++ b/app/public/locales/ja/common.json
@@ -77,8 +77,8 @@
         "exitFullscreen": "全画面を終了"
       },
       "title": {
-        "empty": "ゴミ箱を空にする",
-        "restore": "ゴミ箱から復元"
+        "empty": "アーカイブから削除する",
+        "restore": "アーカイブから戻す"
       },
       "confirm": {
         "title": "ゴミ箱を空にしますか?",
@@ -88,7 +88,7 @@
       },
       "buttons": {
         "cancel": "キャンセル",
-        "confirmDelete": "ゴミ箱を空にする",
+        "confirmDelete": "アーカイブから削除する",
         "restore": "復元",
         "restoreWithCount": "復元 ({{count}})",
         "empty": "削除",
@@ -101,7 +101,7 @@
       "aria": {
         "restore": "選択した項目を復元",
         "restoreWithCount": "{{unit}}を{{count}}件復元",
-        "empty": "ゴミ箱を空にする",
+        "empty": "アーカイブから削除する",
         "emptyWithCount": "{{unit}}を{{count}}件削除"
       },
       "units": {
@@ -249,11 +249,11 @@
         "copy": "コピー ({{shortcut}})",
         "paste": "貼り付け ({{shortcut}})",
         "duplicate": "複製 ({{shortcut}})",
-        "moveToTrash": "ゴミ箱に移動 ({{shortcut}})"
+        "moveToTrash": "アーカイブに移動する ({{shortcut}})"
       },
       "trashMenu": {
-        "restore": "ゴミ箱から復元",
-        "empty": "ゴミ箱を空にする"
+        "restore": "アーカイブから戻す",
+        "empty": "アーカイブから削除する"
       },
       "importExportMenu": {
         "import": "JSONファイルからインポート",
@@ -318,7 +318,7 @@
       "duplicate": "複製",
       "import": "インポート",
       "export": "エクスポート",
-      "moveToTrash": "ゴミ箱に移動",
+      "moveToTrash": "アーカイブに移動する",
       "visible": "表示",
       "hidden": "非表示",
       "checkReference": "参照を確認",
@@ -355,9 +355,9 @@
     },
     "errors": {
       "trashFailed": "ゴミ箱への移動に失敗しました。",
-      "trashReferencedByRoutes": "ルートが参照しているため、このロケーションはゴミ箱に移動できません。",
-      "trashReferencedByLocations": "ロケーションが参照しているため、このシェイプはゴミ箱に移動できません。",
-      "trashBuildSessionRunning": "ビルドセッション実行中のため、ゴミ箱へ移動できません。"
+      "trashReferencedByRoutes": "ルートが参照しているため、このロケーションはアーカイブに移動できません。",
+      "trashReferencedByLocations": "ロケーションが参照しているため、このシェイプはアーカイブに移動できません。",
+      "trashBuildSessionRunning": "ビルドセッション実行中のため、アーカイブに移動できません。"
     },
     "infoPanel": {
       "noTimestamp": "—",
@@ -376,10 +376,10 @@
       "noNode": "このページではノード情報を表示できません。",
       "createdLabel": "作成",
       "updatedLabel": "更新",
-      "confirmTrashTitle": "ゴミ箱に移動",
-      "confirmTrashDescription": "この項目と子要素をゴミ箱に移動しますか？",
+      "confirmTrashTitle": "アーカイブに移動する",
+      "confirmTrashDescription": "この項目と子要素をアーカイブに移動しますか？",
       "confirmTrashCancel": "キャンセル",
-      "confirmTrashConfirm": "ゴミ箱に移動"
+      "confirmTrashConfirm": "アーカイブに移動する"
     }
   },
   "tags": {

--- a/packages/ui/i18n/public/locales/ja/common.json
+++ b/packages/ui/i18n/public/locales/ja/common.json
@@ -118,8 +118,8 @@
         "exitFullscreen": "全画面を終了"
       },
       "title": {
-        "empty": "ゴミ箱を空にする",
-        "restore": "ゴミ箱から復元"
+        "empty": "アーカイブから削除する",
+        "restore": "アーカイブから戻す"
       },
       "confirm": {
         "title": "ゴミ箱を空にしますか?",
@@ -129,7 +129,7 @@
       },
       "buttons": {
         "cancel": "キャンセル",
-        "confirmDelete": "ゴミ箱を空にする",
+        "confirmDelete": "アーカイブから削除する",
         "restore": "復元",
         "restoreWithCount": "復元 ({{count}})",
         "empty": "削除",
@@ -142,7 +142,7 @@
       "aria": {
         "restore": "選択した項目を復元",
         "restoreWithCount": "{{unit}}を{{count}}件復元",
-        "empty": "ゴミ箱を空にする",
+        "empty": "アーカイブから削除する",
         "emptyWithCount": "{{unit}}を{{count}}件削除"
       },
       "units": {
@@ -289,11 +289,11 @@
         "copy": "コピー ({{shortcut}})",
         "paste": "貼り付け ({{shortcut}})",
         "duplicate": "複製 ({{shortcut}})",
-        "moveToTrash": "ゴミ箱に移動 ({{shortcut}})"
+        "moveToTrash": "アーカイブに移動する ({{shortcut}})"
       },
       "trashMenu": {
-        "restore": "ゴミ箱から復元",
-        "empty": "ゴミ箱を空にする"
+        "restore": "アーカイブから戻す",
+        "empty": "アーカイブから削除する"
       },
       "importExportMenu": {
         "import": "JSONファイルからインポート",
@@ -364,7 +364,7 @@
       "duplicate": "複製",
       "import": "インポート",
       "export": "エクスポート",
-      "moveToTrash": "ゴミ箱に移動",
+      "moveToTrash": "アーカイブに移動する",
       "visible": "表示",
       "hidden": "非表示",
       "checkReference": "参照を確認",
@@ -414,9 +414,9 @@
     },
     "errors": {
       "trashFailed": "ゴミ箱への移動に失敗しました。",
-      "trashReferencedByRoutes": "ルートが参照しているため、このロケーションはゴミ箱に移動できません。",
-      "trashReferencedByLocations": "ロケーションが参照しているため、このシェイプはゴミ箱に移動できません。",
-      "trashBuildSessionRunning": "ビルドセッション実行中のため、ゴミ箱へ移動できません。"
+      "trashReferencedByRoutes": "ルートが参照しているため、このロケーションはアーカイブに移動できません。",
+      "trashReferencedByLocations": "ロケーションが参照しているため、このシェイプはアーカイブに移動できません。",
+      "trashBuildSessionRunning": "ビルドセッション実行中のため、アーカイブに移動できません。"
     },
     "infoPanel": {
       "noTimestamp": "—",
@@ -435,10 +435,10 @@
       "noNode": "このページではノード情報を表示できません。",
       "createdLabel": "作成",
       "updatedLabel": "更新",
-      "confirmTrashTitle": "ゴミ箱に移動",
-      "confirmTrashDescription": "この項目と子要素をゴミ箱に移動しますか？",
+      "confirmTrashTitle": "アーカイブに移動する",
+      "confirmTrashDescription": "この項目と子要素をアーカイブに移動しますか？",
       "confirmTrashCancel": "キャンセル",
-      "confirmTrashConfirm": "ゴミ箱に移動"
+      "confirmTrashConfirm": "アーカイブに移動する"
     }
   },
   "treeTable": {


### PR DESCRIPTION
### Motivation
- UI の日本語表現で「ゴミ箱」系のアクション語を利用者向けにより適切な「アーカイブ」表現へ統一するため。

### Description
- 日本語ロケールファイル `app/public/locales/ja/common.json` と `packages/ui/i18n/public/locales/ja/common.json` を更新し、`ゴミ箱に移動`→`アーカイブに移動する`、`ゴミ箱を空にする`→`アーカイブから削除する`、`ゴミ箱から復元`→`アーカイブから戻す` の置換と周辺文の文法調整を行いました。変更は該当の i18n JSON に限定されています。 

### Testing
- 文字列置換前後を `rg` で検出・確認し、差分は上記 2 ファイルに限定されることを確認しました。 
- `pnpm -w turbo run typecheck --filter @hierarchidb/app` を実行しましたが、既存の型解決エラー（`Cannot find module '@hierarchidb/tree-api'`）により typecheck は失敗し、今回の i18n 変更が直接の原因ではないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698edf3242c88323922d064ccb2d2d64)