### PR TITLE
fix(shape): keep final build elapsed summary visible after completion

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #315 / `codex/fix/shape-build-duration-summary-stable` / start: 2026-02-16 02:57 JST
 - #312 / `codex/chore/integration/eria-main-sync-latest-312` / start: 2026-02-16 02:35 JST
 - #301 / `codex/fix/shape-ephemeral-types` / start: 2026-02-15 22:26 JST
 - #297 / `codex/fix/shape/task-list-empty-ui` / start: 2026-02-15 17:26 JST
@@ -102,6 +103,9 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- update: 2026-02-16 08:22 JST #315 `useShapeBuildStep.ts` の elapsed reset 条件を修正。persisted elapsed が空でも local elapsed スナップショット（completedStageElapsedMs）が残っている場合はリセットしないようにし、ビルド完了直後に総経過時間/ステージ経過時間が `-` へ戻る回帰を防止。
+- update: 2026-02-16 08:22 JST #315 検証結果: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts` exit 0（5 passed）、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --output-logs errors-only` exit 0、`pnpm -w turbo run build --filter @hierarchidb/shape-plugin --output-logs errors-only` exit 0。
+- start: 2026-02-16 02:57 JST #315 を Project `hierarchidb` へ追加し、Status を `In Progress` に設定。ブランチ `codex/fix/shape-build-duration-summary-stable` を作成して着手。
 - start: 2026-02-16 02:35 JST #312 を起票し、Issue `https://github.com/kubohiroya/hierarchidb/issues/312` を作成。
 - start: 2026-02-16 02:35 JST #312 を Project `hierarchidb` に追加し、Status を `In Progress` に設定。
 - start: 2026-02-16 02:35 JST ブランチ `codex/chore/integration/eria-main-sync-latest-312` を作成して着手。

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { shouldResetElapsedState } from '../../../components/build-progress/useShapeBuildStep.ts';
+
+describe('shouldResetElapsedState', () => {
+  it('returns false while build is running', () => {
+    expect(shouldResetElapsedState({
+      buildStatus: 'running',
+      buildElapsedMs: 0,
+      stageElapsedByStage: {},
+      localElapsedByStage: {},
+    })).toBe(false);
+  });
+
+  it('returns true when both persisted and local elapsed are empty', () => {
+    expect(shouldResetElapsedState({
+      buildStatus: 'idle',
+      buildElapsedMs: 0,
+      stageElapsedByStage: {},
+      localElapsedByStage: {},
+    })).toBe(true);
+  });
+
+  it('returns false when local elapsed snapshot exists', () => {
+    expect(shouldResetElapsedState({
+      buildStatus: 'idle',
+      buildElapsedMs: 0,
+      stageElapsedByStage: {},
+      localElapsedByStage: {
+        fetch: 2_000,
+      },
+    })).toBe(false);
+  });
+
+  it('returns false when persisted elapsed exists', () => {
+    expect(shouldResetElapsedState({
+      buildStatus: 'completed',
+      buildElapsedMs: 0,
+      stageElapsedByStage: {
+        vt: 1_000,
+      },
+      localElapsedByStage: {},
+    })).toBe(false);
+  });
+
+  it('returns false when total elapsed exists', () => {
+    expect(shouldResetElapsedState({
+      buildStatus: 'failed',
+      buildElapsedMs: 5_000,
+      stageElapsedByStage: {},
+      localElapsedByStage: {},
+    })).toBe(false);
+  });
+});

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts
@@ -128,6 +128,10 @@ const sumNumberRecord = (values: Record<string, number>): number => (
   Object.values(values).reduce((acc, value) => acc + (Number.isFinite(value) ? value : 0), 0)
 );
 
+const hasPositiveElapsed = (values: Record<string, number>): boolean => (
+  Object.values(values).some((value) => Number.isFinite(value) && value > 0)
+);
+
 const mergeElapsedByStage = (
   current: Record<string, number>,
   persisted: Record<string, number>,
@@ -143,14 +147,16 @@ const mergeElapsedByStage = (
   return next;
 };
 
-const shouldResetElapsedState = (params: {
+export const shouldResetElapsedState = (params: {
   buildStatus: BuildStatus;
   buildElapsedMs: number | undefined;
   stageElapsedByStage: Record<string, number>;
+  localElapsedByStage: Record<string, number>;
 }): boolean => {
   if (params.buildStatus === 'running') return false;
-  if (!shallowEqualNumberRecord(params.stageElapsedByStage, {})) return false;
+  if (hasPositiveElapsed(params.stageElapsedByStage)) return false;
   if (typeof params.buildElapsedMs === 'number' && params.buildElapsedMs > 0) return false;
+  if (hasPositiveElapsed(params.localElapsedByStage)) return false;
   return true;
 };
 
@@ -804,8 +810,10 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     buildStatus,
     buildElapsedMs: sessionRecord?.elapsedMs,
     stageElapsedByStage: persistedStageElapsedByStage,
+    localElapsedByStage: completedStageElapsedMs,
   }), [
     buildStatus,
+    completedStageElapsedMs,
     sessionRecord?.elapsedMs,
     persistedStageElapsedByStage,
   ]);
@@ -883,6 +891,15 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
       window.clearInterval(intervalId);
     };
   }, [buildStatus, isTimingStageRunning, timingStageId]);
+
+  useEffect(() => {
+    if (buildStatus !== 'running') return;
+    if (hasPositiveElapsed(persistedStageElapsedByStage)) return;
+    if (typeof sessionRecord?.elapsedMs === 'number' && sessionRecord.elapsedMs > 0) return;
+    setCompletedStageElapsedMs((current) => (
+      shallowEqualNumberRecord(current, {}) ? current : {}
+    ));
+  }, [buildStatus, persistedStageElapsedByStage, sessionRecord?.elapsedMs]);
 
   const hasFailedFetchTasks = useMemo(() => (
     displayTasks.some((task) => task.status === 'failed' && normalizeStageKey(task) === 'fetch')


### PR DESCRIPTION
## Summary\n- keep stage/total elapsed values stable after build completion\n- avoid resetting local elapsed snapshot when persisted elapsed temporarily becomes empty\n- add unit tests for elapsed reset decision logic\n\n## Verification\n- pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts\n- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --output-logs errors-only\n- pnpm -w turbo run build --filter @hierarchidb/shape-plugin --output-logs errors-only\n\nRefs #315