### PR TITLE
feat(route): implement location-coupled build flow and stale sync checks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -39,6 +39,8 @@
 
 ### Doing
 
+- #262 / `codex/docs/route/build-flow-location-coupling-2` / start: 2026-02-14 14:33 JST
+- #261 / `codex/docs/route/build-flow-location-coupling-2` / start: 2026-02-14 14:27 JST
 - #259 / `codex/fix/shape/build-omit-details-threshold-none` / start: 2026-02-14 09:15 JST
 - #258 / `codex/fix/i18n/move-to-archive-ja-locale` / start: 2026-02-14 08:02 JST
 - #255 / `codex/refactor/repo/rename-trash-to-archive` / start: 2026-02-13 22:11 JST
@@ -81,6 +83,9 @@
 
 ## 今日の運用ログ
 
+- update: 2026-02-14 14:33 JST Issue `feat(route): implement location-coupled build flow spec` を起票し `https://github.com/kubohiroya/hierarchidb/issues/262` を作成。Project `hierarchidb` に追加して Status を `In Progress` に設定し、既存専用 worktree `/Users/hiroya/WebstormProjects/hierarchidb-route-build-flow-docs` とブランチ `codex/docs/route/build-flow-location-coupling-2` を継続利用して実装に着手。
+- update: 2026-02-14 14:29 JST #261 で `plugins/route-plugin/README.md` に「2026-02-14 確定仕様（優先）」節を追加し、Step3〜Step6・location 連動カスケード・rebuild required/再ビルド予約・stale 運用の要点を明記。`docs/route-build-flow-spec.md` を新規作成して pre-build→build 詳細仕様（OR/AND 10チェック、fetch key 正規化、transform 差分、Step6 手動整合チェック）を文書化し、`docs/vt-route-pipeline-design.md` から参照リンクを追加。
+- update: 2026-02-14 14:27 JST Issue `docs(route): document build flow with location-coupled behavior` を起票し `https://github.com/kubohiroya/hierarchidb/issues/261` を作成。Project `hierarchidb` に追加して Status を `In Progress` に設定し、専用 worktree `/Users/hiroya/WebstormProjects/hierarchidb-route-build-flow-docs` とブランチ `codex/docs/route/build-flow-location-coupling-2` を作成して着手。
 - update: 2026-02-14 09:22 JST #259 原因は `app/src/features/shape/shapeCreatePresets.ts` のプリセットが `omitDetailsConfig.level` に未対応値（`none` / `moderate`）を設定していたこと。発生範囲は shape プリセット経由で作成された draft の build 実行時（`plugins/shape-plugin/src/services/vt/fetchGeometryFilters.ts`）で、`omit-details thresholds missing for level: ...` により fetch タスクが失敗していた。
 - update: 2026-02-14 09:22 JST #259 修正としてプリセット値を `weak` / `medium` に修正し、`plugins/shape-plugin/src/services/utils/utils.ts` の `mergeBuildConfig` に legacy 値正規化（`none -> weak`, `moderate -> medium`）と不正値ガードを追加。適用範囲は `app/src/features/shape/shapeCreatePresets.ts`, `plugins/shape-plugin/src/services/utils/utils.ts`, 関連 unit test 2 件。
 - update: 2026-02-14 09:22 JST #259 検証結果: `pnpm install --frozen-lockfile` exit 0、`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/mergeBuildConfig.unit.test.ts` exit 0、`pnpm -w turbo run test --filter @hierarchidb/app -- --run src/features/shape/__tests__/shapeCreatePresets.unit.test.ts` exit 0、`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` exit 0。

--- a/docs/route-build-flow-spec.md
+++ b/docs/route-build-flow-spec.md
@@ -1,0 +1,136 @@
+# route ビルド前〜ビルド仕様（2026-02-14 確定）
+
+## 目的
+
+本ドキュメントは、route の pre-build から build/preview までの仕様を定義する。
+特に、route 成果物が location 定義に強く依存する点（非レイトバインディング）を明示する。
+
+## 前提: route と location の関係
+
+- route の LineString は、location が提供する始点/終点の緯度経度を入力として生成される。
+- このため route 成果物は location 定義に従属し、location 変更の影響を受ける。
+- location と route は保存先 DB が異なるため、Dexie transaction で厳密な原子性は保証しない。
+- 非原子的更新により route が stale になることを許容し、事後検出で運用する。
+
+## Step3: 国×交通モードフィルタ（selectedArrayByCountries）
+
+### UI 仕様
+
+- 縦軸: 国名
+- 横軸:
+  - OR 条件（始点または終点が一致）: 空路 / 海路 / 高速鉄道 / 在来線鉄道 / 道路
+  - AND 条件（始点かつ終点が一致）: 空路 / 海路 / 高速鉄道 / 在来線鉄道 / 道路
+- 1 国あたり 10 チェックボックスを持つ。
+
+### 初期状態
+
+- Step2 で読み込んだデータに存在する「国×交通モード」だけチェックボックスを生成する。
+- 生成されたチェックボックスは初期状態で `checked` とする。
+
+### OR/AND 連動
+
+- 同一行で OR 側をチェックした交通モードは、同モードの AND 側を自動で `checked/disabled` にする。
+- OR 側が外れた場合は、AND 側の `disabled` を解除する（AND 側の最終状態はユーザー操作を反映）。
+
+### state 更新
+
+- Step3 の操作結果は `selectedArrayByCountries` に反映する。
+- Step5 の fetch 対象は `selectedArrayByCountries` を唯一の選択入力として扱う。
+
+## Step4: Build 設定
+
+- shape の build 設定 UI を route でそのまま再利用する。
+- 範囲・単位・デフォルト値・ズーム帯適用ルールは原則 shape と共通。
+- VT 設定カードも shape と共用する。
+- 将来拡張として OSRM Route API / searoute-js の追加パラメータを導入可能にする。
+
+## Step5: Build
+
+### UI/制御
+
+- build ステップの UI 構成と動作は shape と基本的に同一とする。
+- 実装は最大限共用し、route 固有差分のみ差し込む。
+
+### 内部パイプライン
+
+- fetch ステージ:
+  - shape と同様にデータソースごとの strategy pattern で実装を切り替える。
+  - 交通モードに応じた LineString GeoJSON を生成する。
+  - `featureCache` には「オリジナル 1 本のみ」の LineString GeoJSON を保存する。
+    - shape のようなズーム帯別 GeoJSON コピーは作成しない。
+- transform ステージ:
+  - route では filtering と simplification を一括で実行する。
+  - simplification algorithm と tolerance の単位は shape transform と共通。
+  - shape との差分は、shape が fetch 終端で filtering していた点のみ。
+- VT ステージ:
+  - shape と完全に同じ処理を利用する。
+
+### fetch キャッシュキー
+
+- キーは `<交通モード> + <start/end 正規化座標>` で構成する。
+- 正規化座標は `(lon,lat)` タプルで比較し、昇順ソートしてから連結する。
+- 双方向経路は同一キーに正規化される。
+
+例:
+
+```text
+<mode>:<min(lon,lat)>|<max(lon,lat)>
+```
+
+### metadata 保存
+
+- route metadata には以下を保存する:
+  - location からコピーした始点/終点座標
+  - 始点/終点の admin0〜2 の name/code
+  - 始点終点間の距離
+  - 中継点数
+
+## Step6: Preview
+
+- shape/location の preview と基本的に同じ UI 構成を利用する。
+- FloatingWindow で以下を重ね表示できる:
+  - Metadata: routes
+  - 交通モード表示トグル
+  - スタイル設定
+- 交通モードは 5 アイコンボタンの複数 on/off トグルとする（location の表示種別トグルと同様）。
+- 保存先は shape と同様の FloatingWindow 永続化（位置・サイズ・モード）を使う。
+
+## location 変更時の波及仕様
+
+### location 行削除
+
+- 対象 location 行がいずれかの route から参照される場合、location UI で警告ダイアログを表示する。
+- 選択肢:
+  - 参照 route をカスケード削除して続行
+  - キャンセル
+
+### location 行更新
+
+- 対象 location 行が参照中の場合、警告ダイアログを表示する。
+- 選択肢:
+  - 参照 route をカスケード更新して続行
+  - キャンセル
+- カスケード更新対象は「同一始点終点を参照する全 route ノード」とする。
+
+### プロパティ別の更新ルール
+
+- 始点/終点の座標変更または admin code 変更:
+  - 該当 route ノードで該当経路の fetch キャッシュを削除
+  - route UI に `rebuild required` タグを表示
+  - sessions に「再ビルド予約」項目を作成
+    - 予約は route ノード単位でまとめる（経路単位では作らない）
+- それ以外（admin name など）:
+  - 対応 route metadata を即時更新
+
+## stale 判定と整合チェック
+
+- stale 判定に使う比較項目は次のセット:
+  - 座標
+  - admin code
+  - admin name
+- Metadata は通常、保持中の値を受動表示する。
+- ただし Step6 の `Metadata: routes` 右上に、route ノード全体を対象にした手動整合チェックボタンを置く。
+- 整合チェック結果は次を表示する:
+  - `✅同期済み(件数)`
+  - `⚠️更新が必要(件数/全体件数)`
+- stale 判定は自動では行わず、手動ボタンで実行する。

--- a/docs/vt-route-pipeline-design.md
+++ b/docs/vt-route-pipeline-design.md
@@ -2,6 +2,7 @@
 
 本ドキュメントは、route 固有の差分のみを記述する。
 共通仕様は `docs/vt-pipeline-design.md` を参照。
+2026-02-14 時点の Step3〜Step6、location 連動、stale 運用の確定仕様は `docs/route-build-flow-spec.md` を優先する。
 
 ## 対象ジオメトリ
 

