### PR TITLE
fix(ui-auth): clear auth tokens on failure

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #294 / `codex/fix/ui-auth/clear-auth-data` / start: 2026-02-15 15:43 JST
 - #284 / `codex/chore/shape/step5-state-diagram-review-docs` / start: 2026-02-15 09:12 JST
 - #283 / `codex/feat/app/page-title-utility` / start: 2026-02-15 07:32 JST
 - #279 / `codex/refactor/ui/shape-task-item-card-list` / start: 2026-02-15 06:43 JST

--- a/packages/ui/auth/src/services/BFFAuthService.ts
+++ b/packages/ui/auth/src/services/BFFAuthService.ts
@@ -369,9 +369,8 @@ export class BFFAuthService {
         localStorage.setItem('refresh_token_id', data.refresh_token_id);
       }
 
-      // Clean up (keep return URL until caller consumes it)
-      this.clearAuthData({ preserveReturnUrl: true });
-      localStorage.removeItem('oauth_state');
+      // Clean up OAuth flow state (keep return URL until caller consumes it)
+      this.clearAuthFlowState({ preserveReturnUrl: true });
 
       // Parse user from token response
       const user = this.parseTokenResponse(data);
@@ -414,7 +413,6 @@ export class BFFAuthService {
 
     // Clear local storage
     this.clearAuthData();
-    localStorage.removeItem(this.USERINFO_STORAGE_KEYS.userinfo);
   }
 
   /**
@@ -443,7 +441,7 @@ export class BFFAuthService {
       });
 
       if (!response.ok) {
-        // Clear tokens on refresh failure
+        // Clear auth data on refresh failure
         this.clearAuthData();
         return null;
       }
@@ -577,23 +575,32 @@ export class BFFAuthService {
   }
 
   /**
-   * Clear authentication data from storage
+   * Clear OAuth flow state without touching tokens.
    */
-  private clearAuthData(options: { preserveReturnUrl?: boolean } = {}): void {
+  private clearAuthFlowState(options: { preserveReturnUrl?: boolean } = {}): void {
     // Clear PKCE data
     localStorage.removeItem('pkce_code_verifier');
 
     // Clear OAuth atoms
     localStorage.removeItem('oauth_state');
 
-    // Clear tokens (keep these for getCurrentUser)
-    // localStorage.removeItem('access_token');
-    // localStorage.removeItem('refresh_token_id');
-
     // Clear provider and return URL
     localStorage.removeItem('auth_provider');
     if (!options.preserveReturnUrl) {
       localStorage.removeItem('auth_return_url');
     }
+  }
+
+  /**
+   * Clear authentication data from storage (tokens + flow state).
+   */
+  private clearAuthData(options: { preserveReturnUrl?: boolean } = {}): void {
+    this.clearAuthFlowState(options);
+
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('refresh_token_id');
+    localStorage.removeItem('refresh_token');
+    localStorage.removeItem('id_token');
+    localStorage.removeItem(this.USERINFO_STORAGE_KEYS.userinfo);
   }
 }


### PR DESCRIPTION
## Summary
- clear auth tokens + userinfo in clearAuthData
- split clearAuthFlowState for OAuth cleanup
- align refresh failure/signOut with clean state

## Testing
- `pnpm install --frozen-lockfile` (warn: gen-iso3166-2 bin missing, approve-builds prompt)
- `pnpm -w turbo run typecheck --filter @hierarchidb/ui-auth`

Refs #294