### PR TITLE
Fix(shape): add build progress diagnostics for task execution

### DIFF
--- a/packages/batch/src/progress/useBatchProgress.ts
+++ b/packages/batch/src/progress/useBatchProgress.ts
@@ -6,6 +6,36 @@ type Unsubscribe = () => void;
 type SubscribeResult = Unsubscribe | Promise<Unsubscribe>;
 
 type Adapter = BuildProgressAdapter | null;
+type ImportMetaEnv = Partial<Record<'DEV', boolean>>;
+type ImportMetaWithEnv = { env?: ImportMetaEnv };
+
+const isDev = typeof import.meta !== 'undefined'
+  ? ((import.meta as ImportMetaWithEnv).env?.DEV === true)
+  : false;
+type ProgressDebugConfig = Partial<Record<'event' | 'skip' | 'all', boolean>>;
+
+const readProgressDebugConfig = (): ProgressDebugConfig | null => {
+  const scope = globalThis as typeof globalThis & {
+    __HDB_BATCH_PROGRESS_DEBUG__?: unknown;
+  };
+  const raw = scope.__HDB_BATCH_PROGRESS_DEBUG__;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  return raw as ProgressDebugConfig;
+};
+
+const isProgressDebugEnabled = (channel: 'event' | 'skip'): boolean => {
+  if (!isDev) return false;
+  const config = readProgressDebugConfig();
+  if (!config) return false;
+  return config.all === true || config[channel] === true;
+};
+
+const logProgressEvent = (event: string, payload: Record<string, unknown>): void => {
+  if (!isDev) return;
+  console.debug('[BatchProgressTrace]', event, payload);
+};
 
 const resolveSkippedCount = (info: BuildUnifiedProgressInfo): number => {
   const payload = info.payload as Record<string, unknown> | undefined;
@@ -14,7 +44,9 @@ const resolveSkippedCount = (info: BuildUnifiedProgressInfo): number => {
 };
 
 const asRecord = (value: unknown): Record<string, unknown> | null => (
-  value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
 );
 
 const readString = (meta: Record<string, unknown> | null, key: string): string | undefined => {
@@ -33,10 +65,14 @@ const readPayloadMeta = (info: BuildUnifiedProgressInfo | null): Record<string, 
   return asRecord(payload.meta);
 };
 
+const readTaskPayloadMeta = (meta: Record<string, unknown> | null): Record<string, unknown> | null => (
+  asRecord(meta?.progressTask)
+);
+
 const buildProgressTaskSignature = (info: BuildUnifiedProgressInfo | null): string | undefined => {
-  const meta = readPayloadMeta(info);
-  if (!meta) return undefined;
-  const progressTask = asRecord(meta.progressTask);
+  const payloadMeta = readPayloadMeta(info);
+  if (!payloadMeta) return undefined;
+  const progressTask = readTaskPayloadMeta(payloadMeta);
   if (!progressTask) return undefined;
   const progress = readNumber(progressTask, 'progress');
   return [
@@ -50,9 +86,9 @@ const buildProgressTaskSignature = (info: BuildUnifiedProgressInfo | null): stri
 };
 
 const buildStageTotalsSignature = (info: BuildUnifiedProgressInfo | null): string | undefined => {
-  const meta = readPayloadMeta(info);
-  if (!meta) return undefined;
-  const stageTotals = asRecord(meta.stageTotals);
+  const payloadMeta = readPayloadMeta(info);
+  if (!payloadMeta) return undefined;
+  const stageTotals = asRecord(payloadMeta.stageTotals);
   if (!stageTotals) return undefined;
   const stages = ['fetch', 'transform', 'vt'] as const;
   return stages
@@ -95,11 +131,22 @@ export function useBatchProgress(
     const next = pendingRef.current;
     pendingRef.current = null;
     if (next) {
+      const hasMeta = !!readPayloadMeta(next);
       const prev = lastProgressRef.current;
       if (next.phase === 'completed') {
         const skipped = resolveSkippedCount(next);
         const done = next.completed + next.failed + skipped;
         if (next.total > 0 && done < next.total) {
+          logProgressEvent('drop-complete-incomplete', {
+            nodeId: next.nodeId,
+            stage: next.stage,
+            phase: next.phase,
+            total: next.total,
+            completed: next.completed,
+            failed: next.failed,
+            skipped,
+            hasMeta,
+          });
           return;
         }
       }
@@ -120,7 +167,35 @@ export function useBatchProgress(
         && lastSignaturesRef.current.progressTask === progressTaskSignature
         && lastSignaturesRef.current.stageTotals === stageTotalsSignature
       );
-      if (isSame) return;
+      if (isSame) {
+        if (isProgressDebugEnabled('skip')) {
+          logProgressEvent('skip-unchanged', {
+            nodeId: next.nodeId,
+            stage: next.stage,
+            phase: next.phase,
+            percentage: normalized.percentage,
+            progressTaskSignature,
+            stageTotalsSignature,
+            hasMeta,
+          });
+        }
+        return;
+      }
+      if (isProgressDebugEnabled('event')) {
+        logProgressEvent('apply', {
+          nodeId: next.nodeId,
+          stage: next.stage,
+          phase: next.phase,
+          percentage: normalized.percentage,
+          total: normalized.total,
+          completed: normalized.completed,
+          failed: normalized.failed,
+          skipped: resolveSkippedCount(normalized),
+          progressTaskSignature,
+          stageTotalsSignature,
+          hasMeta,
+        });
+      }
       lastProgressRef.current = normalized;
       lastSignaturesRef.current = {
         progressTask: progressTaskSignature,
@@ -136,6 +211,22 @@ export function useBatchProgress(
     const subscriptionToken = subscriptionTokenRef.current + 1;
     subscriptionTokenRef.current = subscriptionToken;
     const result: SubscribeResult = currentAdapter.subscribe((info: BuildUnifiedProgressInfo) => {
+      if (isProgressDebugEnabled('event')) {
+        const payloadMeta = readPayloadMeta(info);
+        logProgressEvent('received', {
+          nodeId: info.nodeId,
+          stage: info.stage,
+          phase: info.phase,
+          percentage: info.percentage,
+          total: info.total,
+          completed: info.completed,
+          failed: info.failed,
+          skipped: resolveSkippedCount(info),
+          hasPayloadMeta: Boolean(payloadMeta),
+          hasProgressTaskMeta: Boolean(payloadMeta && asRecord(payloadMeta.progressTask)),
+          hasStageTotalsMeta: Boolean(payloadMeta && asRecord(payloadMeta.stageTotals)),
+        });
+      }
       pendingRef.current = info;
       if (flushFrameRef.current !== null) return;
       flushFrameRef.current = window.requestAnimationFrame(update);

--- a/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressMapping.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressMapping.ts
@@ -61,7 +61,9 @@ type StageTotalsMeta = Partial<Record<'fetch' | 'transform' | 'vt', {
 }>>;
 
 const asRecord = (value: unknown): Record<string, unknown> | null => (
-  value && typeof value === 'object' ? value as Record<string, unknown> : null
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
 );
 
 const readNumber = (value: unknown): number | undefined => (
@@ -83,8 +85,12 @@ const readTaskDisplay = (value: unknown): TaskDisplayPayload | undefined => {
   return display as TaskDisplayPayload;
 };
 
+const readPayloadMeta = (info: ExtendedProgress): Record<string, unknown> | null => {
+  return asRecord(info.payload?.meta);
+};
+
 const readProgressTaskMeta = (info: ExtendedProgress): ProgressTaskMeta | null => {
-  const meta = asRecord(info.payload?.meta);
+  const meta = readPayloadMeta(info);
   if (!meta) return null;
   const progressTask = asRecord(meta.progressTask);
   if (!progressTask) return null;
@@ -92,7 +98,7 @@ const readProgressTaskMeta = (info: ExtendedProgress): ProgressTaskMeta | null =
 };
 
 const readStageTotalsMeta = (info: ExtendedProgress): StageTotalsMeta | undefined => {
-  const meta = asRecord(info.payload?.meta);
+  const meta = readPayloadMeta(info);
   if (!meta) return undefined;
   const stageTotals = asRecord(meta.stageTotals);
   if (!stageTotals) return undefined;

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgress.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgress.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import type { NodeType } from '@hierarchidb/core-types';
 import type { BuildUnifiedProgressInfo } from '@hierarchidb/batch-api';
 import { usePluginBatchProgress } from '@hierarchidb/ui-batch-progress';
@@ -21,6 +22,46 @@ export interface UseBuildProgressOptions {
   autoSubscribe?: boolean;
 }
 
+const isDev = import.meta.env.DEV;
+type BuildProgressDebugConfig = Partial<Record<'mapping' | 'all', boolean>>;
+
+const readBuildProgressDebugConfig = (): BuildProgressDebugConfig | null => {
+  const scope = globalThis as typeof globalThis & {
+    __HDB_SHAPE_BUILD_PROGRESS_DEBUG__?: unknown;
+  };
+  const raw = scope.__HDB_SHAPE_BUILD_PROGRESS_DEBUG__;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  return raw as BuildProgressDebugConfig;
+};
+
+const isBuildProgressDebugEnabled = (): boolean => {
+  if (!isDev) return false;
+  const config = readBuildProgressDebugConfig();
+  if (!config) return false;
+  return config.all === true || config.mapping === true;
+};
+
+const logProgressMapping = (nodeId: string | null, payload: {
+  unifiedExists: boolean;
+  mappedExists: boolean;
+  progressTaskId?: string | null;
+  progressTaskStatus?: string | null;
+  stageTotals?: string;
+}): void => {
+  if (!isDev) return;
+  const hasStageTotals = payload.stageTotals !== undefined;
+  console.debug('[ShapeBuildProgressMappingTrace]', {
+    nodeId,
+    unifiedExists: payload.unifiedExists,
+    mappedExists: payload.mappedExists,
+    progressTaskId: payload.progressTaskId ?? null,
+    progressTaskStatus: payload.progressTaskStatus ?? null,
+    stageTotals: hasStageTotals ? payload.stageTotals : null,
+  });
+};
+
 const SHAPE_NODE_TYPE = 'shape' as NodeType;
 
 export function useBuildProgress(
@@ -33,6 +74,7 @@ export function useBuildProgress(
   const {
     progress,
     status: derivedStatus,
+    unifiedProgress,
     error,
     subscribe,
     unsubscribe,
@@ -45,6 +87,31 @@ export function useBuildProgress(
       mapUnifiedToStatus: (info: BuildUnifiedProgressInfo | null) => toShapeStatus(info as ExtendedProgress | null),
     },
   );
+
+  const previousSignature = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isBuildProgressDebugEnabled()) return;
+    const mappedExists = progress !== null;
+    const unifiedExists = unifiedProgress !== null;
+    const stageTotals = mappedExists
+      ? JSON.stringify(progress?.stageTotals)
+      : undefined;
+    const signature = JSON.stringify({
+      progress,
+      derivedStatus,
+      error: error?.message ?? null,
+    });
+    if (signature === previousSignature.current) return;
+    previousSignature.current = signature;
+    logProgressMapping(nodeId, {
+      unifiedExists,
+      mappedExists,
+      progressTaskId: progress?.progressTaskId ?? null,
+      progressTaskStatus: progress?.progressTaskStatus ?? null,
+      stageTotals,
+    });
+  }, [derivedStatus, error, nodeId, progress]);
+
   return {
     progress,
     status: derivedStatus,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts
@@ -48,6 +48,46 @@ import { shapeMutationAPIImpl, shapeQueryAPIImpl } from '../../../services/batch
 
 const SHAPE_NODE_TYPE = 'shape' as NodeType;
 const PAUSE_COMMAND_TIMEOUT_MS = 60_000;
+const isDev = import.meta.env.DEV;
+type ShapeProgressStepDebugConfig = Partial<Record<'progress' | 'all', boolean>>;
+type ShapeProgressStepTracePayload = {
+  nodeId: string | null;
+  phase: BuildStatus;
+  progressTaskId: string | null;
+  progressTaskStatus: string | null;
+  progressTaskStage: string | null;
+  progressTaskProgress: number | null;
+  percentage: number | null;
+  total: number;
+  completed: number;
+  failed: number;
+  skipped: number;
+  message: string | null;
+};
+
+const readShapeProgressStepDebugConfig = (): ShapeProgressStepDebugConfig | null => {
+  const scope = globalThis as typeof globalThis & {
+    __HDB_SHAPE_PROGRESS_STEP_DEBUG__?: unknown;
+  };
+  const raw = scope.__HDB_SHAPE_PROGRESS_STEP_DEBUG__;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  return raw as ShapeProgressStepDebugConfig;
+};
+
+const isShapeProgressStepDebugEnabled = (): boolean => {
+  if (!isDev) return false;
+  const config = readShapeProgressStepDebugConfig();
+  if (!config) return false;
+  return config.all === true || config.progress === true;
+};
+
+const emitShapeProgressStepTrace = (payload: ShapeProgressStepTracePayload): void => {
+  if (!isDev) return;
+  console.debug('[ShapeBuildProgressStepTrace]', payload);
+};
+
 type StageLikeTask = {
   taskType?: TaskStage;
   type?: TaskStage;
@@ -576,6 +616,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
   const remoteFresh = Boolean(remoteUpdatedAt && Date.now() - remoteUpdatedAt <= coordinator.quietThresholdTimeout);
   const effectiveProgress = hasNodeId ? (progress ?? (remoteFresh ? remoteProgress : null)) : null;
   const effectiveStatus = hasNodeId ? (status ?? (remoteFresh ? remoteStatus : null)) : null;
+  const effectiveProgressTraceRef = useRef<string | null>(null);
   const stages = useShapeBuildStages(t);
   const persistedProcessingStatus = sessionRecord ? toProcessingStatus(sessionRecord.status) : null;
   const processingStatus = persistedProcessingStatus ?? 'idle';
@@ -665,6 +706,27 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     }
     return baseBuildStatus;
   }, [baseBuildStatus, hasInFlightTasks, tasksCompletionStatus]);
+  useEffect(() => {
+    if (!isShapeProgressStepDebugEnabled()) return;
+    const nextTrace: ShapeProgressStepTracePayload = {
+      nodeId: activeNodeId,
+      phase: buildStatus,
+      progressTaskId: effectiveProgress?.progressTaskId ?? null,
+      progressTaskStatus: effectiveProgress?.progressTaskStatus ?? null,
+      progressTaskStage: effectiveProgress?.progressTaskStage ?? null,
+      progressTaskProgress: effectiveProgress?.progressTaskProgress ?? null,
+      percentage: effectiveProgress?.percentage ?? null,
+      total: effectiveProgress?.total ?? 0,
+      completed: effectiveProgress?.completed ?? 0,
+      failed: effectiveProgress?.failed ?? 0,
+      skipped: effectiveProgress?.skipped ?? 0,
+      message: effectiveProgress?.message ?? null,
+    };
+    const signature = JSON.stringify(nextTrace);
+    if (signature === effectiveProgressTraceRef.current) return;
+    effectiveProgressTraceRef.current = signature;
+    emitShapeProgressStepTrace(nextTrace);
+  }, [activeNodeId, buildStatus, effectiveProgress]);
 
   const selectedArrayByCountries = data?.selectedArrayByCountries;
 


### PR DESCRIPTION
## Summary
- Add defensive guards for progress payload metadata parsing to avoid non-object payload regressions.
- Add per-stage progress trace hooks for batch hook and shape mapping to investigate missing progress updates.
- Preserve existing progress behavior while surfacing worker->UI mapping diagnostics.

## Why
Shape build step 5 was logging worker-side task dispatch but UI showed no progress updates. This change adds observable diagnostics and avoids silent metadata-shape issues in progress handling.

## Validation
- pnpm -w turbo run typecheck --filter @hierarchidb/batch (pass)
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin (pass)
- pnpm -w turbo run lint --filter @hierarchidb/shape-plugin --filter @hierarchidb/batch (no tasks to run in this scope)
