### PR TITLE
fix(shape-plugin): add startup transition watchdog diagnostics

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -39,6 +39,8 @@
 
 ### Doing
 
+- #252 / `codex/chore/repo/unify-trash-to-archive` / start: 2026-02-13 18:44 JST
+- #250 / `codex/fix/shape/worker-init-stall-no-log` / start: 2026-02-13 18:02 JST
 - #247 / `codex/fix/shape/no-task-complete-guard` / start: 2026-02-13 14:56 JST
 - #241 / `codex/feat/ui/speeddial-submenu` / start: 2026-02-13 11:13 JST
 - #243 / `codex/feat/app/ssot-template-create-menus` / start: 2026-02-13 12:04 JST
@@ -66,12 +68,22 @@
 
 ### Blocked
 
+- #252 / `codex/chore/repo/unify-trash-to-archive` / blocked: 2026-02-13 18:52 JST（`pnpm typecheck` が差分外既知ブロッカー `@hierarchidb/route-plugin` の型不整合で exit 2、`pnpm test` が差分外既知ブロッカー `@hierarchidb/ui-routing` の `packages/_obsolate_common/api` 参照不整合で exit 1）
+- #250 / `codex/fix/shape/worker-init-stall-no-log` / blocked: 2026-02-13 18:11 JST（`pnpm -w turbo run typecheck --filter @hierarchidb/app` が差分外既知ブロッカー `@hierarchidb/shape-plugin` の `vtConfig.debug.tiles` readonly/mutable 競合で exit 2）
 - #243 / `codex/feat/app/ssot-template-create-menus` / blocked: 2026-02-13 12:30 JST（`pnpm -w turbo run typecheck --filter @hierarchidb/app --filter @hierarchidb/ui-i18n --filter @hierarchidb/ui-treeconsole-breadcrumb --filter @hierarchidb/ui-treeconsole-toolbar --filter @hierarchidb/ui-treeconsole-treetable` が差分外 `@hierarchidb/shape-plugin` の既知型不整合 `vtConfig.debug.tiles` readonly/mutable 競合で exit 2）
 - #241 / `codex/feat/ui/speeddial-submenu` / blocked: 2026-02-13 11:57 JST（`pnpm -w turbo run typecheck --filter @hierarchidb/ui-speeddial-submenu --filter @hierarchidb/ui-treeconsole-breadcrumb --filter @hierarchidb/app` が差分外 `@hierarchidb/shape-plugin` の既知型不整合 `vtConfig.debug.tiles` readonly/mutable 競合で exit 2）
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
 
+- update: 2026-02-13 18:52 JST #252 `Trash/ゴミ箱` → `Archive/アーカイブ` の全置換を実施。追跡ファイル 223 件を対象に識別子・i18n・文言・ルート・ドキュメントを置換し、`app/src/router/pages/tree/archive/*` や `packages/ui/treeconsole/toolbar/src/components/toolbar/ArchiveMenu.tsx` など `trash` 含みのファイル/ディレクトリを `git mv` で改名。`pnpm build` は初回失敗（`RestoreFromArchive` icon 未存在）を `Restore` icon へ修正後、exit 0 で完了。
+- blocked: 2026-02-13 18:52 JST #252 検証結果: `pnpm install --frozen-lockfile` exit 0 / `pnpm build` exit 0。`pnpm typecheck` は `@hierarchidb/route-plugin` 既知型不整合（Dexie ctor, RouteTileSettings型）で exit 2。`pnpm test` は `@hierarchidb/ui-routing` の Vitest 設定で `packages/_obsolate_common/api` 参照不整合により exit 1。対象差分で追加実行した `pnpm -w turbo run test --filter @hierarchidb/app -- --run src/router/pages/tree/archive/__tests__/unit/*.test.ts` も `vitest.setup.base.ts` の `node-fetch` import 解決失敗で exit 1。
+- update: 2026-02-13 18:44 JST Issue `chore(repo): unify Trash/ゴミ箱 naming to Archive/アーカイブ` を起票し `https://github.com/kubohiroya/hierarchidb/issues/252` を作成。Project `hierarchidb` に追加して Status を `In Progress` に設定し、専用 worktree `/Users/hiroya/WebstormProjects/hierarchidb-archive-unify` とブランチ `codex/chore/repo/unify-trash-to-archive` を作成して着手。
+- update: 2026-02-13 18:11 JST #250 で `app/src/contexts/WorkerProvider.tsx` を修正。`initStarted/initCompleted` のモジュールグローバル制御を撤去し、コンポーネントローカルの in-flight/complete ref へ置換。再マウント時にも初期化を再実行できるようにし、`ensureInitialized` の明示タイムアウト race・開始/進捗/完了/失敗の診断ログを追加した。
+- update: 2026-02-13 18:11 JST #250 で回帰テスト `app/src/contexts/WorkerProvider.remount.unit.test.tsx` を追加し、「初回マウント中の初期化が未完でも再マウントで初期化呼び出しが増える」ことを検証。
+- update: 2026-02-13 18:11 JST #250 検証結果: `pnpm -w turbo run test --filter @hierarchidb/app -- --run src/contexts/WorkerProvider.remount.unit.test.tsx` exit 0、`pnpm -w turbo run test --filter @hierarchidb/app -- --run src/worker-runtime/__tests__/unit/initialize-worker-state.unit.test.ts` exit 0、`pnpm -w turbo run build --filter @hierarchidb/app` exit 0。
+- blocked: 2026-02-13 18:11 JST #250 `pnpm e2e:shape-startup` は `waitForTreeTableLoad` で timeout（`Received: waiting`）かつ `504 Outdated Optimize Dep` により失敗（exit 1）。Worker初期化不具合そのものの成否判定に入る前段で停止。
+- update: 2026-02-13 18:02 JST Issue `fix(shape): Worker initialization stalls at 50% without diagnostics` を起票し `https://github.com/kubohiroya/hierarchidb/issues/250` を作成。Project `hierarchidb` に追加して Status を `In Progress` に設定し、ブランチ `codex/fix/shape/worker-init-stall-no-log` を作成して着手。
 - update: 2026-02-13 14:56 JST Issue `fix(shape): prevent silent build completion without tasks` を起票し `https://github.com/kubohiroya/hierarchidb/issues/247` を作成。Project `hierarchidb` に追加して Status を `In Progress` に設定し、ブランチ `codex/fix/shape/no-task-complete-guard` を作成して着手。
 - update: 2026-02-13 12:30 JST #243 で SSOT `app/src/features/templates/nodeCreateTemplates.ts` を導入し、ノードタイプ別テンプレート一覧（shape presets / folder template `population-2023`）を一元定義。`create:shape::preset:*` と `create:folder::template:*` の parser・実行解決を共通化し、folder template は import API 実行で即作成できるようにした。
 - update: 2026-02-13 12:30 JST #243 UI再編として `app/src/plugin-loaders/menu-builders.ts` をSSOT参照に変更し、SpeedDial/ContextMenu の create submenu をノードタイプ別テンプレートから自動構築。resources ツリーでは folder submenu から `Population by Countries` を選択可能にした。

--- a/e2e/shape/shape-build-startup-first-task.spec.ts
+++ b/e2e/shape/shape-build-startup-first-task.spec.ts
@@ -1,5 +1,5 @@
 import '../utils/skip-if-disabled';