--- a/packages/gis-sdk/src/ephemeral/EphemeralBuildState.ts
+++ b/packages/gis-sdk/src/ephemeral/EphemeralBuildState.ts
@@ -8,7 +8,7 @@ import type {
 
 export type EphemeralDomainType = 'shape' | 'route' | 'vt';
 
-export type BuildStatus = 'idle' | 'running' | 'paused' | 'completed' | 'failed';
+export type BuildStatus = 'idle' | 'running' | 'paused' | 'completed' | 'failed' | 'rebuild-reserved';
 
 export type StopReason = 'route-leave' | 'user-pause' | 'failed' | 'completed' | 'unknown';
 

--- a/packages/route-api/src/RouteQueryAPI.ts
+++ b/packages/route-api/src/RouteQueryAPI.ts
@@ -1,5 +1,10 @@
 import type { NodeId } from '@hierarchidb/core-types';
-import type { RouteLineString, RouteNearestLineQuery, RouteNearestLineResponse } from './routeTypes.js';
+import type {
+  RouteLineString,
+  RouteMetadataSyncSummary,
+  RouteNearestLineQuery,
+  RouteNearestLineResponse,
+} from './routeTypes.js';
 
 /**
  * Exposes route plugin artifacts.
@@ -9,5 +14,6 @@ export interface RouteQueryAPI {
   findNearestRouteLine(query: RouteNearestLineQuery): Promise<RouteNearestLineResponse>;
   getVectorTile(nodeId: NodeId, z: number, x: number, y: number): Promise<ArrayBuffer | null>;
   listRouteLineStrings(nodeId: NodeId): Promise<RouteLineString[]>;
+  checkRouteMetadataSync(nodeId: NodeId): Promise<RouteMetadataSyncSummary>;
   countRouteReferencesToLocations(locationNodeIds: NodeId[]): Promise<number>;
 }

--- a/packages/route-api/src/ideGsmRouteCsv.ts
+++ b/packages/route-api/src/ideGsmRouteCsv.ts
@@ -2,6 +2,7 @@ import type { NodeId } from '@hierarchidb/core-types';
 import type { LocationFeatureId } from '@hierarchidb/location-api';
 import type { RouteLineString, RouteMode, RoutePoint } from './routeTypes.js';
 import { ROUTE_MODES } from './routeTypes.js';
+import type { IdeGsmRouteSelectionEntry } from './ideGsmRouteTypes.js';
 
 export type IdeGsmRouteError = {
   id: string;
@@ -239,7 +240,9 @@ function buildRoutePoint(
     admin0Name: admin0Name ?? location.admin0Name ?? location.admin0Code ?? '',
     admin0Code: location.admin0Code,
     admin1Name: admin1Name ?? location.admin1Name ?? location.admin1Code ?? '',
+    admin1Code: location.admin1Code,
     admin2Name: location.admin2Name ?? location.admin2Code,
+    admin2Code: location.admin2Code,
     locationFeatureId: location.locationFeatureId,
     locationId: location.locationNodeId,
     pointId,
@@ -319,3 +322,45 @@ function normalizeMetadata(
   }
   return normalized;
 }
+
+const normalizeCountryCode = (value?: string): string | null => {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toUpperCase();
+  return normalized.length > 0 ? normalized : null;
+};
+
+export const filterIdeGsmRoutesBySelection = (
+  lineStrings: RouteLineString[],
+  entries: IdeGsmRouteSelectionEntry[],
+): RouteLineString[] => {
+  if (entries.length === 0) return lineStrings;
+  const selectionByCountry = new Map<string, { orModes: Set<RouteMode>; andModes: Set<RouteMode> }>();
+  entries.forEach((entry) => {
+    const countryCode = normalizeCountryCode(entry.countryCode);
+    if (!countryCode) return;
+    const existing = selectionByCountry.get(countryCode) ?? {
+      orModes: new Set<RouteMode>(),
+      andModes: new Set<RouteMode>(),
+    };
+    entry.orModes.forEach((mode) => existing.orModes.add(mode));
+    entry.andModes.forEach((mode) => existing.andModes.add(mode));
+    selectionByCountry.set(countryCode, existing);
+  });
+  if (selectionByCountry.size === 0) return lineStrings;
+
+  return lineStrings.filter((line) => {
+    const mode = line.routeMode;
+    const startCountry = normalizeCountryCode(line.startPoint?.admin0Code);
+    const endCountry = normalizeCountryCode(line.endPoint?.admin0Code);
+    const matchedOr = [startCountry, endCountry]
+      .filter((country): country is string => Boolean(country))
+      .some((country) => {
+        const selection = selectionByCountry.get(country);
+        return Boolean(selection && selection.orModes.has(mode));
+      });
+    if (matchedOr) return true;
+    if (!startCountry || !endCountry || startCountry !== endCountry) return false;
+    const selection = selectionByCountry.get(startCountry);
+    return Boolean(selection && selection.andModes.has(mode));
+  });
+};

--- a/packages/route-api/src/ideGsmRouteTypes.ts
+++ b/packages/route-api/src/ideGsmRouteTypes.ts
@@ -2,10 +2,18 @@ import type { ISO2, NodeId } from '@hierarchidb/core-types';
 import type { IdeGsmRouteError } from './ideGsmRouteCsv.js';
 import type { RouteMode } from './routeTypes.js';
 
+export type IdeGsmRouteSelectionEntry = {
+  countryCode: ISO2;
+  countryName?: string;
+  orModes: RouteMode[];
+  andModes: RouteMode[];
+};
+
 export type IdeGsmRouteImportRequest = {
   nodeId: NodeId;
   tabularSourceId: string;
   locationNodeIds?: NodeId[];
+  selectionEntries?: IdeGsmRouteSelectionEntry[];
   chunkSize?: number;
 };
 
@@ -16,6 +24,11 @@ export type IdeGsmRouteImportResult = {
 };
 
 export type IdeGsmRouteCoverageResult = {
+  coverageByCountryOr: Record<ISO2, RouteMode[]>;
+  coverageByCountryAnd: Record<ISO2, RouteMode[]>;
+  /**
+   * Backward-compatible alias for OR coverage.
+   */
   coverageByCountry: Record<ISO2, RouteMode[]>;
   rowCount: number;
   errorCount: number;

--- a/packages/route-api/src/routeTypes.ts
+++ b/packages/route-api/src/routeTypes.ts
@@ -34,7 +34,9 @@ export interface RoutePoint {
   admin0Name?: string;
   admin0Code?: string;
   admin1Name?: string;
+  admin1Code?: string;
   admin2Name?: string;
+  admin2Code?: string;
 }
 
 export interface RouteFeature extends GroupEntity {
@@ -127,6 +129,7 @@ export interface RouteEntityPayload {
   processing?: RouteProcessingConfig;
   processedAt?: number;
   processingStatus?: 'pending' | 'processing' | 'completed' | 'failed';
+  rebuildRequired?: boolean;
   processingError?: string;
   zoomRange?: [number, number];
   buildStartedAt?: number;
@@ -216,6 +219,29 @@ export interface RouteNearestLineResponse {
     latitude: number;
   };
   matches: RouteNearestLineMatch[];
+}
+
+export type RouteMetadataSyncField =
+  | 'reference'
+  | 'coordinates'
+  | 'adminCode'
+  | 'adminName';
+
+export type RouteMetadataSyncStatus = 'synced' | 'stale';
+
+export interface RouteMetadataSyncRow {
+  lineId: string;
+  status: RouteMetadataSyncStatus;
+  staleFields: RouteMetadataSyncField[];
+  reason?: string;
+}
+
+export interface RouteMetadataSyncSummary {
+  checkedAt: number;
+  totalCount: number;
+  syncedCount: number;
+  staleCount: number;
+  rows: RouteMetadataSyncRow[];
 }
 
 export interface RouteWaypointPoint {

--- a/packages/route-store/src/RouteDB.ts
+++ b/packages/route-store/src/RouteDB.ts
@@ -94,7 +94,18 @@ export async function hasRouteReferencesToLocations(
     .anyOf(locationNodeIds)
     .limit(1)
     .toArray();
-  return endMatch.length > 0;
+  if (endMatch.length > 0) return true;
+
+  const rows = await db.features.toArray();
+  const locationIdSet = new Set(locationNodeIds.map((id) => String(id)));
+  return rows.some((row) => {
+    const startLocationId = row.startPoint?.locationId;
+    const endLocationId = row.endPoint?.locationId;
+    return (
+      (startLocationId && locationIdSet.has(String(startLocationId)))
+      || (endLocationId && locationIdSet.has(String(endLocationId)))
+    );
+  });
 }
 
 export async function countRouteReferencesToLocations(
@@ -111,6 +122,18 @@ export async function countRouteReferencesToLocations(
     .where('endLocationId')
     .anyOf(locationNodeIds)
     .primaryKeys();
-  const unique = new Set([...startIds, ...endIds]);
+  const unique = new Set<string>([...startIds.map(String), ...endIds.map(String)]);
+  const rows = await db.features.toArray();
+  const locationIdSet = new Set(locationNodeIds.map((id) => String(id)));
+  rows.forEach((row) => {
+    const startLocationId = row.startPoint?.locationId;
+    const endLocationId = row.endPoint?.locationId;
+    if (
+      (startLocationId && locationIdSet.has(String(startLocationId)))
+      || (endLocationId && locationIdSet.has(String(endLocationId)))
+    ) {
+      unique.add(String(row.id));
+    }
+  });
   return unique.size;
 }

--- a/packages/runtime-worker/src/services/LocationMutationService.ts
+++ b/packages/runtime-worker/src/services/LocationMutationService.ts
@@ -1,11 +1,14 @@
 import type { NodeId } from '@hierarchidb/core-types';
 import type { LocationFeature, LocationPointProperties } from '@hierarchidb/location-store';
 import type { LocationMutationAPI } from '@hierarchidb/location-api';
+import type { RouteLineString } from '@hierarchidb/route-api';
+import { ephemeralRouteDB } from '@hierarchidb/gis-sdk';
 import {
   filterIdeGsmPointsBySelection,
   getLocationDB,
   mortonKeyFromLonLat,
 } from '@hierarchidb/location-store';
+import { getRouteDB } from '@hierarchidb/route-store';
 import {
   IDE_GSM_BULK_CHUNK_SIZE,
   type IdeGsmImportCallback,
@@ -26,6 +29,13 @@ type LocationPointWriteProgress = {
   chunkSize: number;
 };
 
+type LocationUpsertDiff = {
+  featureId: string;
+  nextData: LocationPointProperties;
+  structuralChanged: boolean;
+  metadataChanged: boolean;
+};
+
 export class LocationMutationService implements LocationMutationAPI {
   static async getSingleton(): Promise<LocationMutationService> {
     return SingletonMixin.getSingleton(
@@ -37,9 +47,26 @@ export class LocationMutationService implements LocationMutationAPI {
   async upsertLocationGroups(nodeId: NodeId, items: LocationGroupItem[]): Promise<void> {
     const db = getLocationDB();
     await db.open?.();
+    const existingRows = items.length > 0
+      ? await db.features.bulkGet(
+        items.map((item) => [nodeId, String(item.id)] as [NodeId, string]),
+      )
+      : [];
+    const updateDiffs: LocationUpsertDiff[] = [];
     const now = Date.now();
-    const rows: LocationFeature[] = items.map((item) => {
+    const rows: LocationFeature[] = items.map((item, index) => {
       const data = item.data as LocationPointProperties;
+      const existing = existingRows[index];
+      const structuralChanged = hasStructuralLocationDiff(existing?.data, data);
+      const metadataChanged = hasMetadataLocationDiff(existing?.data, data);
+      if (existing && (structuralChanged || metadataChanged)) {
+        updateDiffs.push({
+          featureId: String(item.id),
+          nextData: data,
+          structuralChanged,
+          metadataChanged: !structuralChanged && metadataChanged,
+        });
+      }
       const longitude = data?.longitude;
       const latitude = data?.latitude;
       const mortonKey = typeof longitude === 'number' && Number.isFinite(longitude)
@@ -60,6 +87,9 @@ export class LocationMutationService implements LocationMutationAPI {
       };
     });
     await db.features.bulkPut(rows);
+    if (updateDiffs.length > 0) {
+      await this.syncRoutesAfterLocationUpdates(nodeId, updateDiffs);
+    }
   }
 
   async deleteLocationGroups(nodeId: NodeId, itemIds: string[]): Promise<void> {
@@ -105,6 +135,7 @@ export class LocationMutationService implements LocationMutationAPI {
       })
       .map((row) => row.id);
     if (!targetIds.length) return;
+    await this.deleteRoutesReferencingLocationRows(nodeId, targetIds.map((id) => String(id)));
     await db.transaction('rw', db.features, async () => {
       for (const id of targetIds) {
         await db.features.delete([nodeId, String(id)]);
@@ -319,4 +350,188 @@ export class LocationMutationService implements LocationMutationAPI {
       options?.onProgress?.({ total: points.length, saved, chunkIndex, chunkSize });
     }
   }
+
+  private async deleteRoutesReferencingLocationRows(
+    locationNodeId: NodeId,
+    locationFeatureIds: string[],
+  ): Promise<void> {
+    if (!locationFeatureIds.length) return;
+    const routeDb = getRouteDB();
+    await routeDb.open?.();
+    const locationFeatureSet = new Set(locationFeatureIds.map((id) => String(id)));
+    const rows = await routeDb.features.toArray();
+    const impacted = (rows as RouteLineString[]).filter((row) => {
+      const startLocationId = row.startPoint?.locationId;
+      const endLocationId = row.endPoint?.locationId;
+      const startFeatureId = row.startPoint?.locationFeatureId;
+      const endFeatureId = row.endPoint?.locationFeatureId;
+      const startMatched = startLocationId === locationNodeId && startFeatureId && locationFeatureSet.has(String(startFeatureId));
+      const endMatched = endLocationId === locationNodeId && endFeatureId && locationFeatureSet.has(String(endFeatureId));
+      return Boolean(startMatched || endMatched);
+    });
+    if (!impacted.length) return;
+    const impactedRouteNodeIds = new Set(impacted.map((row) => row.nodeId));
+    await routeDb.transaction('rw', routeDb.features, routeDb.vectorTiles, routeDb.tileIndex, async () => {
+      for (const route of impacted) {
+        await routeDb.features.delete(route.id);
+      }
+      for (const routeNodeId of impactedRouteNodeIds) {
+        await routeDb.vectorTiles.where('nodeId').equals(routeNodeId).delete();
+        await routeDb.tileIndex.where('nodeId').equals(routeNodeId).delete();
+      }
+    });
+    for (const routeNodeId of impactedRouteNodeIds) {
+      await this.clearFetchCacheAndReserveRouteRebuild(routeNodeId);
+    }
+  }
+
+  private async syncRoutesAfterLocationUpdates(
+    locationNodeId: NodeId,
+    diffs: LocationUpsertDiff[],
+  ): Promise<void> {
+    if (!diffs.length) return;
+    const routeDb = getRouteDB();
+    await routeDb.open?.();
+    const diffByFeatureId = new Map(diffs.map((diff) => [diff.featureId, diff]));
+    const rows = await routeDb.features.toArray();
+    const metadataUpdates: RouteLineString[] = [];
+    const structuralRouteNodes = new Set<NodeId>();
+
+    (rows as RouteLineString[]).forEach((route) => {
+      const startFeatureId = route.startPoint?.locationFeatureId ? String(route.startPoint.locationFeatureId) : null;
+      const endFeatureId = route.endPoint?.locationFeatureId ? String(route.endPoint.locationFeatureId) : null;
+      const startMatched = route.startPoint?.locationId === locationNodeId && startFeatureId
+        ? diffByFeatureId.get(startFeatureId)
+        : undefined;
+      const endMatched = route.endPoint?.locationId === locationNodeId && endFeatureId
+        ? diffByFeatureId.get(endFeatureId)
+        : undefined;
+      if (!startMatched && !endMatched) return;
+
+      if (startMatched?.structuralChanged || endMatched?.structuralChanged) {
+        structuralRouteNodes.add(route.nodeId);
+        return;
+      }
+
+      let changed = false;
+      const nextRoute: RouteLineString = {
+        ...route,
+        startPoint: route.startPoint ? { ...route.startPoint } : route.startPoint,
+        endPoint: route.endPoint ? { ...route.endPoint } : route.endPoint,
+      };
+      if (startMatched?.metadataChanged && nextRoute.startPoint) {
+        nextRoute.startPoint = applyLocationMetadataToRoutePoint(nextRoute.startPoint, startMatched.nextData);
+        changed = true;
+      }
+      if (endMatched?.metadataChanged && nextRoute.endPoint) {
+        nextRoute.endPoint = applyLocationMetadataToRoutePoint(nextRoute.endPoint, endMatched.nextData);
+        changed = true;
+      }
+      if (!changed) return;
+      nextRoute.updatedAt = Date.now();
+      metadataUpdates.push(nextRoute);
+    });
+
+    await routeDb.transaction('rw', routeDb.features, routeDb.vectorTiles, routeDb.tileIndex, async () => {
+      if (metadataUpdates.length > 0) {
+        await routeDb.features.bulkPut(metadataUpdates);
+      }
+      for (const routeNodeId of structuralRouteNodes) {
+        await routeDb.vectorTiles.where('nodeId').equals(routeNodeId).delete();
+        await routeDb.tileIndex.where('nodeId').equals(routeNodeId).delete();
+      }
+    });
+
+    for (const routeNodeId of structuralRouteNodes) {
+      await this.clearFetchCacheAndReserveRouteRebuild(routeNodeId);
+    }
+  }
+
+  private async clearFetchCacheAndReserveRouteRebuild(routeNodeId: NodeId): Promise<void> {
+    await ephemeralRouteDB.open?.();
+    const now = Date.now();
+    await ephemeralRouteDB.transaction(
+      'rw',
+      [ephemeralRouteDB.fetchCache, ephemeralRouteDB.fetchCacheMeta, ephemeralRouteDB.sessions],
+      async () => {
+        await ephemeralRouteDB.fetchCache.where('nodeId').equals(routeNodeId).delete();
+        await ephemeralRouteDB.fetchCacheMeta.where('nodeId').equals(routeNodeId).delete();
+        const current = await ephemeralRouteDB.sessions.get(routeNodeId);
+        if (current?.status === 'running') return;
+        await ephemeralRouteDB.sessions.put({
+          ...(current ?? {}),
+          nodeId: routeNodeId,
+          domainType: 'route',
+          status: 'rebuild-reserved',
+          stage: 'fetch',
+          progress: 0,
+          updatedAt: now,
+          startedAt: current?.startedAt ?? now,
+          completedAt: undefined,
+          stopReason: 'unknown',
+        });
+      },
+    );
+  }
 }
+
+const hasStructuralLocationDiff = (
+  prev?: LocationPointProperties,
+  next?: LocationPointProperties,
+): boolean => {
+  if (!prev || !next) return false;
+  return !isEqualNumber(prev.longitude, next.longitude)
+    || !isEqualNumber(prev.latitude, next.latitude)
+    || !isEqualString(prev.admin0Code, next.admin0Code)
+    || !isEqualString(prev.admin1Code, next.admin1Code)
+    || !isEqualString(prev.admin2Code, next.admin2Code);
+};
+
+const hasMetadataLocationDiff = (
+  prev?: LocationPointProperties,
+  next?: LocationPointProperties,
+): boolean => {
+  if (!prev || !next) return false;
+  const prevComparable = {
+    name: prev.name,
+    type: prev.type,
+    admin0: prev.admin0,
+    admin1: prev.admin1,
+    admin2: prev.admin2,
+    pointId: prev.pointId,
+    metadata: prev.metadata ?? {},
+  };
+  const nextComparable = {
+    name: next.name,
+    type: next.type,
+    admin0: next.admin0,
+    admin1: next.admin1,
+    admin2: next.admin2,
+    pointId: next.pointId,
+    metadata: next.metadata ?? {},
+  };
+  return JSON.stringify(prevComparable) !== JSON.stringify(nextComparable);
+};
+
+const applyLocationMetadataToRoutePoint = (
+  point: NonNullable<RouteLineString['startPoint']>,
+  source: LocationPointProperties,
+): NonNullable<RouteLineString['startPoint']> => ({
+  ...point,
+  name: source.name,
+  locationName: source.name,
+  admin0Name: source.admin0,
+  admin1Name: source.admin1,
+  admin2Name: source.admin2,
+  admin0Code: source.admin0Code,
+  admin1Code: source.admin1Code,
+  admin2Code: source.admin2Code,
+});
+
+const isEqualNumber = (left?: number, right?: number): boolean => {
+  if (left == null && right == null) return true;
+  if (typeof left !== 'number' || typeof right !== 'number') return false;
+  return Math.abs(left - right) <= 1e-9;
+};
+
+const isEqualString = (left?: string, right?: string): boolean => (left ?? '') === (right ?? '');

--- a/packages/runtime-worker/src/services/RouteMutationService.ts
+++ b/packages/runtime-worker/src/services/RouteMutationService.ts
@@ -25,7 +25,7 @@ import { RouteGenerator, SearouteEngine } from '@hierarchidb/route-engine';
 import type { RouteDatabaseHandle } from '@hierarchidb/route-store';
 import { SingletonMixin } from '@hierarchidb/util';
 import { buildIdeGsmLocationIndex } from './route/ideGsmCsv.js';
-import { parseIdeGsmRouteRecords } from '@hierarchidb/route-api';
+import { filterIdeGsmRoutesBySelection, parseIdeGsmRouteRecords } from '@hierarchidb/route-api';
 import { loadTabularTableRows } from './utils/tabular.js';
 import { getStageProcessingClient } from './StageProcessingService.js';
 import { writeVectorTileInput } from './vectorTileStageRunner.js';
@@ -94,10 +94,12 @@ export class RouteMutationService implements RouteMutationAPI {
     const { headers, rows } = await loadTabularTableRows('route', request.tabularSourceId);
     const locationIndex = await buildIdeGsmLocationIndex(this.locationQueryService, locationNodeIds);
     const { lineStrings, errors } = parseIdeGsmRouteRecords(headers, rows, locationIndex, request.nodeId);
-    const coverageByCountry = buildCoverageByCountry(lineStrings);
+    const coverage = buildCoverageByCountry(lineStrings);
     const rowCount = lineStrings.length + errors.length;
     return {
-      coverageByCountry,
+      coverageByCountryOr: coverage.or,
+      coverageByCountryAnd: coverage.and,
+      coverageByCountry: coverage.or,
       rowCount,
       errorCount: errors.length,
       errors,
@@ -128,13 +130,17 @@ export class RouteMutationService implements RouteMutationAPI {
       );
       const { headers, rows } = await loadTabularTableRows('route', request.tabularSourceId);
       const { lineStrings, errors } = parseIdeGsmRouteRecords(headers, rows, locationIndex, request.nodeId);
-      emit({ phase: 'parse', total: lineStrings.length, processed: lineStrings.length });
+      const filteredLineStrings = filterIdeGsmRoutesBySelection(
+        lineStrings,
+        request.selectionEntries ?? [],
+      );
+      emit({ phase: 'parse', total: filteredLineStrings.length, processed: filteredLineStrings.length });
 
       const generator = await getIdeGsmRouteGenerator();
-      emit({ phase: 'waypoints', total: lineStrings.length, processed: 0 });
+      emit({ phase: 'waypoints', total: filteredLineStrings.length, processed: 0 });
       const waypointResults: RouteWaypointResult[] = [];
-      for (let i = 0; i < lineStrings.length; i += 1) {
-        const line = lineStrings[i]!;
+      for (let i = 0; i < filteredLineStrings.length; i += 1) {
+        const line = filteredLineStrings[i]!;
         const result = await buildWaypoints(
           {
             id: line.id,
@@ -147,11 +153,11 @@ export class RouteMutationService implements RouteMutationAPI {
           generator
         );
         waypointResults.push(result);
-        emit({ phase: 'waypoints', total: lineStrings.length, processed: i + 1 });
+        emit({ phase: 'waypoints', total: filteredLineStrings.length, processed: i + 1 });
       }
 
       const waypointMap = new Map(waypointResults.map((result) => [result.id, result]));
-      const linesWithWaypoints = lineStrings.map((line) => {
+      const linesWithWaypoints = filteredLineStrings.map((line) => {
         const result = waypointMap.get(line.id);
         if (!result) return line;
         return {
@@ -425,30 +431,48 @@ const pushUniqueIds = (target: NodeId[], seen: Set<NodeId>, nodes: TreeNode[]) =
   }
 };
 
-const buildCoverageByCountry = (lineStrings: RouteLineString[]): Record<ISO2, RouteLineString['routeMode'][]> => {
-  const coverage = new Map<ISO2, Set<RouteLineString['routeMode']>>();
+const buildCoverageByCountry = (
+  lineStrings: RouteLineString[],
+): {
+  or: Record<ISO2, RouteLineString['routeMode'][]>;
+  and: Record<ISO2, RouteLineString['routeMode'][]>;
+} => {
+  const coverageOr = new Map<ISO2, Set<RouteLineString['routeMode']>>();
+  const coverageAnd = new Map<ISO2, Set<RouteLineString['routeMode']>>();
   for (const line of lineStrings) {
     const startCode = line.startPoint?.admin0Code;
     const endCode = line.endPoint?.admin0Code;
     if (startCode) {
-      const existing = coverage.get(startCode as ISO2) ?? new Set();
+      const existing = coverageOr.get(startCode as ISO2) ?? new Set();
       existing.add(line.routeMode);
-      coverage.set(startCode as ISO2, existing);
+      coverageOr.set(startCode as ISO2, existing);
     }
     if (endCode) {
-      const existing = coverage.get(endCode as ISO2) ?? new Set();
+      const existing = coverageOr.get(endCode as ISO2) ?? new Set();
       existing.add(line.routeMode);
-      coverage.set(endCode as ISO2, existing);
+      coverageOr.set(endCode as ISO2, existing);
+    }
+    if (startCode && endCode && startCode === endCode) {
+      const existing = coverageAnd.get(startCode as ISO2) ?? new Set();
+      existing.add(line.routeMode);
+      coverageAnd.set(startCode as ISO2, existing);
     }
   }
-  const result: Record<ISO2, RouteLineString['routeMode'][]> = {} as Record<
+  const resultOr: Record<ISO2, RouteLineString['routeMode'][]> = {} as Record<
     ISO2,
     RouteLineString['routeMode'][]
   >;
-  for (const [country, modes] of coverage.entries()) {
-    result[country] = Array.from(modes);
+  for (const [country, modes] of coverageOr.entries()) {
+    resultOr[country] = Array.from(modes);
   }
-  return result;
+  const resultAnd: Record<ISO2, RouteLineString['routeMode'][]> = {} as Record<
+    ISO2,
+    RouteLineString['routeMode'][]
+  >;
+  for (const [country, modes] of coverageAnd.entries()) {
+    resultAnd[country] = Array.from(modes);
+  }
+  return { or: resultOr, and: resultAnd };
 };
 
 

--- a/packages/runtime-worker/src/services/RouteQueryService.ts
+++ b/packages/runtime-worker/src/services/RouteQueryService.ts
@@ -1,6 +1,8 @@
 import type { NodeId } from '@hierarchidb/core-types';
 import type {
   RouteLineString,
+  RouteMetadataSyncRow,
+  RouteMetadataSyncSummary,
   RouteNearestEndpoint,
   RouteNearestLine,
   RouteNearestLineQuery,
@@ -9,6 +11,8 @@ import type {
 } from '@hierarchidb/route-api';
 import type { RouteDatabaseHandle } from '@hierarchidb/route-store';
 import { countRouteReferencesToLocations } from '@hierarchidb/route-store';
+import { getLocationDB } from '@hierarchidb/location-store';
+import type { LocationFeature } from '@hierarchidb/location-api';
 import { SingletonMixin } from '@hierarchidb/util';
 import {
   BTree,
@@ -113,6 +117,53 @@ export class RouteQueryService implements RouteQueryAPI {
   async listRouteLineStrings(nodeId: NodeId): Promise<RouteLineStringRecord[]> {
     await this.db.open?.();
     return this.getLineStrings(nodeId);
+  }
+
+  async checkRouteMetadataSync(nodeId: NodeId): Promise<RouteMetadataSyncSummary> {
+    await this.db.open?.();
+    const routeLines = await this.getLineStrings(nodeId);
+    const locationDb = getLocationDB();
+    await locationDb.open?.();
+    const locationCache = new Map<string, LocationFeature | null>();
+    const rows: RouteMetadataSyncRow[] = [];
+
+    for (const line of routeLines) {
+      const staleFields = new Set<RouteMetadataSyncRow['staleFields'][number]>();
+      const reasons: string[] = [];
+      const startResult = await compareRoutePointWithLocation(
+        'start',
+        line.startPoint,
+        locationDb,
+        locationCache,
+      );
+      const endResult = await compareRoutePointWithLocation(
+        'end',
+        line.endPoint,
+        locationDb,
+        locationCache,
+      );
+
+      [...startResult.staleFields, ...endResult.staleFields].forEach((field) => staleFields.add(field));
+      if (startResult.reason) reasons.push(startResult.reason);
+      if (endResult.reason) reasons.push(endResult.reason);
+
+      rows.push({
+        lineId: String(line.id),
+        status: staleFields.size === 0 ? 'synced' : 'stale',
+        staleFields: Array.from(staleFields),
+        reason: reasons.length > 0 ? reasons.join(' / ') : undefined,
+      });
+    }
+
+    const staleCount = rows.filter((row) => row.status === 'stale').length;
+    const syncedCount = rows.length - staleCount;
+    return {
+      checkedAt: Date.now(),
+      totalCount: rows.length,
+      syncedCount,
+      staleCount,
+      rows,
+    };
   }
 
   async countRouteReferencesToLocations(locationNodeIds: NodeId[]): Promise<number> {
@@ -298,3 +349,69 @@ const buildFeatureId = (line: RouteLineStringRecord): string | undefined => {
   if (startId && endId) return `${startId}+${endId}`;
   return undefined;
 };
+
+type RoutePointLike = RouteLineStringRecord['startPoint'];
+
+type RoutePointComparisonResult = {
+  staleFields: Array<RouteMetadataSyncRow['staleFields'][number]>;
+  reason?: string;
+};
+
+const compareRoutePointWithLocation = async (
+  side: 'start' | 'end',
+  point: RoutePointLike | undefined,
+  locationDb: ReturnType<typeof getLocationDB>,
+  cache: Map<string, LocationFeature | null>,
+): Promise<RoutePointComparisonResult> => {
+  const staleFields: Array<RouteMetadataSyncRow['staleFields'][number]> = [];
+  if (!point?.locationId || !point?.locationFeatureId) {
+    staleFields.push('reference');
+    return { staleFields, reason: `${side}: location reference missing` };
+  }
+
+  const cacheKey = `${String(point.locationId)}::${String(point.locationFeatureId)}`;
+  let location = cache.get(cacheKey);
+  if (typeof location === 'undefined') {
+    location = await locationDb.features.get([point.locationId, String(point.locationFeatureId)]);
+    cache.set(cacheKey, location ?? null);
+  }
+  if (!location?.data) {
+    staleFields.push('reference');
+    return { staleFields, reason: `${side}: location row not found` };
+  }
+
+  const coordinateMismatch = !isNearlyEqual(point.longitude, location.data.longitude)
+    || !isNearlyEqual(point.latitude, location.data.latitude);
+  if (coordinateMismatch) {
+    staleFields.push('coordinates');
+  }
+
+  const adminCodeMismatch = !equalsNullableString(point.admin0Code, location.data.admin0Code)
+    || !equalsNullableString(point.admin1Code, location.data.admin1Code)
+    || !equalsNullableString(point.admin2Code, location.data.admin2Code);
+  if (adminCodeMismatch) {
+    staleFields.push('adminCode');
+  }
+
+  const adminNameMismatch = !equalsNullableString(point.admin0Name, location.data.admin0)
+    || !equalsNullableString(point.admin1Name, location.data.admin1)
+    || !equalsNullableString(point.admin2Name, location.data.admin2);
+  if (adminNameMismatch) {
+    staleFields.push('adminName');
+  }
+
+  if (staleFields.length === 0) return { staleFields };
+  return {
+    staleFields,
+    reason: `${side}: ${staleFields.join(', ')}`,
+  };
+};
+
+const isNearlyEqual = (left?: number, right?: number): boolean => {
+  if (typeof left !== 'number' || typeof right !== 'number') return false;
+  return Math.abs(left - right) <= 1e-9;
+};
+
+const equalsNullableString = (left?: string | null, right?: string | null): boolean => (
+  (left ?? '').trim() === (right ?? '').trim()
+);

--- a/packages/runtime-worker/src/services/ShapeQueryService.ts
+++ b/packages/runtime-worker/src/services/ShapeQueryService.ts
@@ -180,10 +180,13 @@ const toBuildSessionRecordFromEphemeral = (
   const stages = readStageMap(session.stages);
   if (!stages) return null;
   if (!isNumber(session.startedAt) || !isNumber(session.updatedAt)) return null;
+  const status: BuildSessionRecord['status'] = session.status === 'rebuild-reserved'
+    ? 'failed'
+    : session.status;
   return {
     nodeId: session.nodeId,
     draftId: session.draftId,
-    status: session.status,
+    status,
     startedAt: session.startedAt,
     updatedAt: session.updatedAt,
     completedAt: session.completedAt,
@@ -258,7 +261,12 @@ export class ShapeQueryService implements ShapeQueryAPI {
     await this.ensureOpen();
     await this.ensureEphemeralOpen();
     const sessions = await ephemeralShapeDB.sessions.toArray();
-    const filtered = sessions.filter((session) => statuses.includes(session.status));
+    const filtered = sessions.filter((session) => {
+      const status: BuildSessionRecord['status'] = session.status === 'rebuild-reserved'
+        ? 'failed'
+        : session.status;
+      return statuses.includes(status);
+    });
     const records = filtered.map(toBuildSessionRecordFromEphemeral).filter(isNonNull);
     return records.map(toShapeBuildSessionRecord);
   }

--- a/packages/ui/map/src/preview/RoutePreviewList.tsx
+++ b/packages/ui/map/src/preview/RoutePreviewList.tsx
@@ -77,6 +77,7 @@ export type RoutePreviewListProps = {
   title: string;
   rows: RoutePreviewLineRow[];
   columnLabels: RoutePreviewColumnLabels;
+  toolbarActions?: React.ReactNode;
   search?: MapPreviewSearchConfig;
   matchedRows?: Set<string>;
   modeMeta?: Record<string, RoutePreviewModeMeta>;
@@ -154,6 +155,7 @@ export const RoutePreviewList: React.FC<RoutePreviewListProps> = ({
   title,
   rows,
   columnLabels,
+  toolbarActions,
   search,
   matchedRows,
   modeMeta,
@@ -295,6 +297,7 @@ export const RoutePreviewList: React.FC<RoutePreviewListProps> = ({
         errorSummaryById={errorSummaryById}
         errorColumnLabels={errorColumnLabels}
         statusLabels={statusLabels}
+        toolbarActions={toolbarActions}
         maxHeight={maxHeight}
         containerSx={{
           position: 'static',

--- a/plugins/location-plugin/src/ui/components/steps/LocationDataSourceStep.tsx
+++ b/plugins/location-plugin/src/ui/components/steps/LocationDataSourceStep.tsx
@@ -145,6 +145,14 @@ export const LocationDataSourceStep: React.FC<LocationDataSourceStepProps> = ({
               'Removing this file will discard its locations and re-import the remaining files.',
             )}
           </Typography>
+          {routeRefCount != null && routeRefCount > 0 ? (
+            <Typography variant="body2" color="warning.main">
+              {t(
+                'dataSource.ideGsm.removeCascadeWarning',
+                'Referenced routes will also be deleted to keep route/location consistency.',
+              )}
+            </Typography>
+          ) : null}
           {routeRefLoading ? (
             <Typography variant="body2" color="text.secondary">
               {t('dataSource.ideGsm.routeRefLoading', 'Checking route references...')}

--- a/plugins/route-plugin/README.md
+++ b/plugins/route-plugin/README.md
@@ -18,6 +18,27 @@
 交通路・輸送ルート情報の収集、管理、可視化を行うHierarchiDBプラグインです。
 OpenStreetMapやNatural Earth等のオープンデータソースから、航路、海路、道路、鉄道等のルートデータをバッチダウンロードし、地図上で可視化・分析できます。
 
+## 2026-02-14 確定仕様（優先）
+
+この節は、route の「ビルド前〜ビルド」仕様の現行定義です。既存の Step 説明と衝突する場合は本節を優先してください。
+詳細は `docs/route-build-flow-spec.md` を参照してください。
+
+- route の成果物は location の始点・終点座標に依存するため、location/shape のレイトバインディングとは異なる。
+- Step3 は国×交通モードの OR/AND マトリクス（1国あたり 10 チェック）で `selectedArrayByCountries` を更新する。
+  - OR を選択したモードは同一行の AND が自動 `checked/disabled` になる。
+  - チェックボックスは Step2 で読み込んだデータ上で実在する国×モードのみ生成し、初期状態は `checked`。
+- Step4 は shape の build 設定 UI（VT 設定カードを含む）を共用する。
+- Step5 は shape と同じ UI/実行構成を最大限共用するが、route は transform で filtering と simplification を一括実行する。
+  - fetch の `featureCache` はズーム帯別コピーではなく、オリジナルの LineString GeoJSON 1 本のみ保存する。
+  - metadata には location 由来の座標、admin0〜2 の name/code、距離、中継点数を保存する。
+- Step6 は shape/location と同等のプレビュー UI を共用する。
+  - FloatingWindow で Metadata: routes / 交通モードトグル / スタイル設定を重ね表示可能。
+  - 交通モードは 5 アイコンの複数 on/off トグル。保存先は shape と同様の FloatingWindow 永続化設定。
+- location 変更時は route への波及を前提とし、削除/変更のたびに location UI 側で警告ダイアログを表示する。
+  - 削除: 参照中 route もカスケード削除するかキャンセル。
+  - 変更: カスケード変更するかキャンセル。座標/admin code 変更時は fetch キャッシュ削除 + `rebuild required` 表示 + sessions に「再ビルド予約」を route ノード単位で作成する。
+  - それ以外の項目変更時は route metadata を即時更新する。
+
 ## 主要機能
 
 - 🛤️ **多様なルートタイプ**: 航路、海路、道路、鉄道、高速鉄道

--- a/plugins/route-plugin/src/ui/components/steps/RoutePreviewStep.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/RoutePreviewStep.tsx
@@ -58,7 +58,7 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
     matchedIdSet,
     selectedIds,
     setSelectedIds,
-    emptyErrorSummary,
+    staleSummaryById,
     emptyContentProps,
     modeMeta,
     columnLabels,
@@ -72,6 +72,10 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
     handleModeColorChange,
     handleLineWidthChange,
     handleLineStyleChange,
+    metadataSyncRunning,
+    metadataSyncError,
+    metadataSyncBadgeText,
+    runMetadataSyncCheck,
   } = useRoutePreviewStep({ draft, nodeId, onUpdate });
 
   return (
@@ -154,13 +158,37 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
                 matchedRows={matchedIdSet}
                 selectedRows={new Set(selectedIds)}
                 onSelectionChange={(next: Set<string | number>) => setSelectedIds(Array.from(next).map(String))}
-                errorSummaryById={emptyErrorSummary}
+                errorSummaryById={staleSummaryById}
                 errorColumnLabels={errorColumnLabels}
                 statusLabels={statusLabels}
+                toolbarActions={(
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() => void runMetadataSyncCheck()}
+                      disabled={metadataSyncRunning}
+                    >
+                      {metadataSyncRunning
+                        ? t('preview.metadataSync.checking', 'Checking...')
+                        : t('preview.metadataSync.checkButton', 'Check sync status')}
+                    </Button>
+                    {metadataSyncBadgeText ? (
+                      <Typography variant="caption" color="text.secondary">
+                        {metadataSyncBadgeText}
+                      </Typography>
+                    ) : null}
+                  </Box>
+                )}
                 emptyContent={emptyContentProps ? (
                   <RoutePreviewEmptyContent {...emptyContentProps} />
                 ) : undefined}
               />
+              {metadataSyncError ? (
+                <Box sx={{ position: 'absolute', left: 12, right: 12, bottom: 12, zIndex: 4 }}>
+                  <Alert severity="error">{metadataSyncError}</Alert>
+                </Box>
+              ) : null}
               {styleWindow.windowState.isVisible ? (
                 <FloatingWindow
                   title={t('routeConfig.style.title', 'Route style')}

--- a/plugins/route-plugin/src/ui/components/steps/RouteSelectionStep.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/RouteSelectionStep.tsx
@@ -24,7 +24,6 @@ import {
   type RouteSelectionStepProps,
   useRouteSelectionStep,
 } from './useRouteSelectionStep.js';
-import type { RouteMode } from '@hierarchidb/route-api';
 
 const RouteSelectionContent: React.FC<RouteSelectionStepProps> = (props) => {
   const {
@@ -44,7 +43,7 @@ const RouteSelectionContent: React.FC<RouteSelectionStepProps> = (props) => {
     matrixConfig,
     currentSelections,
     applySelections,
-    resolveAllowedModesForCountry,
+    isCellEnabledForCountry,
     policy,
   } = useRouteSelectionStep(props);
 
@@ -88,7 +87,7 @@ const RouteSelectionContent: React.FC<RouteSelectionStepProps> = (props) => {
         showAlphabetIndex
         showRegionIndex
         rowHeight={40}
-        isCellEnabled={(country, columnId) => resolveAllowedModesForCountry(country.code).has(columnId as RouteMode)}
+        isCellEnabled={(country, columnId) => isCellEnabledForCountry(country.code, columnId)}
         loading={isIdeGsm && coverageLoading}
         errorMessage={selectionErrorMessage}
         height="100%"

--- a/plugins/route-plugin/src/ui/components/steps/__tests__/RoutePreviewStep.style-floating.unit.test.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/__tests__/RoutePreviewStep.style-floating.unit.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../useRoutePreviewStep.js', () => ({
     matchedIdSet: new Set<string>(),
     selectedIds: [],
     setSelectedIds: vi.fn(),
-    emptyErrorSummary: new Map(),
+    staleSummaryById: new Map(),
     emptyContentProps: undefined,
     modeMeta: {},
     columnLabels: {
@@ -92,6 +92,11 @@ vi.mock('../useRoutePreviewStep.js', () => ({
     handleModeColorChange: vi.fn(),
     handleLineWidthChange: vi.fn(),
     handleLineStyleChange: vi.fn(),
+    metadataSyncSummary: null,
+    metadataSyncRunning: false,
+    metadataSyncError: null,
+    metadataSyncBadgeText: '',
+    runMetadataSyncCheck: vi.fn(),
   }),
 }));
 

--- a/plugins/route-plugin/src/ui/components/steps/__tests__/RouteSelectionStep.style-placement.unit.test.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/__tests__/RouteSelectionStep.style-placement.unit.test.tsx
@@ -48,7 +48,7 @@ vi.mock('../useRouteSelectionStep.js', () => ({
     },
     currentSelections: [],
     applySelections: vi.fn(),
-    resolveAllowedModesForCountry: () => new Set(['airway']),
+    isCellEnabledForCountry: () => true,
     policy: { defaultChecked: null },
     styleConfig: {
       modeColors: { airway: '#1f77b4' },

--- a/plugins/route-plugin/src/ui/components/steps/useRouteBuildSessionLifecycle.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRouteBuildSessionLifecycle.ts
@@ -3,9 +3,11 @@ import type { NodeId } from '@hierarchidb/core-types';
 import { proxy } from 'comlink';
 import {
   IDE_GSM_BULK_CHUNK_SIZE,
+  type IdeGsmRouteSelectionEntry,
   type IdeGsmImportProgress,
   type IdeGsmRouteError,
   type RouteEntity,
+  type RouteMode,
 } from '@hierarchidb/route-api';
 import {
   createSessionCoordinator,
@@ -18,6 +20,7 @@ import {
   type PauseBuildReason,
   useBuildSessionTransition,
 } from '@hierarchidb/components';
+import { ROUTE_MODE_COLUMNS } from './useRouteSelectionStep.js';
 
 export type RouteBuildSessionTransitionPhase =
   | 'acquiring-lock'
@@ -32,6 +35,7 @@ type RouteMutationApi = {
     args: {
       nodeId: NodeId;
       tabularSourceId: string;
+      selectionEntries?: IdeGsmRouteSelectionEntry[];
       chunkSize: number;
     },
     onProgress: (progress: IdeGsmImportProgress) => void,
@@ -72,6 +76,40 @@ type UseRouteBuildSessionLifecycleArgs = {
   transformStageMax: number;
   vtStageMax: number;
   t: (key: string, fallback?: string) => string;
+};
+
+const buildIdeGsmSelectionEntries = (
+  selectedArrayByCountries?: Record<string, boolean[]>,
+): IdeGsmRouteSelectionEntry[] => {
+  if (!selectedArrayByCountries) return [];
+  const entries: IdeGsmRouteSelectionEntry[] = [];
+  Object.entries(selectedArrayByCountries).forEach(([countryCodeRaw, rawRow]) => {
+    const countryCode = countryCodeRaw.trim().toUpperCase();
+    if (!countryCode) return;
+    const row = Array.isArray(rawRow) ? rawRow : [];
+    const orModes: RouteMode[] = [];
+    const andModes: RouteMode[] = [];
+    ROUTE_MODE_COLUMNS.forEach((modeColumn, modeIndex) => {
+      const orChecked = Boolean(row[modeIndex]);
+      const andChecked = row.length >= ROUTE_MODE_COLUMNS.length * 2
+        ? Boolean(row[modeIndex + ROUTE_MODE_COLUMNS.length])
+        : orChecked;
+      if (orChecked) {
+        orModes.push(modeColumn.id);
+      }
+      if (andChecked || orChecked) {
+        andModes.push(modeColumn.id);
+      }
+    });
+    if (orModes.length === 0 && andModes.length === 0) return;
+    entries.push({
+      countryCode,
+      countryName: countryCode,
+      orModes,
+      andModes,
+    });
+  });
+  return entries;
 };
 
 export const useRouteBuildSessionLifecycle = ({
@@ -245,6 +283,7 @@ export const useRouteBuildSessionLifecycle = ({
       notify.error(t('stage.errors.missingSource', 'IDE-GSM source is required.'));
       return;
     }
+    const selectionEntries = buildIdeGsmSelectionEntries(draft.selectedArrayByCountries);
 
     beginBuildSessionTransition('acquiring-lock', {
       message: options?.autoResume
@@ -298,6 +337,7 @@ export const useRouteBuildSessionLifecycle = ({
         {
           nodeId: resolvedRouteNodeId,
           tabularSourceId: sourceId,
+          selectionEntries,
           chunkSize: IDE_GSM_BULK_CHUNK_SIZE,
         },
         proxy((progress: IdeGsmImportProgress) => {

--- a/plugins/route-plugin/src/ui/components/steps/useRoutePreviewStep.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRoutePreviewStep.ts
@@ -21,7 +21,12 @@ import type { SvgIconComponent } from '@mui/icons-material';
 import type { NodeId } from '@hierarchidb/core-types';
 import { getWorkerBridge } from '@hierarchidb/ui-worker-client';
 import { useFloatingWindow } from '@hierarchidb/ui-floating-window';
-import type { RouteEntity, RouteLineString, RouteNearestLineResponse } from '@hierarchidb/route-api';
+import type {
+  RouteEntity,
+  RouteLineString,
+  RouteMetadataSyncSummary,
+  RouteNearestLineResponse,
+} from '@hierarchidb/route-api';
 import { formatDistance, getTransportModeName, useTranslation } from '../../../common/i18n/index.js';
 import {
   LINE_WIDTH_MAX,
@@ -51,6 +56,28 @@ const ROUTE_MODE_OPTIONS: RouteModeOption[] = [
   { id: ROUTE_MODES.H_RAILWAY, label: 'High-speed Rail', Icon: SpeedIcon, modes: [ROUTE_MODES.H_RAILWAY] },
   { id: ROUTE_MODES.ROAD, label: 'Road', Icon: DirectionsCarIcon, modes: [ROUTE_MODES.ROAD, ROUTE_MODES.HIGHWAY] },
 ];
+
+const ROUTE_MODE_SELECTION_PERSIST_KEY = 'hierarchidb:ui:floating-window:route:mode-selection';
+
+const loadRouteModeSelection = (): MapToggleSelection => {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return Object.fromEntries(ROUTE_MODE_OPTIONS.map((option) => [option.id, true])) as MapToggleSelection;
+    }
+    const raw = localStorage.getItem(ROUTE_MODE_SELECTION_PERSIST_KEY);
+    if (!raw) {
+      return Object.fromEntries(ROUTE_MODE_OPTIONS.map((option) => [option.id, true])) as MapToggleSelection;
+    }
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const next: Record<string, boolean> = {};
+    ROUTE_MODE_OPTIONS.forEach((option) => {
+      next[option.id] = parsed[option.id] !== false;
+    });
+    return next as MapToggleSelection;
+  } catch {
+    return Object.fromEntries(ROUTE_MODE_OPTIONS.map((option) => [option.id, true])) as MapToggleSelection;
+  }
+};
 
 const resolveBoundsForLines = (lines: [number, number][][]): Bounds | null => {
   if (!lines.length) return null;
@@ -118,12 +145,13 @@ export const useRoutePreviewStep = ({
   const [lineStringsLoading, setLineStringsLoading] = useState(false);
   const [lineStringsError, setLineStringsError] = useState<string | null>(null);
   const [mapInstance, setMapInstance] = useState<MapLibreMapInstance | null>(null);
-  const [routeModeSelection, setRouteModeSelection] = useState<MapToggleSelection>(() =>
-    Object.fromEntries(ROUTE_MODE_OPTIONS.map((option) => [option.id, true])) as MapToggleSelection
-  );
+  const [routeModeSelection, setRouteModeSelection] = useState<MapToggleSelection>(loadRouteModeSelection);
   const [listSearch, setListSearch] = useState('');
   const [matchedIds, setMatchedIds] = useState<string[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [metadataSyncSummary, setMetadataSyncSummary] = useState<RouteMetadataSyncSummary | null>(null);
+  const [metadataSyncRunning, setMetadataSyncRunning] = useState(false);
+  const [metadataSyncError, setMetadataSyncError] = useState<string | null>(null);
   const [hoverInfo, setHoverInfo] = useState<RouteNearestLineResponse | null>(null);
   const [hoverOpen, setHoverOpen] = useState(false);
   const hoverTimerRef = useRef<number | null>(null);
@@ -175,6 +203,8 @@ export const useRoutePreviewStep = ({
   useEffect(() => {
     if (!previewNodeId) {
       setLineStrings([]);
+      setMetadataSyncSummary(null);
+      setMetadataSyncError(null);
       return;
     }
     let active = true;
@@ -201,6 +231,15 @@ export const useRoutePreviewStep = ({
       active = false;
     };
   }, [previewNodeId]);
+
+  useEffect(() => {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.setItem(ROUTE_MODE_SELECTION_PERSIST_KEY, JSON.stringify(routeModeSelection));
+    } catch {
+      // Ignore persistence failures.
+    }
+  }, [routeModeSelection]);
 
   const formatTemplate = useCallback(
     (template: string, values: Record<string, string | number>) =>
@@ -358,6 +397,22 @@ export const useRoutePreviewStep = ({
   const handleRouteModeToggle = useCallback((id: string) => {
     setRouteModeSelection((prev) => ({ ...prev, [id]: !prev[id] }));
   }, []);
+
+  const runMetadataSyncCheck = useCallback(async () => {
+    if (!previewNodeId) return;
+    setMetadataSyncRunning(true);
+    setMetadataSyncError(null);
+    try {
+      const api = await workerBridgeRef.current.getRouteQueryAPI();
+      const summary = await api.checkRouteMetadataSync(previewNodeId);
+      setMetadataSyncSummary(summary);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setMetadataSyncError(message);
+    } finally {
+      setMetadataSyncRunning(false);
+    }
+  }, [previewNodeId]);
   const listRows = useMemo(
     () => (hasGeometry ? buildRoutePreviewRows(lineStrings) : []),
     [hasGeometry, lineStrings],
@@ -429,7 +484,24 @@ export const useRoutePreviewStep = ({
     setMatchedIds,
   );
   const matchedIdSet = useMemo(() => new Set(matchedIds), [matchedIds]);
-  const emptyErrorSummary = useMemo(() => new Map(), []);
+  const staleSummaryById = useMemo(() => {
+    const map = new Map<string, { count: number; messages: string[] }>();
+    if (!metadataSyncSummary) return map;
+    metadataSyncSummary.rows.forEach((row) => {
+      if (row.status !== 'stale') return;
+      map.set(row.lineId, {
+        count: 1,
+        messages: row.reason ? [row.reason] : ['metadata mismatch'],
+      });
+    });
+    return map;
+  }, [metadataSyncSummary]);
+
+  const metadataSyncBadgeText = useMemo(() => {
+    if (!metadataSyncSummary) return '';
+    return `${t('preview.metadataSync.synced', '✅ Synced')}(${metadataSyncSummary.syncedCount}/${metadataSyncSummary.totalCount}) `
+      + `${t('preview.metadataSync.stale', '⚠️ Rebuild required')}(${metadataSyncSummary.staleCount}/${metadataSyncSummary.totalCount})`;
+  }, [metadataSyncSummary, t]);
 
   const hoverSnackbarProps = {
     open: hoverOpen && Boolean(hoverMessage),
@@ -461,7 +533,7 @@ export const useRoutePreviewStep = ({
     matchedIdSet,
     selectedIds,
     setSelectedIds,
-    emptyErrorSummary,
+    staleSummaryById,
     emptyContentProps,
     modeMeta: routeModeMeta,
     columnLabels: {
@@ -488,8 +560,8 @@ export const useRoutePreviewStep = ({
       ariaLabel: t('preview.list.searchAriaLabel', 'Search routes'),
     },
     statusLabels: {
-      failed: t('preview.list.status.failed', 'Failed'),
-      completed: t('preview.list.status.completed', 'Completed'),
+      failed: t('preview.metadataSync.stale', '⚠️ Rebuild required'),
+      completed: t('preview.metadataSync.synced', '✅ Synced'),
     },
     errorColumnLabels: {
       status: t('preview.list.columns.status', 'Status'),
@@ -502,5 +574,10 @@ export const useRoutePreviewStep = ({
     handleModeColorChange,
     handleLineWidthChange,
     handleLineStyleChange,
+    metadataSyncSummary,
+    metadataSyncRunning,
+    metadataSyncError,
+    metadataSyncBadgeText,
+    runMetadataSyncCheck,
   };
 };

--- a/plugins/route-plugin/src/ui/components/steps/useRouteSelectionStep.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRouteSelectionStep.ts
@@ -32,6 +32,45 @@ export const ROUTE_MODE_COLUMNS: SelectionColumn[] = [
   { id: ROUTE_MODES.ROAD, labelKey: 'transportModes.road', icon: DirectionsCar },
 ];
 
+export type RouteSelectionCondition = 'or' | 'and';
+export type RouteSelectionColumnId = `${RouteSelectionCondition}:${RouteMode}`;
+
+type RouteSelectionColumn = {
+  id: RouteSelectionColumnId;
+  mode: RouteMode;
+  condition: RouteSelectionCondition;
+  labelKey: string;
+  icon: SvgIconComponent;
+};
+
+const buildRouteSelectionColumnId = (condition: RouteSelectionCondition, mode: RouteMode): RouteSelectionColumnId => (
+  `${condition}:${mode}` as RouteSelectionColumnId
+);
+
+const parseRouteSelectionColumnId = (id: string): { condition: RouteSelectionCondition; mode: RouteMode } | null => {
+  const [condition, mode] = id.split(':');
+  if ((condition !== 'or' && condition !== 'and') || !mode) return null;
+  if (!ROUTE_MODE_COLUMNS.some((column) => column.id === mode)) return null;
+  return { condition, mode: mode as RouteMode };
+};
+
+export const ROUTE_SELECTION_COLUMNS: RouteSelectionColumn[] = [
+  ...ROUTE_MODE_COLUMNS.map((column) => ({
+    id: buildRouteSelectionColumnId('or', column.id),
+    condition: 'or' as const,
+    mode: column.id,
+    labelKey: column.labelKey,
+    icon: column.icon,
+  })),
+  ...ROUTE_MODE_COLUMNS.map((column) => ({
+    id: buildRouteSelectionColumnId('and', column.id),
+    condition: 'and' as const,
+    mode: column.id,
+    labelKey: column.labelKey,
+    icon: column.icon,
+  })),
+];
+
 export const ROUTE_STYLE_OPTIONS = [
   { id: 'solid', labelKey: 'routeConfig.style.lineStyle.solid', fallback: 'Solid' },
   { id: 'dashed', labelKey: 'routeConfig.style.lineStyle.dashed', fallback: 'Dashed' },
@@ -64,6 +103,40 @@ const resolveModePolicy = (source?: string | null): ModePolicy => {
       return { allowedModes: ROUTE_MODE_COLUMNS.map((col) => col.id), defaultChecked: null };
   }
 };
+
+const toSelectionArrayByColumn = (row: boolean[] | undefined): Record<RouteSelectionColumnId, boolean> => {
+  const normalized: Record<RouteSelectionColumnId, boolean> = {} as Record<RouteSelectionColumnId, boolean>;
+  ROUTE_SELECTION_COLUMNS.forEach((column, index) => {
+    normalized[column.id] = Boolean(row?.[index]);
+  });
+  // Backward compatibility: legacy 5-cell format (OR only).
+  if (Array.isArray(row) && row.length === ROUTE_MODE_COLUMNS.length) {
+    ROUTE_MODE_COLUMNS.forEach((modeColumn, index) => {
+      const checked = Boolean(row[index]);
+      const orId = buildRouteSelectionColumnId('or', modeColumn.id);
+      const andId = buildRouteSelectionColumnId('and', modeColumn.id);
+      normalized[orId] = checked;
+      normalized[andId] = checked;
+    });
+  }
+  return normalized;
+};
+
+const enforceOrAndRule = (rowByColumn: Record<RouteSelectionColumnId, boolean>): Record<RouteSelectionColumnId, boolean> => {
+  const next = { ...rowByColumn };
+  ROUTE_MODE_COLUMNS.forEach((modeColumn) => {
+    const orId = buildRouteSelectionColumnId('or', modeColumn.id);
+    const andId = buildRouteSelectionColumnId('and', modeColumn.id);
+    if (next[orId]) {
+      next[andId] = true;
+    }
+  });
+  return next;
+};
+
+const toSelectionArray = (rowByColumn: Record<RouteSelectionColumnId, boolean>): boolean[] => (
+  ROUTE_SELECTION_COLUMNS.map((column) => Boolean(rowByColumn[column.id]))
+);
 
 export const useRouteSelectionStep = ({
   draft: draftProp,
@@ -148,7 +221,7 @@ export const useRouteSelectionStep = ({
           tabularSourceId: ideGsmSourceId,
         });
         if (cancelled) return;
-        if (!result || Object.keys(result.coverageByCountry ?? {}).length === 0) {
+        if (!result || Object.keys(result.coverageByCountryOr ?? result.coverageByCountry ?? {}).length === 0) {
           throw new Error(t('routeConfig.ideGsmEmptyCoverage', 'No routes found in IDE-GSM data.'));
         }
         setCoverage(result);
@@ -169,45 +242,71 @@ export const useRouteSelectionStep = ({
     };
   }, [api, coverageRequestKey, ideGsmSourceId, initialize, isIdeGsm, routeNodeId, t]);
 
-  const coverageModeMap = useMemo(() => {
+  const coverageOrModeMap = useMemo(() => {
     const map = new Map<string, Set<RouteMode>>();
     if (!coverage) return map;
-    Object.entries(coverage.coverageByCountry ?? {}).forEach(([country, modes]) => {
+    const source = coverage.coverageByCountryOr ?? coverage.coverageByCountry ?? {};
+    Object.entries(source).forEach(([country, modes]) => {
       map.set(country, new Set(modes));
     });
     return map;
   }, [coverage]);
 
-  const resolveAllowedModesForCountry = useCallback((countryCode: string) => {
-    const allowed = new Set<RouteMode>();
+  const coverageAndModeMap = useMemo(() => {
+    const map = new Map<string, Set<RouteMode>>();
+    if (!coverage) return map;
+    Object.entries(coverage.coverageByCountryAnd ?? {}).forEach(([country, modes]) => {
+      map.set(country, new Set(modes));
+    });
+    return map;
+  }, [coverage]);
+
+  const resolveAvailableColumnSetForCountry = useCallback((countryCode: string) => {
+    const available = new Set<RouteSelectionColumnId>();
     if (isIdeGsm) {
-      const coverageModes = coverageModeMap.get(countryCode);
-      if (!coverageModes) return allowed;
-      coverageModes.forEach((mode) => {
-        if (allowedModeSet.has(mode)) {
-          allowed.add(mode);
+      const coverageOrModes = coverageOrModeMap.get(countryCode);
+      const coverageAndModes = coverageAndModeMap.get(countryCode);
+      ROUTE_MODE_COLUMNS.forEach((modeColumn) => {
+        if (!allowedModeSet.has(modeColumn.id)) return;
+        if (coverageOrModes?.has(modeColumn.id)) {
+          available.add(buildRouteSelectionColumnId('or', modeColumn.id));
+        }
+        if (coverageAndModes?.has(modeColumn.id)) {
+          available.add(buildRouteSelectionColumnId('and', modeColumn.id));
         }
       });
-      return allowed;
+      return available;
     }
-    policy.allowedModes.map((mode) => allowed.add(mode));
-    return allowed;
-  }, [allowedModeSet, coverageModeMap, isIdeGsm, policy.allowedModes]);
+    ROUTE_MODE_COLUMNS.forEach((modeColumn) => {
+      if (!allowedModeSet.has(modeColumn.id)) return;
+      available.add(buildRouteSelectionColumnId('or', modeColumn.id));
+      available.add(buildRouteSelectionColumnId('and', modeColumn.id));
+    });
+    return available;
+  }, [allowedModeSet, coverageAndModeMap, coverageOrModeMap, isIdeGsm]);
 
   const coverageKey = useMemo(() => {
     if (!isIdeGsm || !coverage) return null;
-    return JSON.stringify(coverage.coverageByCountry ?? {});
+    return JSON.stringify({
+      or: coverage.coverageByCountryOr ?? coverage.coverageByCountry ?? {},
+      and: coverage.coverageByCountryAnd ?? {},
+    });
   }, [coverage, isIdeGsm]);
 
   const matrixConfig: MatrixConfig = useMemo(() => ({
-    columns: ROUTE_MODE_COLUMNS.map((mode) => ({
-      id: mode.id,
-      label: t(mode.labelKey, mode.id),
-      description: t(mode.labelKey, mode.id),
-      type: 'custom',
-      width: 150,
-      icon: mode.icon,
-    })),
+    columns: ROUTE_SELECTION_COLUMNS.map((column) => {
+      const conditionLabel = column.condition === 'or'
+        ? t('routeConfig.conditionOr', 'OR')
+        : t('routeConfig.conditionAnd', 'AND');
+      return {
+        id: column.id,
+        label: `${conditionLabel} ${t(column.labelKey, column.mode)}`,
+        description: `${conditionLabel} ${t(column.labelKey, column.mode)}`,
+        type: 'custom',
+        width: 168,
+        icon: column.icon,
+      };
+    }),
     virtualization: {
       rowHeight: 40,
       overscan: 8,
@@ -236,10 +335,10 @@ export const useRouteSelectionStep = ({
   const currentSelections: MatrixSelection[] = useMemo(() => {
     if (iso.status !== 'ready') return [];
     return iso.countries.map((country, index) => {
-      const row = selectionMatrixSource[index] ?? [];
+      const row = toSelectionArrayByColumn(selectionMatrixSource[index]);
       const selections: Record<string, boolean> = {};
-      matrixConfig.columns.forEach((col, colIdx) => {
-        selections[col.id] = Boolean(row[colIdx]);
+      matrixConfig.columns.forEach((col) => {
+        selections[col.id] = Boolean(row[col.id as RouteSelectionColumnId]);
       });
       return { countryCode: country.code, selections };
     });
@@ -249,16 +348,21 @@ export const useRouteSelectionStep = ({
     if (iso.status !== 'ready') return {};
     const normalized: Record<string, boolean[]> = {};
     iso.countries.forEach((country) => {
-      const row = selectionByCountries[country.code] ?? [];
-      const allowedByCountry = resolveAllowedModesForCountry(country.code);
-      normalized[country.code] = matrixConfig.columns.map((col, colIdx) => {
-        if (!allowedByCountry.has(col.id as RouteMode)) return false;
-        if (applyDefaults) return true;
-        return Boolean(row[colIdx]);
+      const currentRow = toSelectionArrayByColumn(selectionByCountries[country.code]);
+      const availableColumns = resolveAvailableColumnSetForCountry(country.code);
+      const nextRowByColumn: Record<RouteSelectionColumnId, boolean> = {} as Record<RouteSelectionColumnId, boolean>;
+      ROUTE_SELECTION_COLUMNS.forEach((column) => {
+        const isAvailable = availableColumns.has(column.id);
+        if (!isAvailable) {
+          nextRowByColumn[column.id] = false;
+          return;
+        }
+        nextRowByColumn[column.id] = applyDefaults ? true : Boolean(currentRow[column.id]);
       });
+      normalized[country.code] = toSelectionArray(enforceOrAndRule(nextRowByColumn));
     });
     return normalized;
-  }, [iso.countries, iso.status, matrixConfig.columns, resolveAllowedModesForCountry, selectionByCountries]);
+  }, [iso.countries, iso.status, resolveAvailableColumnSetForCountry, selectionByCountries]);
 
   const hasAnySelection = useMemo(() => {
     if (iso.status !== 'ready') return false;
@@ -308,17 +412,36 @@ export const useRouteSelectionStep = ({
       iso.countries.forEach((country) => {
         const entry = nextSelections.find((sel) => sel.countryCode === country.code);
         const selections = entry?.selections ?? {};
-        const allowedByCountry = resolveAllowedModesForCountry(country.code);
-        normalized[country.code] = matrixConfig.columns.map((col) => {
-          return allowedByCountry.has(col.id as RouteMode) ? Boolean(selections[col.id]) : false;
+        const availableColumns = resolveAvailableColumnSetForCountry(country.code);
+        const nextRowByColumn: Record<RouteSelectionColumnId, boolean> = {} as Record<RouteSelectionColumnId, boolean>;
+        ROUTE_SELECTION_COLUMNS.forEach((column) => {
+          if (!availableColumns.has(column.id)) {
+            nextRowByColumn[column.id] = false;
+            return;
+          }
+          nextRowByColumn[column.id] = Boolean(selections[column.id]);
         });
+        normalized[country.code] = toSelectionArray(enforceOrAndRule(nextRowByColumn));
       });
       if (selectionSignature(selectionRecordSource) !== selectionSignature(normalized)) {
         emitUpdate({ selectedArrayByCountries: normalized });
       }
     },
-    [emitUpdate, iso.countries, iso.status, matrixConfig.columns, resolveAllowedModesForCountry, selectionRecordSource, selectionSignature],
+    [emitUpdate, iso.countries, iso.status, resolveAvailableColumnSetForCountry, selectionRecordSource, selectionSignature],
   );
+
+  const isCellEnabledForCountry = useCallback((countryCode: string, columnId: string) => {
+    const parsed = parseRouteSelectionColumnId(columnId);
+    if (!parsed) return false;
+    const availableColumns = resolveAvailableColumnSetForCountry(countryCode);
+    if (!availableColumns.has(columnId as RouteSelectionColumnId)) return false;
+    if (parsed.condition === 'and') {
+      const row = toSelectionArrayByColumn(selectionByCountries[countryCode]);
+      const orId = buildRouteSelectionColumnId('or', parsed.mode);
+      if (row[orId]) return false;
+    }
+    return true;
+  }, [resolveAvailableColumnSetForCountry, selectionByCountries]);
 
   useEffect(() => {
     const isValid =
@@ -377,7 +500,7 @@ export const useRouteSelectionStep = ({
     matrixConfig,
     currentSelections,
     applySelections,
-    resolveAllowedModesForCountry,
+    isCellEnabledForCountry,
     policy,
   };
 };

--- a/plugins/route-plugin/src/ui/locales/en.json
+++ b/plugins/route-plugin/src/ui/locales/en.json
@@ -47,6 +47,8 @@
     "emptyCountries": "No countries available. Please try again later.",
     "defaultSelectionNote": "Default selections are applied based on the data source.",
     "customSelectionNote": "Choose the Route Selection to fetch for each country.",
+    "conditionOr": "OR",
+    "conditionAnd": "AND",
     "transportModeLabel": "Transport mode",
     "transportModeHelperText": "Choose the primary transport mode for this route.",
     "routeTypeLabel": "Route type",
@@ -215,6 +217,12 @@
         "errorCount": "Errors",
         "errorMessage": "Error Message"
       }
+    },
+    "metadataSync": {
+      "checkButton": "Check sync status",
+      "checking": "Checking...",
+      "synced": "✅ Synced",
+      "stale": "⚠️ Rebuild required"
     }
   },
   "batch": {

--- a/plugins/route-plugin/src/ui/locales/ja.json
+++ b/plugins/route-plugin/src/ui/locales/ja.json
@@ -47,6 +47,8 @@
     "emptyCountries": "利用可能な国がありません。時間をおいて再試行してください。",
     "defaultSelectionNote": "データソースに応じた既定の選択が適用されています。",
     "customSelectionNote": "国ごとに読み込む交通経路を選択してください。",
+    "conditionOr": "OR条件",
+    "conditionAnd": "AND条件",
     "transportModeLabel": "交通モード",
     "transportModeHelperText": "このルートの主な交通モードを選択してください。",
     "routeTypeLabel": "経路タイプ",
@@ -214,6 +216,12 @@
         "errorCount": "エラー数",
         "errorMessage": "エラーメッセージ"
       }
+    },
+    "metadataSync": {
+      "checkButton": "同期状態を確認",
+      "checking": "確認中...",
+      "synced": "✅同期済み",
+      "stale": "⚠️更新が必要"
     }
   },
   "batch": {


### PR DESCRIPTION
## Summary
- implement route build-flow behavior coupled with location definitions (Step3-6), including explicit non-late-binding semantics
- add Step3 country x mode OR/AND matrix selection model and pass selection entries into route import/build execution
- add stale metadata sync check API/UI in Route preview with manual check action and aggregated synced/stale counts
- add location->route cascading behavior for referenced row delete/update, including fetch cache invalidation and route-node-level rebuild reservation
- document finalized specification in `docs/route-build-flow-spec.md` and sync route plugin README section

## Key implementation points
- `route-api`: extended IDE-GSM request/coverage/metadata sync types and query API (`checkRouteMetadataSync`)
- `runtime-worker`: implemented route metadata sync checker and location mutation cascading logic
- `route-plugin`: updated selection step matrix logic, build session lifecycle payload, preview sync toolbar, i18n texts
- `ui-map`: added preview toolbar action slot for route metadata sync controls
- `gis-sdk`: introduced `rebuild-reserved` ephemeral status; normalized in shape query path to preserve shape API contract

## Verification
- `pnpm build -F @hierarchidb/runtime-worker`
- `pnpm -w turbo run typecheck --filter @hierarchidb/runtime-worker`
- `pnpm -w turbo run typecheck --filter @hierarchidb/route-api --filter @hierarchidb/route-store --filter @hierarchidb/ui-map --filter @hierarchidb/location-plugin --filter @hierarchidb/route-plugin`
- `pnpm -w turbo run test --filter @hierarchidb/runtime-worker`
- `pnpm -w turbo run test --filter @hierarchidb/route-plugin`
