### PR TITLE
feat(route): preview mode/metadata/style panels as floating windows

### DIFF
--- a/plugins/route-plugin/src/ui/components/steps/RoutePreviewStep.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/RoutePreviewStep.tsx
@@ -16,7 +16,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { Palette } from '@mui/icons-material';
+import { FilterAlt, Palette, TableChart } from '@mui/icons-material';
 import { FloatingWindow } from '@hierarchidb/ui-floating-window';
 import { RoutePreviewEmptyContent, RoutePreviewHoverSnackbar } from './RoutePreviewStepElements.js';
 import { DEFAULT_MAP_CONFIG, MapToggleCard, ResourceLayerMap, RoutePreviewList } from '@hierarchidb/ui-map';
@@ -76,6 +76,11 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
     metadataSyncError,
     metadataSyncBadgeText,
     runMetadataSyncCheck,
+    buildErrors,
+    modeWindow,
+    showModeWindowButton,
+    listWindow,
+    showListWindowButton,
   } = useRoutePreviewStep({ draft, nodeId, onUpdate });
 
   return (
@@ -95,6 +100,22 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
           {lineStringsError}
         </Alert>
       )}
+      {buildErrors.length > 0 && (
+        <Alert severity="warning">
+          <Typography variant="body2" fontWeight={600}>
+            {t('preview.buildErrors', 'Build errors detected')}: {buildErrors.length}
+          </Typography>
+          <Box component="ul" sx={{ mb: 0, mt: 1, pl: 2 }}>
+            {buildErrors.slice(0, 5).map((error) => (
+              <Box component="li" key={error.id} sx={{ mb: 0.5 }}>
+                <Typography variant="caption">
+                  [{error.stage}] {error.sourceKey ?? '-'}: {error.message}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Alert>
+      )}
 
       {hasGeometry && (
         <>
@@ -103,18 +124,6 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
           </Alert>
           <Paper variant="outlined" sx={{ p: 2 }}>
             <Typography variant="subtitle1">{t('preview.mapTitle', 'Map Preview')}</Typography>
-            <Box sx={{ mt: 2 }}>
-              <MapToggleCard
-                title="Route Selection"
-                options={routeModeOptions.map((option) => ({
-                  id: option.id,
-                  label: option.label,
-                  icon: <option.Icon fontSize="small" />,
-                }))}
-                selection={routeModeSelection}
-                onToggle={handleRouteModeToggle}
-              />
-            </Box>
             <Box
               sx={{
                 position: 'relative',
@@ -138,52 +147,88 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
                 mapOptions={DEFAULT_MAP_CONFIG.interactionOptions}
                 onLoad={setMapInstance}
               />
-              <RoutePreviewList
-                title={t('preview.list.title', 'Routes')}
-                rows={listRows}
-                loading={lineStringsLoading}
-                error={lineStringsError ?? undefined}
-                columnLabels={columnLabels}
-                modeMeta={Object.fromEntries(Object.entries(modeMeta).map(([key, meta]) => [
-                  key,
-                  { ...meta, icon: <meta.Icon fontSize="small" /> },
-                ]))}
-                search={{
-                  value: listSearch,
-                  onChange: setListSearch,
-                  placeholder: searchLabels.placeholder,
-                  ariaLabel: searchLabels.ariaLabel,
-                }}
-                countLabels={countLabels}
-                matchedRows={matchedIdSet}
-                selectedRows={new Set(selectedIds)}
-                onSelectionChange={(next: Set<string | number>) => setSelectedIds(Array.from(next).map(String))}
-                errorSummaryById={staleSummaryById}
-                errorColumnLabels={errorColumnLabels}
-                statusLabels={statusLabels}
-                toolbarActions={(
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      onClick={() => void runMetadataSyncCheck()}
-                      disabled={metadataSyncRunning}
-                    >
-                      {metadataSyncRunning
-                        ? t('preview.metadataSync.checking', 'Checking...')
-                        : t('preview.metadataSync.checkButton', 'Check sync status')}
-                    </Button>
-                    {metadataSyncBadgeText ? (
-                      <Typography variant="caption" color="text.secondary">
-                        {metadataSyncBadgeText}
-                      </Typography>
-                    ) : null}
-                  </Box>
-                )}
-                emptyContent={emptyContentProps ? (
-                  <RoutePreviewEmptyContent {...emptyContentProps} />
-                ) : undefined}
-              />
+              {modeWindow.windowState.isVisible ? (
+                <FloatingWindow
+                  title={t('preview.modeFilters.title', 'Route mode filters')}
+                  titleIcon={<FilterAlt fontSize="small" />}
+                  initialState={modeWindow.windowState}
+                  onStateChange={modeWindow.handlers.onStateChange}
+                  onClose={modeWindow.handlers.onClose}
+                  resizable
+                  minWidth={220}
+                  minHeight={180}
+                >
+                  <MapToggleCard
+                    title={t('preview.routeSelection', 'Route selection')}
+                    options={routeModeOptions.map((option) => ({
+                      id: option.id,
+                      label: option.label,
+                      icon: <option.Icon fontSize="small" />,
+                    }))}
+                    selection={routeModeSelection}
+                    onToggle={handleRouteModeToggle}
+                  />
+                </FloatingWindow>
+              ) : null}
+              {listWindow.windowState.isVisible ? (
+                <FloatingWindow
+                  title={t('preview.listWindow.title', 'Route metadata')}
+                  titleIcon={<TableChart fontSize="small" />}
+                  initialState={listWindow.windowState}
+                  onStateChange={listWindow.handlers.onStateChange}
+                  onClose={listWindow.handlers.onClose}
+                  resizable
+                  minWidth={420}
+                  minHeight={220}
+                >
+                  <RoutePreviewList
+                    title={t('preview.list.title', 'Routes')}
+                    rows={listRows}
+                    loading={lineStringsLoading}
+                    error={lineStringsError ?? undefined}
+                    columnLabels={columnLabels}
+                    modeMeta={Object.fromEntries(Object.entries(modeMeta).map(([key, meta]) => [
+                      key,
+                      { ...meta, icon: <meta.Icon fontSize="small" /> },
+                    ]))}
+                    search={{
+                      value: listSearch,
+                      onChange: setListSearch,
+                      placeholder: searchLabels.placeholder,
+                      ariaLabel: searchLabels.ariaLabel,
+                    }}
+                    countLabels={countLabels}
+                    matchedRows={matchedIdSet}
+                    selectedRows={new Set(selectedIds)}
+                    onSelectionChange={(next: Set<string | number>) => setSelectedIds(Array.from(next).map(String))}
+                    errorSummaryById={staleSummaryById}
+                    errorColumnLabels={errorColumnLabels}
+                    statusLabels={statusLabels}
+                    toolbarActions={(
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          onClick={() => void runMetadataSyncCheck()}
+                          disabled={metadataSyncRunning}
+                        >
+                          {metadataSyncRunning
+                            ? t('preview.metadataSync.checking', 'Checking...')
+                            : t('preview.metadataSync.checkButton', 'Check sync status')}
+                        </Button>
+                        {metadataSyncBadgeText ? (
+                          <Typography variant="caption" color="text.secondary">
+                            {metadataSyncBadgeText}
+                          </Typography>
+                        ) : null}
+                      </Box>
+                    )}
+                    emptyContent={emptyContentProps ? (
+                      <RoutePreviewEmptyContent {...emptyContentProps} />
+                    ) : undefined}
+                  />
+                </FloatingWindow>
+              ) : null}
               {metadataSyncError ? (
                 <Box sx={{ position: 'absolute', left: 12, right: 12, bottom: 12, zIndex: 4 }}>
                   <Alert severity="error">{metadataSyncError}</Alert>
@@ -259,17 +304,43 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
                   </Box>
                 </FloatingWindow>
               ) : null}
-              {showStyleWindowButton ? (
+              {(showModeWindowButton || showListWindowButton || showStyleWindowButton) ? (
                 <Box position="absolute" top={8} right={8} zIndex={3}>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    size="large"
-                    aria-label={t('routeConfig.style.reopen', 'Show route style')}
-                    onClick={styleWindow.handlers.show}
-                  >
-                    <Palette />
-                  </Button>
+                  <Box display="flex" flexDirection="column" gap={1}>
+                    {showModeWindowButton ? (
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        size="large"
+                        aria-label={t('preview.modeFilters.reopen', 'Show route mode filters')}
+                        onClick={modeWindow.handlers.show}
+                      >
+                        <FilterAlt />
+                      </Button>
+                    ) : null}
+                    {showListWindowButton ? (
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        size="large"
+                        aria-label={t('preview.listWindow.reopen', 'Show route metadata')}
+                        onClick={listWindow.handlers.show}
+                      >
+                        <TableChart />
+                      </Button>
+                    ) : null}
+                    {showStyleWindowButton ? (
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        size="large"
+                        aria-label={t('routeConfig.style.reopen', 'Show route style')}
+                        onClick={styleWindow.handlers.show}
+                      >
+                        <Palette />
+                      </Button>
+                    ) : null}
+                  </Box>
                 </Box>
               ) : null}
               {mapInstance ? <RoutePreviewHoverSnackbar {...hoverSnackbarProps} /> : null}

--- a/plugins/route-plugin/src/ui/components/steps/__tests__/RoutePreviewStep.style-floating.unit.test.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/__tests__/RoutePreviewStep.style-floating.unit.test.tsx
@@ -68,6 +68,48 @@ vi.mock('../useRoutePreviewStep.js', () => ({
       lineWidth: 2,
       lineStyle: 'solid',
     },
+    modeWindow: {
+      windowState: {
+        position: { x: 96, y: 96 },
+        size: { width: 260, height: 220 },
+        isVisible: true,
+        isMinimized: false,
+        isFullscreen: false,
+        zIndex: 1000,
+      },
+      handlers: {
+        onStateChange: vi.fn(),
+        onClose: vi.fn(),
+        onMinimize: vi.fn(),
+        onRestore: vi.fn(),
+        setPosition: vi.fn(),
+        setSize: vi.fn(),
+        show: vi.fn(),
+        hide: vi.fn(),
+      },
+    },
+    showModeWindowButton: false,
+    listWindow: {
+      windowState: {
+        position: { x: 96, y: 356 },
+        size: { width: 640, height: 280 },
+        isVisible: true,
+        isMinimized: false,
+        isFullscreen: false,
+        zIndex: 1000,
+      },
+      handlers: {
+        onStateChange: vi.fn(),
+        onClose: vi.fn(),
+        onMinimize: vi.fn(),
+        onRestore: vi.fn(),
+        setPosition: vi.fn(),
+        setSize: vi.fn(),
+        show: vi.fn(),
+        hide: vi.fn(),
+      },
+    },
+    showListWindowButton: false,
     styleWindow: {
       windowState: {
         position: { x: 640, y: 96 },
@@ -97,6 +139,7 @@ vi.mock('../useRoutePreviewStep.js', () => ({
     metadataSyncError: null,
     metadataSyncBadgeText: '',
     runMetadataSyncCheck: vi.fn(),
+    buildErrors: [],
   }),
 }));
 
@@ -106,6 +149,8 @@ describe('RoutePreviewStep style floating window', () => {
   it('renders route style controls in preview overlay', () => {
     render(<RoutePreviewStep draft={{}} nodeId="route-node-1" onUpdate={() => undefined} />);
 
+    expect(screen.getByText('Route mode filters')).toBeTruthy();
+    expect(screen.getByText('Route metadata')).toBeTruthy();
     expect(screen.getByText('Route style')).toBeTruthy();
     expect(screen.getByText('Mode colors')).toBeTruthy();
     expect(screen.getByText('Line width')).toBeTruthy();

--- a/plugins/route-plugin/src/ui/components/steps/useRoutePreviewStep.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRoutePreviewStep.ts
@@ -22,6 +22,7 @@ import type { NodeId } from '@hierarchidb/core-types';
 import { getWorkerBridge } from '@hierarchidb/ui-worker-client';
 import { useFloatingWindow } from '@hierarchidb/ui-floating-window';
 import type {
+  RouteBuildError,
   RouteEntity,
   RouteLineString,
   RouteMetadataSyncSummary,
@@ -150,6 +151,7 @@ export const useRoutePreviewStep = ({
   const [matchedIds, setMatchedIds] = useState<string[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [metadataSyncSummary, setMetadataSyncSummary] = useState<RouteMetadataSyncSummary | null>(null);
+  const [buildErrors, setBuildErrors] = useState<RouteBuildError[]>([]);
   const [metadataSyncRunning, setMetadataSyncRunning] = useState(false);
   const [metadataSyncError, setMetadataSyncError] = useState<string | null>(null);
   const [hoverInfo, setHoverInfo] = useState<RouteNearestLineResponse | null>(null);
@@ -183,10 +185,20 @@ export const useRoutePreviewStep = ({
     () => mergeRouteStyleConfig(draft.routeStyleConfig),
     [draft.routeStyleConfig],
   );
+  const modeWindow = useFloatingWindow({
+    persistKey: 'hierarchidb:ui:floating-window:route:mode-toggle',
+    initialPosition: { x: 96, y: 96 },
+    initialSize: { width: 260, height: 220 },
+  });
   const styleWindow = useFloatingWindow({
     persistKey: 'hierarchidb:ui:floating-window:route:style-config',
     initialPosition: { x: 640, y: 96 },
     initialSize: { width: 360, height: 520 },
+  });
+  const listWindow = useFloatingWindow({
+    persistKey: 'hierarchidb:ui:floating-window:route:metadata-list',
+    initialPosition: { x: 96, y: 356 },
+    initialSize: { width: 640, height: 280 },
   });
   const attributionItems = useMemo<MapAttributionItem[]>(() => {
     if (!dataSourceConfig) return [];
@@ -203,6 +215,7 @@ export const useRoutePreviewStep = ({
   useEffect(() => {
     if (!previewNodeId) {
       setLineStrings([]);
+      setBuildErrors([]);
       setMetadataSyncSummary(null);
       setMetadataSyncError(null);
       return;
@@ -213,14 +226,19 @@ export const useRoutePreviewStep = ({
     void (async () => {
       try {
         const api = await workerBridgeRef.current.getRouteQueryAPI();
-        const rows = await api.listRouteLineStrings(previewNodeId);
+        const [rows, errors] = await Promise.all([
+          api.listRouteLineStrings(previewNodeId),
+          api.listRouteBuildErrors(previewNodeId),
+        ]);
         if (!active) return;
         setLineStrings(rows);
+        setBuildErrors(errors);
       } catch (error) {
         if (!active) return;
         const message = error instanceof Error ? error.message : String(error);
         setLineStringsError(message);
         setLineStrings([]);
+        setBuildErrors([]);
       } finally {
         if (active) {
           setLineStringsLoading(false);
@@ -568,9 +586,13 @@ export const useRoutePreviewStep = ({
       errorCount: t('preview.list.columns.errorCount', 'Errors'),
       errorMessage: t('preview.list.columns.errorMessage', 'Error Message'),
     },
+    modeWindow,
+    showModeWindowButton: !modeWindow.windowState.isVisible,
     routeStyleConfig,
     styleWindow,
     showStyleWindowButton: !styleWindow.windowState.isVisible,
+    listWindow,
+    showListWindowButton: !listWindow.windowState.isVisible,
     handleModeColorChange,
     handleLineWidthChange,
     handleLineStyleChange,
@@ -579,5 +601,6 @@ export const useRoutePreviewStep = ({
     metadataSyncError,
     metadataSyncBadgeText,
     runMetadataSyncCheck,
+    buildErrors,
   };
 };


### PR DESCRIPTION
## Summary\n- move Route preview mode toggle into a FloatingWindow\n- move Route preview metadata list into a FloatingWindow\n- keep style configuration in FloatingWindow and add reopen buttons for all three windows\n- update preview unit test mock/expectations\n\n## Verification\n- pnpm -w turbo run build --filter @hierarchidb/route-plugin --output-logs errors-only\n- pnpm -w turbo run typecheck --filter @hierarchidb/route-plugin --output-logs errors-only\n- cd plugins/route-plugin && ROUTE_TESTS=1 pnpm exec vitest run -c vitest.config.ts src/ui/components/steps/__tests__/RoutePreviewStep.style-floating.unit.test.tsx