### PR TITLE
docs(shape): review step5 state transitions (#284)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #284 / `codex/chore/shape/step5-state-diagram-review-docs` / start: 2026-02-15 09:12 JST
 - #283 / `codex/feat/app/page-title-utility` / start: 2026-02-15 07:32 JST
 - #279 / `codex/refactor/ui/shape-task-item-card-list` / start: 2026-02-15 06:43 JST
 - #280 / `codex/fix/ui/task-item-card-vertical-align` / start: 2026-02-15 07:03 JST
@@ -87,6 +88,7 @@
 
 ## 今日の運用ログ
 
+- update: 2026-02-15 09:32 JST #284 Shape Step5 の状態遷移レビュー結果を反映し、Worker内部状態遷移/Worker↔UIシーケンス図と不一致点を追記。
 - update: 2026-02-15 08:54 JST #283 Step1 タイトルで i18n キー露出（basicinfo.title）を防ぐため、タイトル生成で存在チェック+ロード完了再評価+key露出ガードを追加。`pnpm -w turbo run typecheck --filter @hierarchidb/app` exit 0 を確認。
 - update: 2026-02-14 23:45 JST #276 タスク status の `regression`/`warning`/`rebuild-reserved` を削除し、task queue seed/legacy purge と EphemeralDB v7 を追加。`pnpm -w turbo run typecheck --filter @hierarchidb/batch-api --filter @hierarchidb/ui-batch-progress --filter @hierarchidb/gis-sdk --filter @hierarchidb/runtime-worker --filter @hierarchidb/shape-api --filter @hierarchidb/shape-store --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/vectortile-orchestrator --filter @hierarchidb/shape-plugin` と `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useBuildProgressPanelState.unit.test.ts src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx` を exit 0 で確認。
 - update: 2026-02-14 23:41 JST #276 で recycled status 対応（cacheReuse 廃止・進捗集計から除外・UI表示/アイコン更新）を実装し、`pnpm -w turbo run test --filter @hierarchidb/shape-plugin` を exit 0 で確認。

--- a/plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md
+++ b/plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md
@@ -147,6 +147,80 @@ stateDiagram-v2
 - E2E:
   - `e2e/shape/shape-build-startup-first-task.spec.ts`
 
+## 2026-02-15 検証結果（Worker実装/テスト照合）
+
+### 最新性の判定
+結論: 本文書は一部 outdated。
+
+### 不一致点（要点）
+- 「リアルタイム進捗購読（ポーリングのみ）」は不正確。実装は `subscribeBatchProgress` / `subscribeBatchTasks` の購読に加え、UI 側で 1s 間隔のリコンシル (`getBuildTasks`) を併用している。
+  - 参照: `packages/ui/batch/src/hooks/useBatchProgressState.ts`, `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks.ts`, `plugins/shape-plugin/src/worker/api.ts`
+- 実行ステージは `fetch -> transform -> vt` だけではなく、`metadata-stage` と `cleanup-stage` を含む。
+  - 参照: `plugins/shape-plugin/src/services/vt/shapePipeline.ts`
+- Worker 側は購読者がいない場合に `emitProgressSnapshot` をスキップする。ログ上 `progress snapshot skipped (no subscriber)` が出力されるため、UI 購読が遅れると初期 progress が欠落し得る。
+  - 参照: `plugins/shape-plugin/src/worker/api.ts`
+- ダイアログ間状態共有は `DialogContextProvider` ではなく、Jotai atoms + `useShapeBuildStep` が中心。
+  - 参照: `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts`
+- 自動クローズ/エラーリカバリー/セッション復旧の仕様は本文書にのみ存在し、実装側の呼び出し箇所が確認できない。
+  - 参照: `plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md` 以外に該当コードなし
+
+### Worker 内部状態遷移（詳細・実装準拠）
+
+```mermaid
+flowchart TD
+  A["Start / Resume"] --> B["lock-acquire"]
+  B -->|lock acquired| C["draft-save"]
+  B -->|lock unavailable| B1["waiting-lock"]
+  B1 --> C
+  C --> D["worker-initialize"]
+  D --> E["payload-build"]
+  E --> F["session-start-request"]
+  F --> G["awaiting-first-task"]
+  G -->|task signal| P["pipeline-dispatch"]
+  G -->|timeout / failed / cancelled| X["startup error/cancel"]
+  P --> S1["prepare-pipeline-run"]
+  S1 --> S2["fetch-stage"]
+  S2 --> S3["transform-stage"]
+  S3 --> S4["vt-stage"]
+  S4 --> S5["metadata-stage"]
+  S5 --> S6["cleanup-stage"]
+  S6 --> Z["completed"]
+```
+
+### AwaitingFirstTask のガード条件（補足）
+- `hasFirstTaskSignal` は `queued` / `running` / `completed` / `progressTaskId` / `progress.total` のいずれかで成立。
+- `buildStatus=completed` かつ `sessionProgressTotal>0` の場合は、task stream 未同期でも成功遷移となる。
+- 45s 超過で `timeout` エラー遷移となる。
+  - 参照: `plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts`, `resolveStartupTransitionWatchdogEvent.unit.test.ts`
+
+### Worker↔UI シーケンス（通知の欠落候補）
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant UI as ShapeBuildStep(UI)
+  participant Bridge as WorkerBridge
+  participant Worker as shapeBatchAPI/ShapePipeline
+  participant Queue as VtTaskQueueDb
+
+  UI->>Bridge: subscribeBatchProgress/subscribeBuildTasks (auto on mount)
+  User->>UI: Start
+  UI->>Bridge: startOrResumeBuildSession(nodeId)
+  Bridge->>Worker: startOrResumeBuildSession
+  Worker->>Worker: startBatchProcess (load-draft...emit-planned-progress)
+  Worker-->>UI: progress snapshot (if subscribed)
+  Note over Worker,UI: 購読が遅い場合は<br/>`progress snapshot skipped (no subscriber)`
+  Worker->>Queue: enqueue tasks
+  Worker-->>UI: task snapshot / updates (if subscribed)
+  UI->>Bridge: getBuildTasks (reconcile when empty/in-flight)
+  UI->>UI: タスク一覧・サマリー更新
+```
+
+### 通知/呼び出しの欠落ポイント（現状の候補）
+- `emit-planned-progress` 時点で UI 側購読が未接続だと progress 初期通知が欠落する。
+- `subscribeBuildTasks` が `nodeId` 不一致でフィルタされると、タスク更新が UI に届かない。
+  - 参照: `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks.ts`（`node_id_mismatch` で drop）
+
 ## ダイアログ制御の詳細仕様
 
 ### 1. ShapeEditDialog 内の Build Progress への遷移


### PR DESCRIPTION
## Summary
- Documented mismatches vs current worker behavior and tests.
- Added detailed worker internal state diagram and Worker↔UI sequence diagram.
- Highlighted likely notification gaps for progress/task updates.

## Testing
- Not run (docs only)
