### PR TITLE
fix(shape): emit progress snapshot after enqueue

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -88,6 +88,8 @@
 
 ## 今日の運用ログ
 
+- done: 2026-02-15 10:05 JST #287 fetch enqueue 後に progress snapshot を emit するよう修正し、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/app` exit 0 を確認。
+- start: 2026-02-15 09:35 JST #287 enqueue 後の progress snapshot 通知修正に着手。
 - update: 2026-02-15 09:32 JST #284 Shape Step5 の状態遷移レビュー結果を反映し、Worker内部状態遷移/Worker↔UIシーケンス図と不一致点を追記。
 - update: 2026-02-15 08:54 JST #283 Step1 タイトルで i18n キー露出（basicinfo.title）を防ぐため、タイトル生成で存在チェック+ロード完了再評価+key露出ガードを追加。`pnpm -w turbo run typecheck --filter @hierarchidb/app` exit 0 を確認。
 - update: 2026-02-15 09:32 JST #284 Shape Step5 の状態遷移レビュー結果を反映し、Worker内部状態遷移/Worker↔UIシーケンス図と不一致点を追記。

--- a/plugins/shape-plugin/src/services/vt/shapeFetchStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapeFetchStage.ts
@@ -204,6 +204,12 @@ export type ShapeFetchStageParams = {
   resumeExistingTasks?: boolean;
   abortController?: AbortController;
   failureHandling?: 'continue' | 'stop' | 'skip';
+  onTasksEnqueued?: (payload: {
+    nodeId: NodeId;
+    stage: 'fetch';
+    taskCount: number;
+    source: 'created' | 'reused';
+  }) => Promise<void> | void;
 };
 
 const buildRetryConfig = (config: ShapeRuntimeBuildConfig): RetryConfig => {
@@ -1095,6 +1101,22 @@ const createFetchHandler = (params: {
 export const runShapeFetchStage = async (params: ShapeFetchStageParams): Promise<void> => {
   const abortSignal = params.abortController?.signal;
   const resumeExistingTasks = Boolean(params.resumeExistingTasks);
+  const notifyTasksEnqueued = async (payload: {
+    taskCount: number;
+    source: 'created' | 'reused';
+  }): Promise<void> => {
+    if (!params.onTasksEnqueued) return;
+    try {
+      await params.onTasksEnqueued({
+        nodeId: params.nodeId,
+        stage: 'fetch',
+        taskCount: payload.taskCount,
+        source: payload.source,
+      });
+    } catch (error) {
+      console.warn('[ShapeFetch] notify tasks enqueued failed', error);
+    }
+  };
   if (!resumeExistingTasks) {
     const staleTasks = await listTasksByStage(params.taskQueue, params.nodeId, 'fetch');
     await deleteTasksByIds(params.taskQueue, staleTasks.map((task) => task.taskId));
@@ -1125,6 +1147,7 @@ export const runShapeFetchStage = async (params: ShapeFetchStageParams): Promise
       );
     }
     setFetchPlannedTotal(params.nodeId, 0);
+    await notifyTasksEnqueued({ taskCount: 0, source: 'created' });
     return;
   }
   const configSignature = buildStableSignature(params.buildConfig.fetchConfig ?? null);
@@ -1132,8 +1155,10 @@ export const runShapeFetchStage = async (params: ShapeFetchStageParams): Promise
     const tasks = buildFetchTasks(params.nodeId, payloads, metadataForPayloads, configSignature);
     setFetchPlannedTotal(params.nodeId, tasks.length);
     await reconcileFetchTasks(params, existingTasks, tasks, resumeExistingTasks);
+    await notifyTasksEnqueued({ taskCount: tasks.length, source: 'created' });
   } else {
     setFetchPlannedTotal(params.nodeId, existingTasks.length);
+    await notifyTasksEnqueued({ taskCount: existingTasks.length, source: 'reused' });
   }
   await runStageTasks({
     nodeId: params.nodeId,

--- a/plugins/shape-plugin/src/services/vt/shapePipeline.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipeline.ts
@@ -30,6 +30,12 @@ export type ShapePipelineParams = {
   resumeExistingTasks?: boolean;
   buildContinuationPolicy?: BuildContinuationPolicy;
   pipelineRunId?: string;
+  onTasksEnqueued?: (payload: {
+    nodeId: NodeId;
+    stage: 'fetch';
+    taskCount: number;
+    source: 'created' | 'reused';
+  }) => Promise<void> | void;
 };
 
 type ShapePipelineContext = {
@@ -164,6 +170,7 @@ const runFetchStage = async (context: ShapePipelineContext): Promise<boolean> =>
     failureHandling,
     buildContinuationPolicy,
     pipelineRunId: params.pipelineRunId,
+    onTasksEnqueued: params.onTasksEnqueued,
   });
   console.warn('[ShapePipeline][Stage] fetch done', JSON.stringify({
     nodeId: params.nodeId,

--- a/plugins/shape-plugin/src/services/vt/shapePipelineFetchStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineFetchStage.ts
@@ -24,6 +24,12 @@ export type ShapeFetchStageParams = {
   failureHandling: 'continue' | 'stop';
   buildContinuationPolicy: BuildContinuationPolicy;
   pipelineRunId?: string;
+  onTasksEnqueued?: (payload: {
+    nodeId: NodeId;
+    stage: 'fetch';
+    taskCount: number;
+    source: 'created' | 'reused';
+  }) => Promise<void> | void;
 };
 
 export const runShapeFetchStageSection = async (params: ShapeFetchStageParams): Promise<boolean> => {
@@ -44,6 +50,7 @@ export const runShapeFetchStageSection = async (params: ShapeFetchStageParams): 
       resumeExistingTasks: params.resumeExistingTasks,
       abortController: fetchAbortController,
       failureHandling: params.failureHandling,
+      onTasksEnqueued: params.onTasksEnqueued,
     });
   } catch (error) {
     const baseMessage = error instanceof Error ? error.message : String(error);

--- a/plugins/shape-plugin/src/worker/api.ts
+++ b/plugins/shape-plugin/src/worker/api.ts
@@ -1832,11 +1832,15 @@ export const shapeBatchAPI = {
         }),
         { existingTaskCount, plannedFetchTotal },
       );
-      await executeStartupStep(
-        'emit-planned-progress',
-        async () => emitProgressSnapshot(nodeForSession, 'Fetch task plan prepared.'),
-        { plannedFetchTotal },
-      );
+      const emitQueuedProgressSnapshot = async (payload: {
+        nodeId: NodeId;
+        stage: 'fetch';
+        taskCount: number;
+        source: 'created' | 'reused';
+      }): Promise<void> => {
+        if (payload.stage !== 'fetch') return;
+        await emitProgressSnapshot(payload.nodeId, 'Fetch task plan prepared.');
+      };
       emitStartupStepLog('start', 'pipeline-dispatch', {
         runId: pipelineRunId,
         payloadCount: downloadTaskPayloads.length,
@@ -1867,6 +1871,7 @@ export const shapeBatchAPI = {
         buildContinuationPolicy,
         resumeExistingTasks,
         pipelineRunId,
+        onTasksEnqueued: emitQueuedProgressSnapshot,
         }).then(async () => {
           const completedAt = Date.now();
           terminalProgressMessage = undefined;
@@ -2241,11 +2246,15 @@ export const shapeBatchAPI = {
           }),
           { existingTaskCount, plannedFetchTotal },
         );
-        await executeResumeStep(
-          'emit-planned-progress',
-          async () => emitProgressSnapshot(nodeId, 'Fetch task plan prepared.'),
-          { plannedFetchTotal },
-        );
+        const emitQueuedProgressSnapshot = async (payload: {
+          nodeId: NodeId;
+          stage: 'fetch';
+          taskCount: number;
+          source: 'created' | 'reused';
+        }): Promise<void> => {
+          if (payload.stage !== 'fetch') return;
+          await emitProgressSnapshot(payload.nodeId, 'Fetch task plan prepared.');
+        };
         emitResumeStepLog('start', 'pipeline-dispatch', {
           runId: pipelineRunId,
           existingTaskCount,
@@ -2271,6 +2280,7 @@ export const shapeBatchAPI = {
           resumeExistingTasks: true,
           buildContinuationPolicy,
           pipelineRunId,
+          onTasksEnqueued: emitQueuedProgressSnapshot,
         }).then(async () => {
           const completedAt = Date.now();
           terminalProgressMessage = undefined;


### PR DESCRIPTION
## Summary
- emit progress snapshot after fetch tasks are enqueued (start/resume)
- remove planned-progress snapshot before enqueue and wire enqueue callback through pipeline
- record #287 completion in TASKS.md

## Testing
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/app

Refs #287