### PR TITLE
fix(shape-plugin): normalize build session status

### DIFF
--- a/plugins/shape-plugin/src/services/batch/ShapeBuildAPIClient.ts
+++ b/plugins/shape-plugin/src/services/batch/ShapeBuildAPIClient.ts
@@ -124,6 +124,20 @@ const readResourceUsage = (value: unknown): ResourceUsage | undefined => {
   };
 };
 
+const normalizeBuildSessionStatus = (status: string | undefined): BuildSessionRecord['status'] => {
+  if (status === 'idle'
+    || status === 'running'
+    || status === 'paused'
+    || status === 'completed'
+    || status === 'failed') {
+    return status;
+  }
+  if (status === 'queued' || status === 'regression' || status === 'warning' || status === 'rebuild-reserved') {
+    return 'running';
+  }
+  return 'idle';
+};
+
 const toBuildSessionRecordFromEphemeral = (
   session: EphemeralBuildSessionRecord
 ): BuildSessionRecord | null => {
@@ -134,7 +148,7 @@ const toBuildSessionRecordFromEphemeral = (
   return {
     nodeId: session.nodeId,
     draftId: session.draftId,
-    status: session.status,
+    status: normalizeBuildSessionStatus(session.status),
     selectedArrayByCountries: isSelectedArrayByCountries(session.selectedArrayByCountries)
       ? session.selectedArrayByCountries
       : undefined,


### PR DESCRIPTION
## What
- Fix TypeScript error in ShapeBuildAPIClient where ephemeral session status can be 'rebuild-reserved', which is not assignable to BuildSessionRecord['status'].
- Introduced status normalization before mapping ephemeral session records.
- Keeps persisted session status compatibility by mapping transient states to 'running'.

## How to verify
- Run: pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin
- Result: success (98/98 packages, typecheck pass)
