### PR TITLE
refactor(shape-ui): task item card list

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #279 / `codex/refactor/ui/shape-task-item-card-list` / start: 2026-02-15 06:43 JST
 - #276 / `codex/fix/shape/step5-resume-task-list` / start: 2026-02-14 22:13 JST
 - #275 / `codex/fix/shape/step5-task-history-icons` / start: 2026-02-14 21:44 JST
 - #262 / `codex/docs/route/build-flow-location-coupling-2` / start: 2026-02-14 14:33 JST

--- a/app/src/contexts/__tests__/shape-workerprovider.full-flow.test.tsx
+++ b/app/src/contexts/__tests__/shape-workerprovider.full-flow.test.tsx
@@ -129,8 +129,7 @@ vi.mock('~/worker-runtime/client.ts', async () => {
             status === 'queued' ||
             status === 'completed' ||
             status === 'failed' ||
-            status === 'paused' ||
-            status === 'regression'
+            status === 'paused'
           ? status
           : 'queued';
     return {

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
@@ -3,14 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { Provider } from 'jotai';
 import { createStore } from 'jotai/vanilla';
 import type { ShapeBuildTaskSummary } from '../../../atoms/shapeBuildProgressAtoms.js';
-import { TaskListVirtualized } from '../../../components/build-progress/TaskListVirtualized.tsx';
+import { TaskItemCardListCard } from '../../../components/build-progress/TaskItemCardListCard.tsx';
 
 vi.mock('../../../i18n.js', () => ({
   useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
 }));
 
-describe('TaskListVirtualized', () => {
-  it('renders recycled and new task icons', () => {
+describe('TaskItemCardListCard', () => {
+  it('renders recycled and stage task icons', () => {
     const tasks: ShapeBuildTaskSummary[] = [
       {
         taskId: 'task-1',
@@ -33,7 +33,7 @@ describe('TaskListVirtualized', () => {
 
     render(
       <Provider store={store}>
-        <TaskListVirtualized
+        <TaskItemCardListCard
           stageId="fetch"
           tasks={tasks}
           stageValue={0}
@@ -46,6 +46,6 @@ describe('TaskListVirtualized', () => {
     );
 
     expect(screen.getAllByTestId('task-icon-recycling')).toHaveLength(1);
-    expect(screen.getAllByTestId('task-icon-add')).toHaveLength(1);
+    expect(screen.getAllByTestId('task-icon-stage-fetch')).toHaveLength(1);
   });
 });

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel.tsx
@@ -27,8 +27,8 @@ import { BuildSessionProgressPanel, useBuildStageFilter } from '@hierarchidb/com
 import { BuildSessionLauncherPanel } from '@hierarchidb/ui-batch-progress';
 import { DownloadRetryControls, type DownloadRetryConfig, WorkerNumberConfigCard } from '@hierarchidb/ui-accordion-config';
 import { useAtomValue, useSetAtom } from 'jotai';
-import type { TaskWithMetadata } from './TaskListVirtualized.tsx';
-import { TaskListVirtualized, sortTransformTasks, sortVectorTileTasks } from './TaskListVirtualized.tsx';
+import type { TaskItemWithMetadata } from './TaskItemCardListCard.tsx';
+import { TaskItemCardListCard, sortTransformTasks, sortVectorTileTasks } from './TaskItemCardListCard.tsx';
 import type { ShapeEntity } from '../../../common/types/ShapeEntity.ts';
 import type { ShapeProcessingConfig } from '../../../common/types/index.js';
 import {
@@ -53,11 +53,11 @@ const TaskProgressBar = ({
   resolveTaskTitle,
 }: {
   stages: BuildStage[];
-  tasksByStage: Record<string, TaskWithMetadata[]>;
+  tasksByStage: Record<string, TaskItemWithMetadata[]>;
   stageTotals?: TaskProgressSummary['stageTotals'];
   buildStatus: TaskProgressSummary['buildStatus'];
   activeStageId?: string | null;
-  resolveTaskTitle: (task: TaskWithMetadata) => string;
+  resolveTaskTitle: (task: TaskItemWithMetadata) => string;
 }) => {
   const theme = useTheme();
   const filter = useBuildStageFilter();
@@ -429,13 +429,13 @@ const BuildProgressStageContent = ({
   showHeader?: boolean;
   stage: BuildStage;
   stageValue: number;
-  tasksByStage: Record<string, TaskWithMetadata[]>;
+  tasksByStage: Record<string, TaskItemWithMetadata[]>;
   paneProgress?: Array<{ paneId?: string; progress?: number; taskCount?: number; completedCount?: number; status?: string }>;
   isTaskSummaryLoading: boolean;
   isTasksLoading: boolean;
   resolveStatusLabel: (statusValue?: string, skipped?: boolean) => string;
   resolveStatusColor: (statusValue?: string, skipped?: boolean) => 'default' | 'success' | 'error' | 'warning' | 'info';
-  resolveTaskTitle: (task: TaskWithMetadata) => string;
+  resolveTaskTitle: (task: TaskItemWithMetadata) => string;
   t: (key: string, fallback: string) => string;
 }) => {
   const filter = useBuildStageFilter();
@@ -626,7 +626,7 @@ const BuildProgressStageContent = ({
           }}
           ref={listWrapperRef}
         >
-          <TaskListVirtualized
+          <TaskItemCardListCard
             ref={listScrollRef}
             stageId={stage.id}
             tasks={displayTasks}
@@ -815,7 +815,7 @@ export const ShapeBuildProgressPanel = ({
 
   const tasksByStageForDisplay = useMemo(() => {
     if (!isResetSessionLoading) return tasksByStage;
-    return stages.reduce<Record<string, TaskWithMetadata[]>>((acc, stage) => {
+    return stages.reduce<Record<string, TaskItemWithMetadata[]>>((acc, stage) => {
       acc[stage.id] = [];
       return acc;
     }, {});

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard.tsx
@@ -1,0 +1,88 @@
+import { type ReactElement, type ReactNode, cloneElement, isValidElement } from 'react';
+import { Box } from '@mui/material';
+import RecyclingIcon from '@mui/icons-material/Recycling';
+import type { ShapeBuildTaskSummary } from '../../atoms/shapeBuildProgressAtoms.js';
+import { isTaskPhaseMessage, isTaskSkipped } from '../../../common/utils/taskMessages.ts';
+import { formatGeometrySimplifySummary, parseGeometrySimplifyError } from './geometrySimplifyError.ts';
+import { formatTaskDisplayMessage } from './taskDisplayText.ts';
+import { TaskItem } from './TaskItem.tsx';
+import type { TaskItemWithMetadata } from './useTaskItemCardList.ts';
+
+type Translate = (key: string, fallback?: string) => string;
+
+type TaskItemCardProps = {
+  task: ShapeBuildTaskSummary;
+  stageId: string;
+  stageValue: number;
+  resolveStatusLabel: (statusValue?: string, skipped?: boolean) => string;
+  resolveStatusColor: (statusValue?: string, skipped?: boolean) => 'default' | 'success' | 'error' | 'warning' | 'info';
+  resolveTaskTitle: (task: TaskItemWithMetadata) => string;
+  stageIcon?: ReactNode | null;
+  translate: Translate;
+};
+
+const withIconSize = (icon: ReactElement): ReactElement => {
+  const existingSx = icon.props?.sx ?? {};
+  return cloneElement(icon, { sx: { ...existingSx, fontSize: 16 } });
+};
+
+export const TaskItemCard = ({
+  task,
+  stageId,
+  stageValue,
+  resolveStatusLabel,
+  resolveStatusColor,
+  resolveTaskTitle,
+  stageIcon,
+  translate,
+}: TaskItemCardProps) => {
+  const statusValue = task.status;
+  const isSkipped = isTaskSkipped(task.display, task.message);
+  const displayProgress = Math.min(100, Math.max(0, task.progress ?? stageValue));
+  const statusLabelValue = resolveStatusLabel(statusValue, isSkipped);
+  const statusColor = resolveStatusColor(statusValue, isSkipped);
+  const taskTitle = resolveTaskTitle(task as TaskItemWithMetadata);
+  const displayMessage = formatTaskDisplayMessage(task.display, translate);
+  const errorMessage = typeof task.errorMessage === 'string' ? task.errorMessage.trim() : '';
+  const fallbackError = typeof task.error === 'string' ? task.error.trim() : '';
+  const failedMessage = errorMessage || fallbackError;
+  const geometryDetails = parseGeometrySimplifyError(task.message);
+  const baseMessage = task.message?.split(' (')[0];
+  const failedTaskMessage = task.status === 'failed'
+    && failedMessage
+    && (!task.message || isTaskPhaseMessage(task.message))
+    ? failedMessage
+    : null;
+  const taskMessage = displayMessage
+    ?? failedTaskMessage
+    ?? (task.message && task.message !== taskTitle
+      ? (geometryDetails ? baseMessage : task.message)
+      : undefined);
+  const detailLines = displayMessage ? undefined : (geometryDetails ? formatGeometrySimplifySummary(geometryDetails) : undefined);
+  let leadingIcon: ReactNode = null;
+  if (task.status === 'recycled') {
+    leadingIcon = (
+      <RecyclingIcon data-testid="task-icon-recycling" sx={{ fontSize: 16, color: 'text.secondary' }} />
+    );
+  } else if (stageIcon) {
+    const stageIconElement = isValidElement(stageIcon) ? withIconSize(stageIcon) : stageIcon;
+    leadingIcon = (
+      <Box data-testid={`task-icon-stage-${stageId}`} sx={{ display: 'flex', alignItems: 'center' }}>
+        {stageIconElement}
+      </Box>
+    );
+  }
+
+  return (
+    <TaskItem
+      title={taskTitle}
+      leadingIcon={leadingIcon}
+      statusLabel={statusLabelValue}
+      statusColor={statusColor}
+      message={taskMessage}
+      detailLines={detailLines}
+      progress={displayProgress}
+      fallbackProgress={stageValue}
+    />
+  );
+};

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard.tsx
@@ -1,0 +1,115 @@
+import { type CSSProperties, type ReactNode, forwardRef, useCallback, useMemo } from 'react';
+import { Box } from '@mui/material';
+import type { ShapeBuildTaskSummary } from '../../atoms/shapeBuildProgressAtoms.js';
+import { useTranslation } from '../../i18n.js';
+import { useShapeBuildStages } from './useShapeBuildStages.ts';
+import { TaskItemCard } from './TaskItemCard.tsx';
+import {
+  useTaskItemCardList,
+  sortTransformTasks,
+  sortVectorTileTasks,
+  type TaskItemWithMetadata,
+} from './useTaskItemCardList.ts';
+
+type TaskItemCardListCardProps = {
+  stageId: string;
+  tasks: ShapeBuildTaskSummary[];
+  stageValue: number;
+  resolveStatusLabel: (statusValue?: string, skipped?: boolean) => string;
+  resolveStatusColor: (statusValue?: string, skipped?: boolean) => 'default' | 'success' | 'error' | 'warning' | 'info';
+  resolveTaskTitle: (task: TaskItemWithMetadata) => string;
+  scrollToTaskId?: string;
+  scrollRequestId?: number;
+  virtualize?: boolean;
+};
+
+export const TaskItemCardListCard = forwardRef<HTMLDivElement, TaskItemCardListCardProps>(({
+  stageId,
+  tasks,
+  stageValue,
+  resolveStatusLabel,
+  resolveStatusColor,
+  resolveTaskTitle,
+  scrollToTaskId,
+  scrollRequestId,
+  virtualize = true,
+}: TaskItemCardListCardProps, ref) => {
+  const { t } = useTranslation();
+  const stages = useShapeBuildStages(t);
+  const stageIconById = useMemo(() => {
+    return new Map(stages.map((stage) => [stage.id, stage.icon]));
+  }, [stages]);
+  const resolveStageIcon = useCallback((taskStageId: string): ReactNode | null => (
+    stageIconById.get(taskStageId) ?? null
+  ), [stageIconById]);
+  const {
+    orderedTasks,
+    shouldVirtualize,
+    setRefs,
+    virtualizer,
+  } = useTaskItemCardList({
+    stageId,
+    tasks,
+    scrollToTaskId,
+    scrollRequestId,
+    virtualize,
+    ref,
+  });
+  const renderTaskItemCard = useCallback((task: ShapeBuildTaskSummary, key: string, style?: CSSProperties) => {
+    const taskStageId = task.stage ?? stageId;
+    const stageIcon = resolveStageIcon(taskStageId);
+    return (
+      <Box key={key} sx={style} data-task-id={task.taskId ?? undefined}>
+        <TaskItemCard
+          task={task}
+          stageId={taskStageId}
+          stageValue={stageValue}
+          resolveStatusLabel={resolveStatusLabel}
+          resolveStatusColor={resolveStatusColor}
+          resolveTaskTitle={resolveTaskTitle}
+          stageIcon={stageIcon}
+          translate={t}
+        />
+      </Box>
+    );
+  }, [resolveStageIcon, resolveStatusColor, resolveStatusLabel, resolveTaskTitle, stageId, stageValue, t]);
+
+  return (
+    <Box
+      ref={setRefs}
+      onWheel={(event) => event.stopPropagation()}
+      sx={{ flex: 1, minHeight: 0, height: '100%', overflow: 'auto' }}
+    >
+      {shouldVirtualize ? (
+        <Box sx={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const task = orderedTasks[virtualRow.index];
+            if (!task) return null;
+            const taskTitle = resolveTaskTitle(task as TaskItemWithMetadata);
+            const key = task.taskId ?? `${virtualRow.index}-${taskTitle}`;
+            return renderTaskItemCard(task, key, {
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${virtualRow.start}px)`,
+              paddingRight: 2,
+              height: `${virtualRow.size}px`,
+            });
+          })}
+        </Box>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, pr: 1 }}>
+          {orderedTasks.map((task, index) => {
+            const taskTitle = resolveTaskTitle(task as TaskItemWithMetadata);
+            const key = task.taskId ?? `${index}-${taskTitle}`;
+            return renderTaskItemCard(task, key);
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+});
+
+export { sortTransformTasks, sortVectorTileTasks };
+export type { TaskItemWithMetadata };

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState.ts
@@ -24,7 +24,7 @@ import {
   suspendSuspectOpenAtom,
   suspendSuspectControlsAtom,
 } from '../../atoms/shapeBuildProgressAtoms.js';
-import type { TaskWithMetadata } from './TaskListVirtualized.tsx';
+import type { TaskItemWithMetadata } from './TaskItemCardListCard.tsx';
 import type { ShapeEntity } from '../../../common/types/ShapeEntity.ts';
 import { DEFAULT_PROCESSING_CONFIG, mergeProcessingConfig } from '../../../common/types/index.js';
 import type { ShapeBuildTaskSummary } from '../../atoms/shapeBuildProgressAtoms.ts';
@@ -196,7 +196,7 @@ export const useBuildProgressPanelState = (params: {
   });
 
   const resolveTaskTitle = useCallback(
-    (task: TaskWithMetadata): string =>
+    (task: TaskItemWithMetadata): string =>
       resolveShapeTaskTitle(task, t('stage.tasks.unknown', '(Title unavailable)')),
     [t],
   );
@@ -222,7 +222,7 @@ export const useBuildProgressPanelState = (params: {
       const failureMessage = resolveFailureMessage(failedTask);
       if (!failureMessage) continue;
       return {
-        title: resolveTaskTitle(failedTask as TaskWithMetadata),
+        title: resolveTaskTitle(failedTask as TaskItemWithMetadata),
         message: failureMessage,
       };
     }

--- a/plugins/shape-plugin/src/ui/components/build-progress/useTaskItemCardList.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useTaskItemCardList.ts
@@ -1,33 +1,30 @@
-import { type CSSProperties, type MutableRefObject, forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
-import { Box } from '@mui/material';
-import AddBoxIcon from '@mui/icons-material/AddBox';
-import RecyclingIcon from '@mui/icons-material/Recycling';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { type ForwardedRef, type MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react';
+import { type Virtualizer, useVirtualizer } from '@tanstack/react-virtual';
 import { useSetAtom } from 'jotai';
 import type { ShapeBuildTaskSummary } from '../../atoms/shapeBuildProgressAtoms.js';
-import { isTaskPhaseMessage, isTaskSkipped } from '../../../common/utils/taskMessages.ts';
 import { taskViewportRangeAtom } from '../../atoms/shapeBuildProgressAtoms.js';
-import { TaskItem, TASK_ITEM_HEIGHT } from './TaskItem.tsx';
-import { formatGeometrySimplifySummary, parseGeometrySimplifyError } from './geometrySimplifyError.ts';
-import { formatTaskDisplayMessage } from './taskDisplayText.ts';
-import { useTranslation } from '../../i18n.js';
+import { TASK_ITEM_HEIGHT } from './TaskItem.tsx';
 
-export type TaskWithMetadata = ShapeBuildTaskSummary & { title?: string };
+export type TaskItemWithMetadata = ShapeBuildTaskSummary & { title?: string };
 
-type TaskListProps = {
+type TaskItemCardListArgs = {
   stageId: string;
   tasks: ShapeBuildTaskSummary[];
-  stageValue: number;
-  resolveStatusLabel: (statusValue?: string, skipped?: boolean) => string;
-  resolveStatusColor: (statusValue?: string, skipped?: boolean) => 'default' | 'success' | 'error' | 'warning' | 'info';
-  resolveTaskTitle: (task: TaskWithMetadata) => string;
   scrollToTaskId?: string;
   scrollRequestId?: number;
   virtualize?: boolean;
+  ref?: ForwardedRef<HTMLDivElement>;
+};
+
+type TaskItemCardListState = {
+  orderedTasks: ShapeBuildTaskSummary[];
+  shouldVirtualize: boolean;
+  setRefs: (node: HTMLDivElement | null) => void;
+  virtualizer: Virtualizer<HTMLDivElement, Element>;
 };
 
 const getVectorTileCoordsFromTitle = (task: ShapeBuildTaskSummary): { z: number; x: number; y: number } | null => {
-  const title = (task as TaskWithMetadata).title;
+  const title = (task as TaskItemWithMetadata).title;
   if (!title) return null;
   const match = title.match(/z\s*(\d+)\s*\/\s*(\d+)\s*\/\s*(\d+)/i);
   if (!match) return null;
@@ -70,18 +67,14 @@ export const sortTransformTasks = (tasks: ShapeBuildTaskSummary[]): ShapeBuildTa
   return sorted;
 };
 
-export const TaskListVirtualized = forwardRef<HTMLDivElement, TaskListProps>(({
+export const useTaskItemCardList = ({
   stageId,
   tasks,
-  stageValue,
-  resolveStatusLabel,
-  resolveStatusColor,
-  resolveTaskTitle,
   scrollToTaskId,
   scrollRequestId,
   virtualize = true,
-}: TaskListProps, ref) => {
-  const { t } = useTranslation();
+  ref,
+}: TaskItemCardListArgs): TaskItemCardListState => {
   const shouldVirtualize = virtualize;
   const parentRef = useRef<HTMLDivElement | null>(null);
   const setRefs = useCallback((node: HTMLDivElement | null) => {
@@ -103,17 +96,18 @@ export const TaskListVirtualized = forwardRef<HTMLDivElement, TaskListProps>(({
     endTaskId: string;
     total: number;
   } | null>(null);
-  const virtualizer = useVirtualizer({
-    count: tasks.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => TASK_ITEM_HEIGHT,
-    overscan: 8,
-  });
   const orderedTasks = useMemo(() => {
     if (stageId === 'vt') return sortVectorTileTasks(tasks);
     if (stageId === 'transform') return sortTransformTasks(tasks);
     return tasks;
   }, [stageId, tasks]);
+  const virtualizer = useVirtualizer<HTMLDivElement, Element>({
+    count: orderedTasks.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => TASK_ITEM_HEIGHT,
+    overscan: 8,
+  });
+
   useEffect(() => {
     if (!shouldVirtualize) return;
     if (!scrollToTaskId || scrollRequestId == null) return;
@@ -129,7 +123,7 @@ export const TaskListVirtualized = forwardRef<HTMLDivElement, TaskListProps>(({
     const scrollEl = parentRef.current;
     if (!scrollEl) return;
     const updateViewport = () => {
-      if (tasks.length === 0) {
+      if (orderedTasks.length === 0) {
         setViewportRange((prev) => (prev && prev.stageId === stageId ? null : prev));
         lastViewportRef.current = null;
         return;
@@ -180,11 +174,11 @@ export const TaskListVirtualized = forwardRef<HTMLDivElement, TaskListProps>(({
     return () => {
       scrollEl.removeEventListener('scroll', handleScroll);
     };
-  }, [setViewportRange, shouldVirtualize, stageId, orderedTasks, tasks.length]);
+  }, [setViewportRange, shouldVirtualize, stageId, orderedTasks]);
 
   useEffect(() => {
     if (shouldVirtualize) return;
-    if (tasks.length === 0) {
+    if (orderedTasks.length === 0) {
       setViewportRange((prev) => (prev && prev.stageId === stageId ? null : prev));
       lastViewportRef.current = null;
       return;
@@ -219,86 +213,12 @@ export const TaskListVirtualized = forwardRef<HTMLDivElement, TaskListProps>(({
       ...next,
       updatedAt: Date.now(),
     });
-  }, [setViewportRange, shouldVirtualize, stageId, orderedTasks, tasks.length]);
+  }, [setViewportRange, shouldVirtualize, stageId, orderedTasks]);
 
-  const renderTaskItem = useCallback((task: ShapeBuildTaskSummary, key: string, style?: CSSProperties) => {
-    const statusValue = task.status;
-    const isSkipped = isTaskSkipped(task.display, task.message);
-    const displayProgress = Math.min(100, Math.max(0, task.progress ?? stageValue));
-    const statusLabelValue = resolveStatusLabel(statusValue, isSkipped);
-    const statusColor = resolveStatusColor(statusValue, isSkipped);
-    const taskTitle = resolveTaskTitle(task as TaskWithMetadata);
-    const displayMessage = formatTaskDisplayMessage(task.display, t);
-    const errorMessage = typeof task.errorMessage === 'string' ? task.errorMessage.trim() : '';
-    const fallbackError = typeof task.error === 'string' ? task.error.trim() : '';
-    const failedMessage = errorMessage || fallbackError;
-    const geometryDetails = parseGeometrySimplifyError(task.message);
-    const baseMessage = task.message?.split(' (')[0];
-    const failedTaskMessage = task.status === 'failed'
-      && failedMessage
-      && (!task.message || isTaskPhaseMessage(task.message))
-      ? failedMessage
-      : null;
-    const taskMessage = displayMessage
-      ?? failedTaskMessage
-      ?? (task.message && task.message !== taskTitle
-        ? (geometryDetails ? baseMessage : task.message)
-        : undefined);
-    const detailLines = displayMessage ? undefined : (geometryDetails ? formatGeometrySimplifySummary(geometryDetails) : undefined);
-    const leadingIcon = task.status === 'recycled' ? (
-      <RecyclingIcon data-testid="task-icon-recycling" sx={{ fontSize: 16, color: 'text.secondary' }} />
-    ) : (
-      <AddBoxIcon data-testid="task-icon-add" color="primary" sx={{ fontSize: 16 }} />
-    );
-    return (
-      <Box key={key} sx={style} data-task-id={task.taskId ?? undefined}>
-        <TaskItem
-          title={taskTitle}
-          leadingIcon={leadingIcon}
-          statusLabel={statusLabelValue}
-          statusColor={statusColor}
-          message={taskMessage}
-          detailLines={detailLines}
-          progress={displayProgress}
-          fallbackProgress={stageValue}
-        />
-      </Box>
-    );
-  }, [resolveStatusColor, resolveStatusLabel, resolveTaskTitle, stageValue, t]);
-
-  return (
-    <Box
-      ref={setRefs}
-      onWheel={(event) => event.stopPropagation()}
-      sx={{ flex: 1, minHeight: 0, height: '100%', overflow: 'auto' }}
-    >
-      {shouldVirtualize ? (
-        <Box sx={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
-          {virtualizer.getVirtualItems().map((virtualRow) => {
-            const task = orderedTasks[virtualRow.index];
-            if (!task) return null;
-            const taskTitle = resolveTaskTitle(task as TaskWithMetadata);
-            const key = task.taskId ?? `${virtualRow.index}-${taskTitle}`;
-            return renderTaskItem(task, key, {
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              transform: `translateY(${virtualRow.start}px)`,
-              paddingRight: 2,
-              height: `${TASK_ITEM_HEIGHT}px`,
-            });
-          })}
-        </Box>
-      ) : (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, pr: 1 }}>
-          {orderedTasks.map((task, index) => {
-            const taskTitle = resolveTaskTitle(task as TaskWithMetadata);
-            const key = task.taskId ?? `${index}-${taskTitle}`;
-            return renderTaskItem(task, key);
-          })}
-        </Box>
-      )}
-    </Box>
-  );
-});
+  return {
+    orderedTasks,
+    shouldVirtualize,
+    setRefs,
+    virtualizer,
+  };
+};


### PR DESCRIPTION
## Summary\n- Rename TaskListVirtualized to TaskItemCardListCard and remove Virtualized naming.\n- Extract TaskItemCard and move logic into useTaskItemCardList.\n- Use stage-based icons via useShapeBuildStages.\n\n## Testing\n- pnpm -w turbo run typecheck --filter @hierarchidb/app\n\nRefs #279