-import { test, expect, type ConsoleMessage } from '@playwright/test';
+import { test, expect, type ConsoleMessage, type Page, type Worker } from '@playwright/test';
 import {
   buildAppUrl,
   clearTestData,
@@ -11,6 +11,7 @@ import {
 type SelectedArrayByCountries = Record<string, boolean[]>;
 
 type ConsolePayload = Record<string, unknown>;
+type WorkerDiagnostics = Record<string, unknown>;
 
 type E2EAuthSeed = {
   accessToken: string;
@@ -62,6 +63,88 @@ const readConsolePayload = async (msg: ConsoleMessage): Promise<ConsolePayload |
 const readString = (payload: ConsolePayload | null, key: string): string | null => {
   const value = payload?.[key];
   return typeof value === 'string' ? value : null;
+};
+
+const appendWorkerTraceLog = (
+  workerStartupLogs: string[],
+  source: string,
+  text: string,
+): void => {
+  workerStartupLogs.push(`[${source}] ${text}`);
+  if (workerStartupLogs.length > 200) {
+    workerStartupLogs.splice(0, workerStartupLogs.length - 200);
+  }
+};
+
+const collectWorkerDiagnostics = async (page: Page, nodeId: string): Promise<WorkerDiagnostics> => {
+  return page.evaluate(async (targetNodeId) => {
+    const ref = (window as any).__HDB_WORKER_CLIENT_REF__;
+    if (!ref) {
+      return { error: 'worker-ref-missing' };
+    }
+    try {
+      if (!ref.isInitialized && typeof ref.initialize === 'function') {
+        await ref.initialize();
+      }
+      const api = ref.client ?? ref.getAPI?.();
+      if (!api) {
+        return { error: 'worker-api-missing' };
+      }
+      const [tasksResult, statusResult, sessionRecordResult] = await Promise.all([
+        (async () => {
+          try {
+            const tasks = await api.getBuildTasks('shape', targetNodeId);
+            return { ok: true, tasks };
+          } catch (error) {
+            return { ok: false, error: error instanceof Error ? error.message : String(error) };
+          }
+        })(),
+        (async () => {
+          try {
+            const status = await api.getBuildSessionStatus('shape', targetNodeId);
+            return { ok: true, status };
+          } catch (error) {
+            return { ok: false, error: error instanceof Error ? error.message : String(error) };
+          }
+        })(),
+        (async () => {
+          try {
+            const queryApi = await api.getShapeQueryAPI();
+            const sessionRecord = await queryApi.getBuildSessionRecord(targetNodeId);
+            return { ok: true, sessionRecord };
+          } catch (error) {
+            return { ok: false, error: error instanceof Error ? error.message : String(error) };
+          }
+        })(),
+      ]);
+      const tasks = tasksResult.ok && Array.isArray(tasksResult.tasks) ? tasksResult.tasks : [];
+      const status = statusResult.ok ? statusResult.status : null;
+      const sessionRecord = sessionRecordResult.ok ? sessionRecordResult.sessionRecord : null;
+      return {
+        taskCount: tasks.length,
+        taskHead: tasks.slice(0, 5).map((task: Record<string, unknown>) => ({
+          taskId: task.taskId,
+          type: task.type ?? task.stage,
+          status: task.status,
+          progress: task.progress,
+        })),
+        batchStatus: status,
+        sessionStatus: sessionRecord?.status ?? null,
+        sessionStopReason: sessionRecord?.stopReason ?? null,
+        sessionProgressTotal: sessionRecord?.progress?.total ?? null,
+        sessionProgressCompleted: sessionRecord?.progress?.completed ?? null,
+        sessionProgressFailed: sessionRecord?.progress?.failed ?? null,
+        sessionStageId: sessionRecord?.stageId ?? null,
+        sessionStageHeartbeatAt: sessionRecord?.stageHeartbeatAt ?? null,
+        sessionUpdatedAt: sessionRecord?.updatedAt ?? null,
+        taskQueryError: tasksResult.ok ? null : tasksResult.error,
+        statusQueryError: statusResult.ok ? null : statusResult.error,
+        sessionQueryError: sessionRecordResult.ok ? null : sessionRecordResult.error,
+      };
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  }, nodeId);
 };
 
 test.describe('Shape build startup first-task UX', () => {
@@ -249,6 +332,7 @@ test.describe('Shape build startup first-task UX', () => {
     const firstTaskSuccessLogs: string[] = [];
     const firstTaskFailureLogs: string[] = [];
     const authRequiredLogs: string[] = [];
+    const workerStartupLogs: string[] = [];
     const startupTrace: string[] = [];
     const pushStartupTrace = (entry: string): void => {
       startupTrace.push(entry);
@@ -260,8 +344,19 @@ test.describe('Shape build startup first-task UX', () => {
     const handleStartupConsole = (msg: ConsoleMessage) => {
       const pending = (async () => {
         const text = msg.text();
-        if (text.includes('[ShapeBuildProgressStep]') || text.includes('[ShapeBuildStartResumeTrace]')) {
+        if (
+          text.includes('[ShapeBuildProgressStep]')
+          || text.includes('[ShapeBuildStartResumeTrace]')
+          || text.includes('[ShapeAwaitingFirstTaskDecisionTrace]')
+          || text.includes('[ShapeBuildWorkerStageTrace]')
+        ) {
           pushStartupTrace(text);
+        }
+        if (text.includes('[shapeBatchAPI] startup')) {
+          workerStartupLogs.push(text);
+          if (workerStartupLogs.length > 120) {
+            workerStartupLogs.splice(0, workerStartupLogs.length - 120);
+          }
         }
         if (text.includes('Authentication required')) {
           authRequiredLogs.push(text);
@@ -309,6 +404,34 @@ test.describe('Shape build startup first-task UX', () => {
         pendingConsoleTasks.delete(pending);
       });
     };
+
+    const workerConsoleHandlers = new Map<Worker, (msg: ConsoleMessage) => void>();
+    const attachWorkerConsole = (worker: Worker) => {
+      if (workerConsoleHandlers.has(worker)) return;
+      appendWorkerTraceLog(workerStartupLogs, 'worker-attach', worker.url());
+      const handler = (msg: ConsoleMessage) => {
+        const text = msg.text();
+        if (
+          text.includes('[shapeBatchAPI] startup')
+          || text.includes('[shapeBatchAPI] progress snapshot')
+          || text.includes('[ShapePipeline]')
+        ) {
+          appendWorkerTraceLog(workerStartupLogs, `worker:${worker.url()}`, text);
+        }
+      };
+      workerConsoleHandlers.set(worker, handler);
+      worker.on('console', handler);
+    };
+    const detachWorkerConsoles = () => {
+      workerConsoleHandlers.forEach((handler, worker) => {
+        worker.off('console', handler);
+        appendWorkerTraceLog(workerStartupLogs, 'worker-detach', worker.url());
+      });
+      workerConsoleHandlers.clear();
+    };
+
+    page.workers().forEach(attachWorkerConsole);
+    page.on('worker', attachWorkerConsole);
     page.on('console', handleStartupConsole);
 
     try {
@@ -331,14 +454,32 @@ test.describe('Shape build startup first-task UX', () => {
       const waitStartMs = Date.now();
       while (Date.now() - waitStartMs < 60000) {
         await Promise.allSettled(Array.from(pendingConsoleTasks));
+        const workerTrace = workerStartupLogs.slice(-20).join('\n');
         if (authRequiredLogs.length > 0) {
-          throw new Error(`Auth required during build start: ${authRequiredLogs[0]}`);
+          throw new Error(
+            `Auth required during build start: ${authRequiredLogs[0]}`
+            + `\nRecent worker startup trace:\n${workerTrace || '(none)'}`
+          );
         }
         if (startupTimeoutLogs.length > 0) {
-          throw new Error(`Startup timeout detected: ${startupTimeoutLogs[0]}`);
+          const workerDiagnostics = await collectWorkerDiagnostics(page, String(shapeNode.nodeId));
+          const recentTrace = startupTrace.slice(-25).join('\n');
+          throw new Error(
+            `Startup timeout detected: ${startupTimeoutLogs[0]}`
+            + `\nRecent startup trace:\n${recentTrace || '(none)'}`
+            + `\nRecent worker startup trace:\n${workerTrace || '(none)'}`
+            + `\nWorker diagnostics:\n${JSON.stringify(workerDiagnostics)}`
+          );
         }
         if (firstTaskFailureLogs.length > 0) {
-          throw new Error(`Startup failed before first-task signal: ${firstTaskFailureLogs[0]}`);
+          const workerDiagnostics = await collectWorkerDiagnostics(page, String(shapeNode.nodeId));
+          const recentTrace = startupTrace.slice(-25).join('\n');
+          throw new Error(
+            `Startup failed before first-task signal: ${firstTaskFailureLogs[0]}`
+            + `\nRecent startup trace:\n${recentTrace || '(none)'}`
+            + `\nRecent worker startup trace:\n${workerTrace || '(none)'}`
+            + `\nWorker diagnostics:\n${JSON.stringify(workerDiagnostics)}`
+          );
         }
         if (firstTaskSuccessLogs.length > 0) {
           break;
@@ -347,8 +488,10 @@ test.describe('Shape build startup first-task UX', () => {
       }
       if (firstTaskSuccessLogs.length === 0) {
         const recentTrace = startupTrace.slice(-15).join('\n');
+        const workerTrace = workerStartupLogs.slice(-20).join('\n');
         throw new Error(
           `No explicit startup outcome within 60s.\nRecent startup trace:\n${recentTrace || '(none)'}`
+          + `\nRecent worker startup trace:\n${workerTrace || '(none)'}`
         );
       }
 
@@ -357,6 +500,8 @@ test.describe('Shape build startup first-task UX', () => {
       expect(firstTaskFailureLogs).toHaveLength(0);
       expect(firstTaskSuccessLogs.length).toBeGreaterThan(0);
     } finally {
+      page.off('worker', attachWorkerConsole);
+      detachWorkerConsoles();
       page.off('console', handleStartupConsole);
     }
   });

--- a/plans/shape-build-session-comprehensive-stability-execplan.md
+++ b/plans/shape-build-session-comprehensive-stability-execplan.md
@@ -22,6 +22,7 @@ After this change, a user can clear IndexedDB, re-authenticate, start a Shape bu
 - [x] (2026-02-13 12:00 JST) Validated Create Shape Step5 startup path with Chrome DevTools MCP (`localhost:4200`) and captured payload evidence.
 - [x] (2026-02-13 12:14 JST) Ran Playwright E2E with explicit auth seed (`E2E_AUTH_ACCESS_TOKEN`) and `/auth/verify` precheck; scenario passed without startup timeout.
 - [x] (2026-02-13 12:50 JST) Added `pnpm e2e:shape-startup` wrapper and local auth-seed file support (`e2e/.auth/shape-startup-auth.json`), including fail-fast checks for missing seed.
+- [x] (2026-02-13 15:20 JST) Added `task stream ready` gating so `awaiting-first-task` does not finalize on uninitialized `taskCount` (undefined), and updated unit/integration coverage.
 - [ ] Update this plan with final outcomes and retrospective.
 
 ## Surprises & Discoveries

--- a/plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md
+++ b/plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md
@@ -55,19 +55,49 @@ stateDiagram-v2
         InitializingWorker --> StartingSession: resume ❓
         BuildingPayloads --> StartingSession: payload ready ❓
         StartingSession --> AwaitingFirstTask: request accepted ✅
-        AwaitingFirstTask --> [*]: first task signal observed ✅
-        AwaitingFirstTask --> [*]: completed without tasks ✅
-        AwaitingFirstTask --> [*]: timeout / failed / paused ❓
     }
 
     Starting --> Processing: startup success ✅
-    Starting --> Failed: startup error / timeout ❓
+    Starting --> Failed: startup error / timeout ❌
     Processing --> Paused: Pause ❓
     Paused --> Starting: Resume ❓
     Processing --> Completed: Success ❓
     Processing --> Failed: Error ❓
     Completed --> Idle: Close Dialog ❓
     Failed --> Idle: Abort / Close ❓
+```
+
+### AwaitingFirstTask 以降の詳細分岐（実装準拠）
+
+```mermaid
+flowchart TD
+    A["AwaitingFirstTask"] --> B{"hasFirstTaskSignal?"}
+    A --> T["timeout (45s)"]:::ng
+
+    B -->|"yes + started task"| S1["startup success: task-execution-started"]:::ok
+    B -->|"yes + queued/progress only"| S2["startup success: task-queue-observed"]:::ok
+    B -->|"no"| C{"buildStatus"}
+
+    C -->|"running"| W1["continue waiting"]:::ok
+    C -->|"failed"| E1["startup error: failed-before-task-start"]:::ok
+    C -->|"paused"| P{"isPausePending?"}
+    C -->|"completed"| D{"isTaskStreamReady?"}
+
+    P -->|"true"| W2["continue waiting"]:::ok
+    P -->|"false"| X1["startup cancelled: paused-before-task-start"]:::ok
+
+    D -->|"false"| W3["continue waiting"]:::ok
+    D -->|"true"| E{"taskCount is number?"}
+    E -->|"no (undefined)"| W4["continue waiting"]:::ok
+    E -->|"yes"| F{"taskCount === 0?"}
+
+    F -->|"no"| S3["startup success: completed-before-first-task-update"]:::ok
+    F -->|"yes"| G{"expectTaskGeneration?"}
+    G -->|"true"| W5["continue waiting"]:::ok
+    G -->|"false"| S4["startup success: completed-without-generating-tasks"]:::ok
+
+    classDef ok fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    classDef ng fill:#ffebee,stroke:#c62828,color:#b71c1c
 ```
 
 ```mermaid
@@ -80,23 +110,42 @@ stateDiagram-v2
 
 - 実行ステージは `fetch -> transform -> vt`。
 - 起動フェーズ `awaiting-first-task` は待機監視対象で、10s で wait 通知、20s で long-wait 警告、45s で timeout エラー終了。
-- `awaiting-first-task` のテスト済みシグナル判定:
+- `awaiting-first-task` の task-signal 判定:
   - `running/completed/failed/...` タスク受信
   - `queued` タスク受信
   - progress メタデータ（`progressTaskId` または `total > 0`）受信
-- 遷移テストの主要証跡:
-  - ユニット: `plugins/shape-plugin/src/ui/__tests__/hooks/unit/awaitingFirstTaskSignal.unit.test.ts`
-  - ユニット: `plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts`
-  - 結合（hook）: `plugins/shape-plugin/src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx`
-  - E2E（Step5 起動）: `e2e/shape/shape-build-startup-first-task.spec.ts`
-- MCP 実ブラウザ確認（`localhost:4200`, 2026-02-13 12:00 JST）:
-  - `start session response: { status: "running", hasError: false }` の後、`awaiting-first-task` は `outcome: "success"` で終了（`reason: "completed-without-generating-tasks"`, `elapsedMs: 48`）。
-  - 同 run では `build session transition timeout` ログは未観測（timeout 再発なし）。
-- E2E 自動検証（Playwright, 2026-02-13 12:14 JST）:
-  - `e2e/shape/shape-build-startup-first-task.spec.ts` は `E2E_AUTH_ACCESS_TOKEN` 注入 + `/auth/verify` 成功を前提に pass（`awaiting-first-task` timeout 非発生を確認）。
-  - 実行導線: `pnpm e2e:shape-startup`（`e2e/.auth/shape-startup-auth.json` または `E2E_AUTH_ACCESS_TOKEN` を利用）。
-- 現在の blocked（❌）:
-  - 認証シード未設定時の Playwright 実行は `Authentication required` で startup 検証に未到達（環境依存のため `E2E_AUTH_ACCESS_TOKEN` などの注入が必要）。
+- task stream の初回同期完了前は `taskCount` を `undefined` として扱う。
+- ただし Worker session の `progress.total > 0` が確認できた場合は、task stream 未同期でも `completed-with-session-progress-evidence` で成功遷移する。
+- `buildStatus=failed` で失敗遷移する場合は Worker `stageId` をエラーメッセージへ埋め込み、失敗位置を UI ログから直接追跡できるようにする。
+
+### AwaitingFirstTask 遷移マトリクス（矢印とテスト証跡）
+
+| ID | 遷移 | 条件（要約） | 状態 | 主な証跡 |
+| --- | --- | --- | --- | --- |
+| AFT-01 | `AwaitingFirstTask -> success(task-execution-started)` | `hasFirstTaskSignal && hasStartedTasks` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-02 | `AwaitingFirstTask -> success(task-queue-observed)` | `hasFirstTaskSignal && !hasStartedTasks` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` / integration: `buildSessionStartup.integration.test.tsx` |
+| AFT-03 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=running && no signal` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-04 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=completed && !isTaskStreamReady && sessionProgressTotal<=0` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-05 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=completed && taskCount=undefined && sessionProgressTotal<=0` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-06 | `AwaitingFirstTask -> success(completed-before-first-task-update)` | `buildStatus=completed && taskCount>0` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-07 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=completed && taskCount=0 && expectTaskGeneration=true` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-08 | `AwaitingFirstTask -> success(completed-without-generating-tasks)` | `buildStatus=completed && taskCount=0 && expectTaskGeneration=false` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` / e2e: `shape-build-startup-first-task.spec.ts` |
+| AFT-09 | `AwaitingFirstTask -> success(completed-with-session-progress-evidence)` | `buildStatus=completed && sessionProgressTotal>0 && (task stream未同期 or taskCount未確定 or taskCount=0)` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` / e2e: `shape-build-startup-first-task.spec.ts` |
+| AFT-10 | `AwaitingFirstTask -> error(failed-before-task-start)` | `buildStatus=failed`（`sessionStageId` があればメッセージへ付与） | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-11 | `AwaitingFirstTask -> cancelled(paused-before-task-start)` | `buildStatus=paused && !isPausePending` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-12 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=paused && isPausePending` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
+| AFT-13 | `AwaitingFirstTask -> error(timeout)` | `awaiting-first-task elapsed >= 45s` | ✅ | unit: `resolveStartupTransitionWatchdogEvent.unit.test.ts` |
+
+### 検証ソース一覧
+
+- Unit:
+  - `plugins/shape-plugin/src/ui/__tests__/hooks/unit/awaitingFirstTaskSignal.unit.test.ts`
+  - `plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts`
+  - `plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveStartupTransitionWatchdogEvent.unit.test.ts`
+- Integration:
+  - `plugins/shape-plugin/src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx`
+- E2E:
+  - `e2e/shape/shape-build-startup-first-task.spec.ts`
 
 ## ダイアログ制御の詳細仕様
 

--- a/plugins/shape-plugin/src/services/vt/shapePipeline.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipeline.ts
@@ -357,15 +357,63 @@ const runCleanupStage = async (context: ShapePipelineContext): Promise<void> => 
 
 export const runShapePipeline = async (params: ShapePipelineParams): Promise<void> => {
   const context = await createShapePipelineContext(params);
-  await preparePipelineRun(context);
+  const markPipelineCheckpoint = (stage: string, phase: 'start' | 'success' | 'error'): void => {
+    void shapeMutationAPIImpl.updateBuildSession(params.nodeId, {
+      stageId: `pipeline:${stage}:${phase}`,
+      stageHeartbeatAt: Date.now(),
+    }).catch(() => {});
+  };
+  const checkpoint = async <T>(stage: string, action: () => Promise<T>): Promise<T> => {
+    const startedAt = Date.now();
+    markPipelineCheckpoint(stage, 'start');
+    console.warn('[ShapePipeline][Checkpoint] start', JSON.stringify({
+      nodeId: params.nodeId,
+      runId: params.pipelineRunId ?? null,
+      stage,
+      startedAt,
+    }));
+    try {
+      const result = await action();
+      const finishedAt = Date.now();
+      markPipelineCheckpoint(stage, 'success');
+      console.warn('[ShapePipeline][Checkpoint] finish', JSON.stringify({
+        nodeId: params.nodeId,
+        runId: params.pipelineRunId ?? null,
+        stage,
+        outcome: 'success',
+        startedAt,
+        finishedAt,
+        elapsedMs: finishedAt - startedAt,
+      }));
+      return result;
+    } catch (error) {
+      const finishedAt = Date.now();
+      markPipelineCheckpoint(stage, 'error');
+      console.error('[ShapePipeline][Checkpoint] finish', JSON.stringify({
+        nodeId: params.nodeId,
+        runId: params.pipelineRunId ?? null,
+        stage,
+        outcome: 'error',
+        startedAt,
+        finishedAt,
+        elapsedMs: finishedAt - startedAt,
+        errorMessage: error instanceof Error ? error.message : String(error),
+        errorName: error instanceof Error ? error.name : undefined,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      }));
+      throw error;
+    }
+  };
 
-  let stopAfterStage = await runFetchStage(context);
+  await checkpoint('prepare-pipeline-run', async () => preparePipelineRun(context));
+
+  let stopAfterStage = await checkpoint('fetch-stage', async () => runFetchStage(context));
   if (!stopAfterStage) {
-    stopAfterStage = await runTransformStage(context);
+    stopAfterStage = await checkpoint('transform-stage', async () => runTransformStage(context));
   }
   if (!stopAfterStage) {
-    await runVtStage(context);
+    await checkpoint('vt-stage', async () => runVtStage(context));
   }
-  await runMetadataStage(context);
-  await runCleanupStage(context);
+  await checkpoint('metadata-stage', async () => runMetadataStage(context));
+  await checkpoint('cleanup-stage', async () => runCleanupStage(context));
 };

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx
@@ -38,6 +38,7 @@ describe('buildSessionStartup integration baseline', () => {
     const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
     try {
       const { result } = renderHook(() => useShapeBuildTasks('node-integration'));
+      expect(result.current.isTaskStreamReady).toBe(false);
 
       await act(async () => {
         await Promise.resolve();
@@ -66,6 +67,7 @@ describe('buildSessionStartup integration baseline', () => {
       });
 
       expect(result.current.tasks).toHaveLength(1);
+      expect(result.current.isTaskStreamReady).toBe(true);
 
       const hasQueuedTasks = result.current.tasks.some((task) => task.status === 'queued');
       const hasStartedTasks = result.current.tasks.some((task) => (

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts
@@ -9,7 +9,9 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       hasProgressTaskSignal: true,
       buildStatus: 'running',
       taskCount: 3,
+      isTaskStreamReady: true,
       isPausePending: false,
+      expectTaskGeneration: true,
     });
     expect(decision).toMatchObject({
       kind: 'success',
@@ -31,7 +33,9 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       hasProgressTaskSignal: false,
       buildStatus: 'running',
       taskCount: 1,
+      isTaskStreamReady: true,
       isPausePending: false,
+      expectTaskGeneration: true,
     });
     expect(decision).toMatchObject({
       kind: 'success',
@@ -53,7 +57,9 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       hasProgressTaskSignal: false,
       buildStatus: 'completed',
       taskCount: 0,
+      isTaskStreamReady: true,
       isPausePending: false,
+      expectTaskGeneration: false,
     });
     expect(decision).toEqual({
       kind: 'success',
@@ -65,20 +71,18 @@ describe('resolveAwaitingFirstTaskDecision', () => {
     });
   });
 
-  it('returns success without extra transition when completed with tasks', () => {
+  it('continues waiting when completed without tasks but task generation is expected', () => {
     const decision = resolveAwaitingFirstTaskDecision({
       hasFirstTaskSignal: false,
       hasStartedTasks: false,
       hasProgressTaskSignal: false,
       buildStatus: 'completed',
-      taskCount: 2,
+      taskCount: 0,
+      isTaskStreamReady: true,
       isPausePending: false,
+      expectTaskGeneration: true,
     });
-    expect(decision).toEqual({
-      kind: 'success',
-      reason: 'completed-before-first-task-update',
-      transitionFinish: undefined,
-    });
+    expect(decision).toEqual({ kind: 'continue' });
   });
 
   it('returns error when build fails before first task start', () => {
@@ -88,7 +92,9 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       hasProgressTaskSignal: false,
       buildStatus: 'failed',
       taskCount: 0,
+      isTaskStreamReady: false,
       isPausePending: false,
+      expectTaskGeneration: true,
     });
     expect(decision).toEqual({
       kind: 'error',
@@ -100,6 +106,28 @@ describe('resolveAwaitingFirstTaskDecision', () => {
     });
   });
 
+  it('includes worker stageId in failure message when available', () => {
+    const decision = resolveAwaitingFirstTaskDecision({
+      hasFirstTaskSignal: false,
+      hasStartedTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'failed',
+      taskCount: 0,
+      isTaskStreamReady: false,
+      isPausePending: false,
+      expectTaskGeneration: true,
+      sessionStageId: 'pipeline:fetch-stage:error',
+    });
+    expect(decision).toEqual({
+      kind: 'error',
+      reason: 'failed-before-task-start',
+      transitionFinish: {
+        level: 'error',
+        message: 'Build failed before task execution started (worker stage: pipeline:fetch-stage:error).',
+      },
+    });
+  });
+
   it('returns cancelled when paused before first task start and pause is not pending', () => {
     const decision = resolveAwaitingFirstTaskDecision({
       hasFirstTaskSignal: false,
@@ -107,7 +135,9 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       hasProgressTaskSignal: false,
       buildStatus: 'paused',
       taskCount: 0,
+      isTaskStreamReady: false,
       isPausePending: false,
+      expectTaskGeneration: true,
     });
     expect(decision).toEqual({
       kind: 'cancelled',
@@ -126,7 +156,135 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       hasProgressTaskSignal: false,
       buildStatus: 'paused',
       taskCount: 0,
+      isTaskStreamReady: false,
       isPausePending: true,
+      expectTaskGeneration: true,
+    });
+    expect(decision).toEqual({ kind: 'continue' });
+  });
+
+  it('continues waiting while task stream is not ready even if status is completed', () => {
+    const decision = resolveAwaitingFirstTaskDecision({
+      hasFirstTaskSignal: false,
+      hasStartedTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'completed',
+      taskCount: 0,
+      isTaskStreamReady: false,
+      isPausePending: false,
+      expectTaskGeneration: true,
+    });
+    expect(decision).toEqual({ kind: 'continue' });
+  });
+
+  it('returns success when stream is not ready but worker session progress proves completion', () => {
+    const decision = resolveAwaitingFirstTaskDecision({
+      hasFirstTaskSignal: false,
+      hasStartedTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'completed',
+      taskCount: undefined,
+      isTaskStreamReady: false,
+      isPausePending: false,
+      expectTaskGeneration: true,
+      sessionProgressTotal: 5,
+    });
+    expect(decision).toEqual({
+      kind: 'success',
+      reason: 'completed-with-session-progress-evidence',
+      transitionFinish: {
+        level: 'info',
+        message: 'Build completed before task stream synchronization.',
+      },
+    });
+  });
+
+  it('continues waiting while task count is still unknown after stream becomes ready', () => {
+    const decision = resolveAwaitingFirstTaskDecision({
+      hasFirstTaskSignal: false,
+      hasStartedTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'completed',
+      taskCount: undefined,
+      isTaskStreamReady: true,
+      isPausePending: false,
+      expectTaskGeneration: true,
+    });
+    expect(decision).toEqual({ kind: 'continue' });
+  });
+
+  it('returns success when task count is unknown but worker session progress proves completion', () => {
+    const decision = resolveAwaitingFirstTaskDecision({
+      hasFirstTaskSignal: false,
+      hasStartedTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'completed',
+      taskCount: undefined,
+      isTaskStreamReady: true,
+      isPausePending: false,
+      expectTaskGeneration: true,
+      sessionProgressTotal: 5,
+    });
+    expect(decision).toEqual({
+      kind: 'success',
+      reason: 'completed-with-session-progress-evidence',
+      transitionFinish: {
+        level: 'info',
+        message: 'Build completed before task stream synchronization.',
+      },
+    });
+  });
+
+  it('returns success when completed after at least one task record is observed', () => {
+    const decision = resolveAwaitingFirstTaskDecision({
+      hasFirstTaskSignal: false,
+      hasStartedTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'completed',
+      taskCount: 2,
+      isTaskStreamReady: true,
+      isPausePending: false,
+      expectTaskGeneration: true,
+    });
+    expect(decision).toEqual({
+      kind: 'success',
+      reason: 'completed-before-first-task-update',
+      transitionFinish: undefined,
+    });
+  });
+
+  it('returns success when completed with zero UI tasks but worker session progress proves task execution', () => {
+    const decision = resolveAwaitingFirstTaskDecision({
+      hasFirstTaskSignal: false,
+      hasStartedTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'completed',
+      taskCount: 0,
+      isTaskStreamReady: true,
+      isPausePending: false,
+      expectTaskGeneration: true,
+      sessionProgressTotal: 5,
+    });
+    expect(decision).toEqual({
+      kind: 'success',
+      reason: 'completed-with-session-progress-evidence',
+      transitionFinish: {
+        level: 'info',
+        message: 'Build completed before task stream synchronization.',
+      },
+    });
+  });
+
+  it('continues waiting while build is still running and no first-task signal exists', () => {
+    const decision = resolveAwaitingFirstTaskDecision({
+      hasFirstTaskSignal: false,
+      hasStartedTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'running',
+      taskCount: undefined,
+      isTaskStreamReady: false,
+      isPausePending: false,
+      expectTaskGeneration: true,
     });
     expect(decision).toEqual({ kind: 'continue' });
   });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveStartupTransitionWatchdogEvent.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveStartupTransitionWatchdogEvent.unit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveStartupTransitionWatchdogEvent,
+  START_DIAGNOSTIC_LONG_WAIT_MS,
+  START_DIAGNOSTIC_TIMEOUT_MS,
+  START_DIAGNOSTIC_WARN_MS,
+} from '../../../components/build-progress/resolveStartupTransitionWatchdogEvent.ts';
+
+describe('resolveStartupTransitionWatchdogEvent', () => {
+  it('returns wait when warn threshold is reached first time', () => {
+    const event = resolveStartupTransitionWatchdogEvent({
+      elapsedMs: START_DIAGNOSTIC_WARN_MS,
+      warnStep: 0,
+    });
+    expect(event).toEqual({
+      kind: 'wait',
+      nextWarnStep: 1,
+    });
+  });
+
+  it('returns long-wait when long threshold is reached after wait', () => {
+    const event = resolveStartupTransitionWatchdogEvent({
+      elapsedMs: START_DIAGNOSTIC_LONG_WAIT_MS,
+      warnStep: 1,
+    });
+    expect(event).toEqual({
+      kind: 'long-wait',
+      nextWarnStep: 2,
+    });
+  });
+
+  it('returns timeout when timeout threshold is reached after long-wait', () => {
+    const event = resolveStartupTransitionWatchdogEvent({
+      elapsedMs: START_DIAGNOSTIC_TIMEOUT_MS,
+      warnStep: 2,
+    });
+    expect(event).toEqual({
+      kind: 'timeout',
+      nextWarnStep: 3,
+    });
+  });
+
+  it('returns none when timeout already emitted', () => {
+    const event = resolveStartupTransitionWatchdogEvent({
+      elapsedMs: START_DIAGNOSTIC_TIMEOUT_MS + 1000,
+      warnStep: 3,
+    });
+    expect(event).toEqual({
+      kind: 'none',
+      nextWarnStep: 3,
+    });
+  });
+});

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
@@ -56,6 +56,7 @@ describe('useShapeBuildTasks', () => {
 
   it('applies snapshot and update events without polling', async () => {
     const { result } = renderHook(() => useShapeBuildTasks('node-1'));
+    expect(result.current.isTaskStreamReady).toBe(false);
 
     await waitFor(() => {
       expect(subscribeMock).toHaveBeenCalled();
@@ -82,6 +83,7 @@ describe('useShapeBuildTasks', () => {
     await waitFor(() => {
       expect(result.current.tasks).toHaveLength(1);
       expect(result.current.isLoading).toBe(false);
+      expect(result.current.isTaskStreamReady).toBe(true);
     });
 
     act(() => {

--- a/plugins/shape-plugin/src/ui/components/build-progress/resolveAwaitingFirstTaskDecision.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/resolveAwaitingFirstTaskDecision.ts
@@ -24,7 +24,8 @@ export type AwaitingFirstTaskDecision =
       | 'task-execution-started'
       | 'task-queue-observed'
       | 'completed-without-generating-tasks'
-      | 'completed-before-first-task-update';
+      | 'completed-before-first-task-update'
+      | 'completed-with-session-progress-evidence';
     taskExecutionStarted?: TaskExecutionStarted;
     notification?: Notification;
     transitionFinish?: TransitionFinish;
@@ -45,13 +46,28 @@ export type AwaitingFirstTaskDecisionInput = {
   hasStartedTasks: boolean;
   hasProgressTaskSignal: boolean;
   buildStatus: BuildStatus;
-  taskCount: number;
+  taskCount: number | undefined;
+  isTaskStreamReady: boolean;
   isPausePending: boolean;
+  expectTaskGeneration: boolean;
+  sessionProgressTotal?: number;
+  sessionStageId?: string | null;
+};
+
+const buildFailedBeforeTaskStartMessage = (sessionStageId?: string | null): string => {
+  if (typeof sessionStageId === 'string' && sessionStageId.length > 0) {
+    return `Build failed before task execution started (worker stage: ${sessionStageId}).`;
+  }
+  return 'Build failed before task execution started.';
 };
 
 export const resolveAwaitingFirstTaskDecision = (
   input: AwaitingFirstTaskDecisionInput,
 ): AwaitingFirstTaskDecision => {
+  const hasSessionProgressEvidence = (
+    typeof input.sessionProgressTotal === 'number'
+    && input.sessionProgressTotal > 0
+  );
   if (input.hasFirstTaskSignal) {
     return {
       kind: 'success',
@@ -72,7 +88,46 @@ export const resolveAwaitingFirstTaskDecision = (
     };
   }
   if (input.buildStatus === 'completed') {
+    if (!input.isTaskStreamReady) {
+      if (hasSessionProgressEvidence) {
+        return {
+          kind: 'success',
+          reason: 'completed-with-session-progress-evidence',
+          transitionFinish: {
+            level: 'info',
+            message: 'Build completed before task stream synchronization.',
+          },
+        };
+      }
+      return { kind: 'continue' };
+    }
+    if (typeof input.taskCount !== 'number') {
+      if (hasSessionProgressEvidence) {
+        return {
+          kind: 'success',
+          reason: 'completed-with-session-progress-evidence',
+          transitionFinish: {
+            level: 'info',
+            message: 'Build completed before task stream synchronization.',
+          },
+        };
+      }
+      return { kind: 'continue' };
+    }
     const completedWithoutTasks = input.taskCount === 0;
+    if (completedWithoutTasks && input.expectTaskGeneration) {
+      if (hasSessionProgressEvidence) {
+        return {
+          kind: 'success',
+          reason: 'completed-with-session-progress-evidence',
+          transitionFinish: {
+            level: 'info',
+            message: 'Build completed before task stream synchronization.',
+          },
+        };
+      }
+      return { kind: 'continue' };
+    }
     return {
       kind: 'success',
       reason: completedWithoutTasks
@@ -92,7 +147,7 @@ export const resolveAwaitingFirstTaskDecision = (
       reason: 'failed-before-task-start',
       transitionFinish: {
         level: 'error',
-        message: 'Build failed before task execution started.',
+        message: buildFailedBeforeTaskStartMessage(input.sessionStageId),
       },
     };
   }

--- a/plugins/shape-plugin/src/ui/components/build-progress/resolveStartupTransitionWatchdogEvent.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/resolveStartupTransitionWatchdogEvent.ts
@@ -1,0 +1,48 @@
+export const START_DIAGNOSTIC_WARN_MS = 10_000;
+export const START_DIAGNOSTIC_LONG_WAIT_MS = 20_000;
+export const START_DIAGNOSTIC_TIMEOUT_MS = 45_000;
+
+export type BuildStartupTransitionWarnStep = 0 | 1 | 2 | 3;
+
+export type StartupTransitionWatchdogEventKind =
+  | 'none'
+  | 'wait'
+  | 'long-wait'
+  | 'timeout';
+
+export type StartupTransitionWatchdogEvent = {
+  kind: StartupTransitionWatchdogEventKind;
+  nextWarnStep: BuildStartupTransitionWarnStep;
+};
+
+export type ResolveStartupTransitionWatchdogEventInput = {
+  elapsedMs: number;
+  warnStep: BuildStartupTransitionWarnStep;
+};
+
+export const resolveStartupTransitionWatchdogEvent = (
+  input: ResolveStartupTransitionWatchdogEventInput,
+): StartupTransitionWatchdogEvent => {
+  if (input.elapsedMs >= START_DIAGNOSTIC_TIMEOUT_MS && input.warnStep < 3) {
+    return {
+      kind: 'timeout',
+      nextWarnStep: 3,
+    };
+  }
+  if (input.elapsedMs >= START_DIAGNOSTIC_LONG_WAIT_MS && input.warnStep < 2) {
+    return {
+      kind: 'long-wait',
+      nextWarnStep: 2,
+    };
+  }
+  if (input.elapsedMs >= START_DIAGNOSTIC_WARN_MS && input.warnStep < 1) {
+    return {
+      kind: 'wait',
+      nextWarnStep: 1,
+    };
+  }
+  return {
+    kind: 'none',
+    nextWarnStep: input.warnStep,
+  };
+};

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts
@@ -39,6 +39,10 @@ import { shouldResumeBuildSession } from './shouldResumeBuildSession.ts';
 import { createBuildStartDraftData } from './createBuildStartDraftData.ts';
 import { hasAwaitingFirstTaskSignal } from './awaitingFirstTaskSignal.ts';
 import { resolveAwaitingFirstTaskDecision } from './resolveAwaitingFirstTaskDecision.ts';
+import {
+  resolveStartupTransitionWatchdogEvent,
+  type BuildStartupTransitionWarnStep,
+} from './resolveStartupTransitionWatchdogEvent.ts';
 import type { ShapeBuildSessionRecord } from '@hierarchidb/shape-api';
 import { shapeMutationAPIImpl, shapeQueryAPIImpl } from '../../../services/batch/ShapeBuildAPIClient.ts';
 
@@ -192,10 +196,6 @@ type StartupStepMemorySnapshot = {
   jsHeapSizeLimit: number | null;
 };
 
-const START_DIAGNOSTIC_WARN_MS = 10_000;
-const START_DIAGNOSTIC_LONG_WAIT_MS = 20_000;
-const START_DIAGNOSTIC_TIMEOUT_MS = 45_000;
-
 const getErrorMessage = (error: unknown): string => (
   error instanceof Error ? error.message : String(error)
 );
@@ -337,9 +337,10 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
 
   const [isPausePending, setIsPausePending] = useState(false);
   const clearStartPendingRef = useRef<(() => void) | null>(null);
-  const buildSessionTransitionWarnStepRef = useRef<0 | 1 | 2 | 3>(0);
+  const buildSessionTransitionWarnStepRef = useRef<BuildStartupTransitionWarnStep>(0);
   const buildSessionTransitionTaskStartNotifiedRef = useRef(false);
   const buildSessionTransitionWaitLogStepRef = useRef(-1);
+  const awaitingFirstTaskExpectationRef = useRef(false);
   const buildStartupStepStartedAtRef = useRef<Map<BuildStartupStep, number>>(new Map());
   const buildStartupStepMemoryAtStartRef = useRef<Map<BuildStartupStep, StartupStepMemorySnapshot>>(new Map());
   const previousTransitionActiveRef = useRef(false);
@@ -353,6 +354,8 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
   const [suspendSuspectOpen, setSuspendSuspectOpen] = useState(false);
   const [suspendSuspectMessage, setSuspendSuspectMessage] = useState<string | null>(null);
   const [sessionRecord, setSessionRecord] = useState<ShapeBuildSessionRecord | null>(null);
+  const lastWorkerStageTraceKeyRef = useRef<string | null>(null);
+  const lastAwaitingFirstTaskDecisionTraceKeyRef = useRef<string | null>(null);
   const persistedStageElapsedByStage = useMemo<Record<string, number>>(
     () => (sessionRecord?.elapsedByStage ?? {}),
     [sessionRecord?.elapsedByStage]
@@ -395,6 +398,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     buildSessionTransitionWarnStepRef.current = 0;
     buildSessionTransitionTaskStartNotifiedRef.current = false;
     buildSessionTransitionWaitLogStepRef.current = -1;
+    awaitingFirstTaskExpectationRef.current = false;
     progressTerminalLogKeyRef.current = null;
     setBuildSessionTransitionElapsedMs(0);
   }, []);
@@ -542,6 +546,31 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     };
   }, [refreshSessionRecord]);
 
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    if (!activeNodeId) return;
+    const stageId = sessionRecord?.stageId ?? null;
+    const status = sessionRecord?.status ?? null;
+    const stageHeartbeatAt = sessionRecord?.stageHeartbeatAt ?? null;
+    const updatedAt = sessionRecord?.updatedAt ?? null;
+    const key = `${String(activeNodeId)}:${status ?? '-'}:${stageId ?? '-'}:${stageHeartbeatAt ?? '-'}`;
+    if (lastWorkerStageTraceKeyRef.current === key) return;
+    lastWorkerStageTraceKeyRef.current = key;
+    console.log('[ShapeBuildWorkerStageTrace]', {
+      nodeId: String(activeNodeId),
+      status,
+      stageId,
+      stageHeartbeatAt,
+      updatedAt,
+    });
+  }, [
+    activeNodeId,
+    sessionRecord?.stageHeartbeatAt,
+    sessionRecord?.stageId,
+    sessionRecord?.status,
+    sessionRecord?.updatedAt,
+  ]);
+
   const { progress, status, error } = useBuildProgress(activeNodeId, { autoSubscribe: Boolean(activeNodeId) });
   const hasNodeId = Boolean(activeNodeId && !error);
   const remoteFresh = Boolean(remoteUpdatedAt && Date.now() - remoteUpdatedAt <= coordinator.quietThresholdTimeout);
@@ -566,7 +595,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
   const baseBuildStatus = useMemo<BuildStatus>(() => (
     toBuildStatus(statusSource)
   ), [statusSource]);
-  const { tasks, isLoading: isTasksLoading } = useShapeBuildTasks(activeNodeId, {
+  const { tasks, isLoading: isTasksLoading, isTaskStreamReady } = useShapeBuildTasks(activeNodeId, {
     reportFailures: reportTaskFailures,
   });
   const isTaskSummaryLoading = false;
@@ -1149,8 +1178,15 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     const intervalId = window.setInterval(() => {
       const elapsedMs = Date.now() - buildSessionTransition.startedAt;
       setBuildSessionTransitionElapsedMs(elapsedMs);
-      if (elapsedMs >= START_DIAGNOSTIC_TIMEOUT_MS && buildSessionTransitionWarnStepRef.current < 3) {
-        buildSessionTransitionWarnStepRef.current = 3;
+      const watchdogEvent = resolveStartupTransitionWatchdogEvent({
+        elapsedMs,
+        warnStep: buildSessionTransitionWarnStepRef.current,
+      });
+      if (watchdogEvent.kind === 'none') {
+        return;
+      }
+      buildSessionTransitionWarnStepRef.current = watchdogEvent.nextWarnStep;
+      if (watchdogEvent.kind === 'timeout') {
         emitBuildSessionTransitionLog('error', 'build session transition timeout', {
           phase: buildSessionTransition.phase,
           elapsedMs,
@@ -1167,8 +1203,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
         });
         return;
       }
-      if (elapsedMs >= START_DIAGNOSTIC_LONG_WAIT_MS && buildSessionTransitionWarnStepRef.current < 2) {
-        buildSessionTransitionWarnStepRef.current = 2;
+      if (watchdogEvent.kind === 'long-wait') {
         emitBuildSessionTransitionLog('warn', 'build session transition long wait', {
           phase: buildSessionTransition.phase,
           elapsedMs,
@@ -1179,8 +1214,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
         );
         return;
       }
-      if (elapsedMs >= START_DIAGNOSTIC_WARN_MS && buildSessionTransitionWarnStepRef.current < 1) {
-        buildSessionTransitionWarnStepRef.current = 1;
+      if (watchdogEvent.kind === 'wait') {
         emitBuildSessionTransitionLog('info', 'build session transition wait', {
           phase: buildSessionTransition.phase,
           elapsedMs,
@@ -1238,14 +1272,49 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
   useEffect(() => {
     if (!buildSessionTransition.active) return;
     if (buildSessionTransition.phase !== 'awaiting-first-task') return;
-    const decision = resolveAwaitingFirstTaskDecision({
+    const decisionInput = {
       hasFirstTaskSignal,
       hasStartedTasks,
       hasProgressTaskSignal,
       buildStatus,
-      taskCount: displayTasks.length,
+      taskCount: isTaskStreamReady ? displayTasks.length : undefined,
+      isTaskStreamReady,
       isPausePending,
+      expectTaskGeneration: awaitingFirstTaskExpectationRef.current,
+      sessionProgressTotal: sessionRecord?.progress?.total,
+      sessionStageId: sessionRecord?.stageId ?? null,
+    };
+    const decisionTraceKey = import.meta.env.DEV
+      ? JSON.stringify({
+        phase: buildSessionTransition.phase,
+        buildStatus: decisionInput.buildStatus,
+        hasFirstTaskSignal: decisionInput.hasFirstTaskSignal,
+        hasStartedTasks: decisionInput.hasStartedTasks,
+        hasProgressTaskSignal: decisionInput.hasProgressTaskSignal,
+        taskCount: decisionInput.taskCount,
+        isTaskStreamReady: decisionInput.isTaskStreamReady,
+        isPausePending: decisionInput.isPausePending,
+        expectTaskGeneration: decisionInput.expectTaskGeneration,
+        sessionProgressTotal: decisionInput.sessionProgressTotal ?? null,
+        sessionStageId: decisionInput.sessionStageId ?? null,
+      })
+      : null;
+    if (decisionTraceKey && lastAwaitingFirstTaskDecisionTraceKeyRef.current !== decisionTraceKey) {
+      lastAwaitingFirstTaskDecisionTraceKeyRef.current = decisionTraceKey;
+      console.log('[ShapeAwaitingFirstTaskDecisionTrace] input', JSON.stringify({
+        nodeId: activeNodeId ? String(activeNodeId) : null,
+        ...decisionInput,
+      }));
+    }
+    const decision = resolveAwaitingFirstTaskDecision({
+      ...decisionInput,
     });
+    if (import.meta.env.DEV && decision.kind !== 'continue') {
+      console.log('[ShapeAwaitingFirstTaskDecisionTrace] decision', JSON.stringify({
+        nodeId: activeNodeId ? String(activeNodeId) : null,
+        decision,
+      }));
+    }
     if (decision.kind === 'continue') return;
 
     if (decision.kind === 'success') {
@@ -1286,6 +1355,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     });
     finishBuildSessionTransition(decision.transitionFinish);
   }, [
+    activeNodeId,
     buildStatus,
     displayTasks.length,
     emitBuildSessionTransitionLog,
@@ -1295,7 +1365,9 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     hasProgressTaskSignal,
     hasStartedTasks,
     isPausePending,
+    isTaskStreamReady,
     pushBuildSessionTransitionNotification,
+    sessionRecord?.progress?.total,
     buildSessionTransition.active,
     buildSessionTransition.phase,
   ]);
@@ -1562,6 +1634,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
           source: startupSource,
         });
         void updateSessionRecord({ status: 'running', stopReason: undefined, canResume: false });
+        awaitingFirstTaskExpectationRef.current = false;
         advanceBuildSessionTransitionPhase('awaiting-first-task', {
           level: 'info',
           message: 'Build resumed. Waiting for worker task updates...',
@@ -1668,6 +1741,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
           message: 'Build completed immediately after start.',
         });
       } else {
+        awaitingFirstTaskExpectationRef.current = true;
         advanceBuildSessionTransitionPhase('awaiting-first-task', {
           level: 'info',
           message: 'Build requested. Waiting for worker task updates...',

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
@@ -24,6 +24,7 @@ type SyncArgs = {
   setTasks: (tasks: ShapeBuildTaskSummary[]) => void;
   setIsLoading: (loading: boolean) => void;
   setError: (error: Error | null) => void;
+  markTaskStreamSynchronized?: () => void;
 };
 
 const isTaskStage = (value: unknown): value is TaskStage => (
@@ -535,7 +536,13 @@ const shouldPreferNextTask = (
   return shouldApplyTaskUpdate(current, next);
 };
 
-export const useShapeBuildTaskSync = ({ sessionNodeId, setTasks, setIsLoading, setError }: SyncArgs) => {
+export const useShapeBuildTaskSync = ({
+  sessionNodeId,
+  setTasks,
+  setIsLoading,
+  setError,
+  markTaskStreamSynchronized,
+}: SyncArgs) => {
   const isLoadingRef = useRef(false);
   const errorRef = useRef<Error | null>(null);
   const tasksRef = useRef<ShapeBuildTaskSummary[]>([]);
@@ -574,18 +581,22 @@ export const useShapeBuildTaskSync = ({ sessionNodeId, setTasks, setIsLoading, s
 
   const flushTasks = useCallback((next: ShapeBuildTaskSummary[], dirty: boolean) => {
     if (!dirty) {
+      markTaskStreamSynchronized?.();
       return;
     }
     if (areTaskListsEquivalentForView(committedTasksRef.current, next)) {
       committedTasksRef.current = next;
+      markTaskStreamSynchronized?.();
       return;
     }
     committedTasksRef.current = next;
     if (!isMountedRef.current) {
+      markTaskStreamSynchronized?.();
       return;
     }
     setTasks(next);
-  }, [setTasks]);
+    markTaskStreamSynchronized?.();
+  }, [markTaskStreamSynchronized, setTasks]);
 
   const scheduleFlush = useCallback((next: ShapeBuildTaskSummary[], dirty = true) => {
     if (!isMountedRef.current) {

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { NodeId, NodeType } from '@hierarchidb/core-types';
 import { getWorkerBridge } from '@hierarchidb/ui-worker-client';
 import { useAtom } from 'jotai';
@@ -21,6 +21,7 @@ export interface UseShapeBuildTasksState {
   tasks: ShapeBuildTaskSummary[];
   isLoading: boolean;
   error: Error | null;
+  isTaskStreamReady: boolean;
   refresh: () => Promise<void>;
 }
 
@@ -87,6 +88,7 @@ export function useShapeBuildTasks(
   const [tasks, setTasks] = useAtom(tasksAtom);
   const [isLoading, setIsLoading] = useAtom(tasksLoadingAtom);
   const [error, setError] = useAtom(tasksErrorAtom);
+  const [isTaskStreamReady, setIsTaskStreamReady] = useState(false);
   const reportedFailuresRef = useRef<Set<string>>(new Set());
   const handleSnapshotRef = useRef<(tasks: RawTaskSummary[]) => void>(() => {});
   const handleUpdateRef = useRef<(task: RawTaskSummary) => void>(() => {});
@@ -94,6 +96,10 @@ export function useShapeBuildTasks(
   const reconcileInFlightRef = useRef(false);
   const subscriptionRef = useRef<(() => void) | null>(null);
   const subscriptionIdRef = useRef(0);
+
+  const markTaskStreamSynchronized = useCallback(() => {
+    setIsTaskStreamReady((current) => (current ? current : true));
+  }, []);
 
   const {
     tasksRef,
@@ -111,6 +117,7 @@ export function useShapeBuildTasks(
     setTasks,
     setIsLoading,
     setError,
+    markTaskStreamSynchronized,
   });
 
   useEffect(() => {
@@ -140,6 +147,7 @@ export function useShapeBuildTasks(
       subscriptionRef.current();
       subscriptionRef.current = null;
     }
+    setIsTaskStreamReady(false);
     resetPending();
     const hadTasks = tasksRef.current.length > 0;
     const hadError = errorRef.current !== null;
@@ -306,8 +314,9 @@ export function useShapeBuildTasks(
       tasks,
       isLoading,
       error,
+      isTaskStreamReady,
       refresh,
     }),
-    [error, isLoading, refresh, tasks],
+    [error, isLoading, isTaskStreamReady, refresh, tasks],
   );
 }

--- a/plugins/shape-plugin/src/worker/api.ts
+++ b/plugins/shape-plugin/src/worker/api.ts
@@ -96,6 +96,30 @@ const buildFetchStageOptions = (buildConfig: ShapeRuntimeBuildConfig) => ({
   retryDelay: buildConfig.fetchConfig.retryDelay,
 });
 
+const summarizeSelectedArrayByCountries = (
+  selectedArrayByCountries: SelectedArrayByCountries | undefined,
+): { selectedCountryCount: number; selectedAdminPairCount: number } => {
+  if (!selectedArrayByCountries || typeof selectedArrayByCountries !== 'object' || Array.isArray(selectedArrayByCountries)) {
+    return { selectedCountryCount: 0, selectedAdminPairCount: 0 };
+  }
+  let selectedCountryCount = 0;
+  let selectedAdminPairCount = 0;
+  Object.values(selectedArrayByCountries).forEach((row) => {
+    if (!Array.isArray(row)) return;
+    let hasSelectedInCountry = false;
+    row.forEach((selected) => {
+      if (selected === true) {
+        hasSelectedInCountry = true;
+        selectedAdminPairCount += 1;
+      }
+    });
+    if (hasSelectedInCountry) {
+      selectedCountryCount += 1;
+    }
+  });
+  return { selectedCountryCount, selectedAdminPairCount };
+};
+
 const resolveFetchTaskPayloadsForPlan = async (input: {
   nodeId: NodeId;
   dataSource: DataSourceName;
@@ -1335,7 +1359,15 @@ const emitProgressSnapshot = async (
   message?: string,
 ): Promise<void> => {
   const sub = progressCallbacks.get(String(nodeId));
-  if (!sub?.callback) return;
+  if (!sub?.callback) {
+    if (typeof message === 'string' && message.length > 0) {
+      console.warn('[shapeBatchAPI] progress snapshot skipped (no subscriber)', JSON.stringify({
+        nodeId,
+        message,
+      }));
+    }
+    return;
+  }
   try {
     const taskQueue = new VtTaskQueueDb();
     const vtTasks = await listTasks(taskQueue, nodeId);
@@ -1353,6 +1385,23 @@ const emitProgressSnapshot = async (
   } catch (error) {
     console.error('[shapeBatchAPI] progress snapshot build failed', error);
   }
+};
+
+const toErrorDiagnostics = (error: unknown): {
+  errorMessage: string;
+  errorName?: string;
+  errorStack?: string;
+} => {
+  if (error instanceof Error) {
+    return {
+      errorMessage: error.message,
+      errorName: error.name,
+      errorStack: error.stack,
+    };
+  }
+  return {
+    errorMessage: String(error),
+  };
 };
 
 
@@ -1460,6 +1509,10 @@ export const shapeBatchAPI = {
       step: string,
       extra?: Record<string, unknown>,
     ): void => {
+      void shapeMutationAPIImpl.updateBuildSession(startupNodeId, {
+        stageId: `startup:${step}:${phase}`,
+        stageHeartbeatAt: Date.now(),
+      }).catch(() => {});
       const payload = {
         scope: startupScope,
         phase,
@@ -1544,7 +1597,11 @@ export const shapeBatchAPI = {
       throw new Error(`Working copy not found: ${draftId}`);
     }
 
-    const selectedAdminPairCount = countSelectedAdminPairs(draftEntity.selectedArrayByCountries);
+    const selectionSummary = await executeStartupStep(
+      'summarize-selection',
+      async () => summarizeSelectedArrayByCountries(draftEntity.selectedArrayByCountries),
+    );
+    const selectedAdminPairCount = selectionSummary.selectedAdminPairCount;
     if (!downloadTaskPayloads.length && selectedAdminPairCount === 0) {
       throw new Error('Shape batch session requires download task payloads or selection');
     }
@@ -1575,7 +1632,11 @@ export const shapeBatchAPI = {
         selectedArrayByCountries: draftEntity.selectedArrayByCountries,
         downloadTaskPayloads,
       }),
-      { payloadCount: downloadTaskPayloads.length },
+      {
+        payloadCount: downloadTaskPayloads.length,
+        selectedCountryCount: selectionSummary.selectedCountryCount,
+        selectedAdminPairCount: selectionSummary.selectedAdminPairCount,
+      },
     );
     if ((downloadTaskPayloads.length > 0 || selectedAdminPairCount > 0) && fetchPlan.plannedFetchTotal === 0) {
       throw new Error(
@@ -1684,6 +1745,11 @@ export const shapeBatchAPI = {
         runId: pipelineRunId,
         payloadCount: downloadTaskPayloads.length,
       });
+      void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
+        stageId: 'startup:pipeline-dispatch:start',
+        stageHeartbeatAt: Date.now(),
+      }).catch(() => {});
+      let terminalProgressMessage: string | undefined;
       void runShapePipeline({
         nodeId: nodeForSession,
         dataSource: resolvedDataSource,
@@ -1694,27 +1760,48 @@ export const shapeBatchAPI = {
         buildContinuationPolicy,
         resumeExistingTasks,
         pipelineRunId,
-      }).then(async () => {
-        const completedAt = Date.now();
-        await updateBuildSessionFromTasks(nodeForSession, {
-          status: 'completed',
-          stopReason: 'completed',
-          completedAt,
-          canResume: false,
+        }).then(async () => {
+          const completedAt = Date.now();
+          terminalProgressMessage = undefined;
+          void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
+            stageId: 'startup:pipeline-dispatch:success',
+            stageHeartbeatAt: completedAt,
+          }).catch(() => {});
+          await updateBuildSessionFromTasks(nodeForSession, {
+            status: 'completed',
+            stopReason: 'completed',
+            completedAt,
+            canResume: false,
+          });
+        }).catch(async (error) => {
+          const failedAt = Date.now();
+          const diagnostics = toErrorDiagnostics(error);
+          console.error('[shapeBatchAPI] vt pipeline failed', error);
+          console.error('[shapeBatchAPI] startup', JSON.stringify({
+            scope: startupScope,
+            phase: 'finish',
+            step: 'pipeline-run',
+            nodeId: nodeForSession,
+            runId: pipelineRunId,
+            outcome: 'error',
+            failedAt,
+            ...diagnostics,
+          }));
+          terminalProgressMessage = `Pipeline failed (${diagnostics.errorName ?? 'Error'}): ${diagnostics.errorMessage}`;
+          void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
+            stageId: 'startup:pipeline-dispatch:error',
+            stageHeartbeatAt: failedAt,
+          }).catch(() => {});
+          await updateBuildSessionFromTasks(nodeForSession, {
+            status: 'failed',
+            stopReason: 'failed',
+            completedAt: failedAt,
+            canResume: false,
+          });
+        }).finally(() => {
+          clearActivePipelineRuntimeState(nodeForSession);
+          void emitProgressSnapshot(nodeForSession, terminalProgressMessage);
         });
-      }).catch(async (error) => {
-        const failedAt = Date.now();
-        console.error('[shapeBatchAPI] vt pipeline failed', error);
-        await updateBuildSessionFromTasks(nodeForSession, {
-          status: 'failed',
-          stopReason: 'failed',
-          completedAt: failedAt,
-          canResume: false,
-        });
-      }).finally(() => {
-        clearActivePipelineRuntimeState(nodeForSession);
-        void emitProgressSnapshot(nodeForSession);
-      });
       emitStartupStepLog('finish', 'pipeline-dispatch', {
         runId: pipelineRunId,
         payloadCount: downloadTaskPayloads.length,
@@ -1818,6 +1905,10 @@ export const shapeBatchAPI = {
         step: string,
         extra?: Record<string, unknown>,
       ): void => {
+        void shapeMutationAPIImpl.updateBuildSession(nodeId, {
+          stageId: `startup:${step}:${phase}`,
+          stageHeartbeatAt: Date.now(),
+        }).catch(() => {});
         console.warn('[shapeBatchAPI] startup', JSON.stringify({
           scope: resumeScope,
           phase,
@@ -1956,6 +2047,11 @@ export const shapeBatchAPI = {
             payloadProcessingConfig: Boolean(payloadProcessingConfig),
           },
         });
+        const selectionSummary = await executeResumeStep(
+          'summarize-selection',
+          async () => summarizeSelectedArrayByCountries(draftEntity.selectedArrayByCountries),
+          { existingTaskCount },
+        );
         const fetchPlan = await executeResumeStep(
           'plan-fetch-total',
           async () => estimatePlannedFetchTotal({
@@ -1963,9 +2059,13 @@ export const shapeBatchAPI = {
             buildConfig: mergedRuntimeConfig,
             selectedArrayByCountries: draftEntity.selectedArrayByCountries,
           }),
-          { existingTaskCount },
+          {
+            existingTaskCount,
+            selectedCountryCount: selectionSummary.selectedCountryCount,
+            selectedAdminPairCount: selectionSummary.selectedAdminPairCount,
+          },
         );
-        const selectedAdminPairCount = countSelectedAdminPairs(draftEntity.selectedArrayByCountries);
+        const selectedAdminPairCount = selectionSummary.selectedAdminPairCount;
         if (existingTaskCount === 0 && selectedAdminPairCount === 0) {
           throw new Error('[shapeBatchAPI] Resume requires selected countries/admin levels or existing queued tasks.');
         }
@@ -2041,6 +2141,11 @@ export const shapeBatchAPI = {
           nodeId,
           runId: pipelineRunId,
         });
+        void shapeMutationAPIImpl.updateBuildSession(nodeId, {
+          stageId: 'startup:pipeline-dispatch:start',
+          stageHeartbeatAt: Date.now(),
+        }).catch(() => {});
+        let terminalProgressMessage: string | undefined;
         void runShapePipeline({
           nodeId,
           dataSource: resolvedDataSource,
@@ -2052,6 +2157,11 @@ export const shapeBatchAPI = {
           pipelineRunId,
         }).then(async () => {
           const completedAt = Date.now();
+          terminalProgressMessage = undefined;
+          void shapeMutationAPIImpl.updateBuildSession(nodeId, {
+            stageId: 'startup:pipeline-dispatch:success',
+            stageHeartbeatAt: completedAt,
+          }).catch(() => {});
           await updateBuildSessionFromTasks(nodeId, {
             status: 'completed',
             stopReason: 'completed',
@@ -2060,7 +2170,23 @@ export const shapeBatchAPI = {
           });
         }).catch(async (error) => {
           const failedAt = Date.now();
+          const diagnostics = toErrorDiagnostics(error);
           console.error('[shapeBatchAPI] vt pipeline failed', error);
+          console.error('[shapeBatchAPI] startup', JSON.stringify({
+            scope: resumeScope,
+            phase: 'finish',
+            step: 'pipeline-run',
+            nodeId,
+            runId: pipelineRunId,
+            outcome: 'error',
+            failedAt,
+            ...diagnostics,
+          }));
+          terminalProgressMessage = `Pipeline failed (${diagnostics.errorName ?? 'Error'}): ${diagnostics.errorMessage}`;
+          void shapeMutationAPIImpl.updateBuildSession(nodeId, {
+            stageId: 'startup:pipeline-dispatch:error',
+            stageHeartbeatAt: failedAt,
+          }).catch(() => {});
           await updateBuildSessionFromTasks(nodeId, {
             status: 'failed',
             stopReason: 'failed',
@@ -2069,7 +2195,7 @@ export const shapeBatchAPI = {
           });
         }).finally(() => {
           clearActivePipelineRuntimeState(nodeId);
-          void emitProgressSnapshot(nodeId);
+          void emitProgressSnapshot(nodeId, terminalProgressMessage);
         });
         emitResumeStepLog('finish', 'pipeline-dispatch', {
           runId: pipelineRunId,


### PR DESCRIPTION
## Summary
- add startup transition watchdog event resolver for shape build startup state transitions
- wire watchdog handling into build progress hooks and worker API flow
- extend unit/integration/e2e tests and update related docs/exec plan notes
- update TASKS operation log for #250

## Verification
- pnpm install --frozen-lockfile
- pnpm -w exec turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts src/ui/__tests__/hooks/unit/resolveStartupTransitionWatchdogEvent.unit.test.ts src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
- pnpm -w exec turbo run typecheck --filter @hierarchidb/shape-plugin
- pnpm -w exec turbo run build --filter @hierarchidb/shape-plugin

## Related
- Refs #250
