### PR TITLE
feat(shape-plugin): add step4 anomaly guard controls and retry diagnostics

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #318 / `codex/feat/shape/step4-anomaly-guard-controls` / start: 2026-02-16 08:40 JST
 - #315 / `codex/fix/shape-build-duration-summary-stable` / start: 2026-02-16 02:57 JST
 - #312 / `codex/chore/integration/eria-main-sync-latest-312` / start: 2026-02-16 02:35 JST
 - #301 / `codex/fix/shape-ephemeral-types` / start: 2026-02-15 22:26 JST
@@ -103,6 +104,9 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- done: 2026-02-16 08:55 JST #318 Step4 に `Fetch Geometry Intake Guard` / `Anomaly Detection & Auto Retry` / `Tile Output Quality Guard` を追加し、Transform 実行に `execution-path` ログ（topojson/geojson 判別）・intake guard・異常スコア判定+再試行・shape/route での polygon 修復スキップ分岐を実装。`pnpm -w turbo run build --filter @hierarchidb/gis-sdk --filter @hierarchidb/shape-api --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` と `pnpm -w turbo run typecheck --filter @hierarchidb/gis-sdk --filter @hierarchidb/shape-api --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` は exit 0。追加テスト `packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts` を含む `pnpm exec vitest run ...` も exit 0。
+- blocked: 2026-02-16 08:55 JST #318 `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` は差分外既知失敗 `plugins/shape-plugin/src/__tests__/unit/shapeFetchStage.unit.test.ts` ほか3ファイルで `TypeError: db.delete is not a function` により exit 1（今回差分由来ではない）。
+- start: 2026-02-16 08:40 JST #318 を起票し（https://github.com/kubohiroya/hierarchidb/issues/318）、Project `hierarchidb` の Status を `In Progress` に設定。ブランチ `codex/feat/shape/step4-anomaly-guard-controls` を `origin/ERIA-Cartograph` 起点で作成して着手。
 - update: 2026-02-16 08:22 JST #315 `useShapeBuildStep.ts` の elapsed reset 条件を修正。persisted elapsed が空でも local elapsed スナップショット（completedStageElapsedMs）が残っている場合はリセットしないようにし、ビルド完了直後に総経過時間/ステージ経過時間が `-` へ戻る回帰を防止。
 - update: 2026-02-16 08:22 JST #315 検証結果: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts` exit 0（5 passed）、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --output-logs errors-only` exit 0、`pnpm -w turbo run build --filter @hierarchidb/shape-plugin --output-logs errors-only` exit 0。
 - start: 2026-02-16 02:57 JST #315 を Project `hierarchidb` へ追加し、Status を `In Progress` に設定。ブランチ `codex/fix/shape-build-duration-summary-stable` を作成して着手。

--- a/packages/gis-sdk/src/config.ts
+++ b/packages/gis-sdk/src/config.ts
@@ -16,7 +16,18 @@ export interface FetchConfig {
   retryDelay: number;
   retryLimit: number;
   retryBackoff: 'linear' | 'exponential';
+  geometryIntakeGuard?: FetchGeometryIntakeGuardConfig;
 }
+
+export type GeometryIntakeValidationLevel = 'off' | 'basic' | 'strict';
+
+export type FetchGeometryIntakeGuardConfig = {
+  validationLevel: GeometryIntakeValidationLevel;
+  dedupeEpsilon: number;
+  minRingAreaThreshold: number;
+  normalizeRingOrientation: boolean;
+  keepBaselineSnapshot: boolean;
+};
 
 export interface CleanupConfig {
   deleteFetchApiCache?: boolean;
@@ -76,12 +87,33 @@ export type SelfIntersectionTuningConfig = {
 
 export type GeometryEngine = 'turf';
 export type TransformSimplifyAlgorithm = 'geojson' | 'topojson';
+export type TransformExecutionLogLevel = 'off' | 'summary' | 'verbose';
+export type TransformFallbackMode = 'switch_algorithm' | 'disable_simplify' | 'best_score';
+
+export type TransformAnomalyDetectionConfig = {
+  enabled: boolean;
+  maxEdgeLengthRatio: number;
+  maxAreaDriftPercent: number;
+  maxSelfIntersectionCount: number;
+  maxLineLengthDriftPercent: number;
+};
+
+export type TransformAnomalyRetryConfig = {
+  enabled: boolean;
+  maxRetries: number;
+  toleranceScale: number;
+  fallbackMode: TransformFallbackMode;
+};
 
 export interface TransformConfig {
   zoomBandBoundaries: number[];
   maxConcurrent: number;
   geometryEngine?: GeometryEngine;
   simplifyAlgorithm?: TransformSimplifyAlgorithm;
+  preserveTopology?: boolean;
+  executionLogLevel?: TransformExecutionLogLevel;
+  anomalyDetection?: TransformAnomalyDetectionConfig;
+  anomalyRetry?: TransformAnomalyRetryConfig;
   enableFeatureFiltering: boolean;
   featureAreaThreshold: number;
   minVertexCountForAreaFilter: number;
@@ -131,7 +163,18 @@ export interface VTConfig {
     tiles?: readonly string[];
     features?: readonly string[];
   };
+  outputQualityGuard?: VTOutputQualityGuardConfig;
 }
+
+export type VTGuardAction = 'mark_warning' | 'fallback_less_simplified' | 'drop_tile';
+
+export type VTOutputQualityGuardConfig = {
+  enabled: boolean;
+  minZoom: number;
+  maxZoom: number;
+  actionOnAnomaly: VTGuardAction;
+  enablePreviewOverlay: boolean;
+};
 
 export interface RouteTransformConfig {
   minDistanceMetersByBand?: number[];

--- a/packages/shape-api/src/defaults.ts
+++ b/packages/shape-api/src/defaults.ts
@@ -5,11 +5,33 @@ export const DEFAULT_BUILD_CONFIG = {
   fetchConfig: {
     deleteOnComplete: false,
     timeoutMs: 300000,
+    geometryIntakeGuard: {
+      validationLevel: 'basic',
+      dedupeEpsilon: 0.000001,
+      minRingAreaThreshold: 0.0,
+      normalizeRingOrientation: true,
+      keepBaselineSnapshot: true,
+    },
   },
   transformConfig: {
     zoomBandBoundaries: DEFAULT_ZOOM_BAND_BOUNDARIES,
     geometryEngine: 'turf',
     simplifyAlgorithm: 'topojson',
+    preserveTopology: true,
+    executionLogLevel: 'summary',
+    anomalyDetection: {
+      enabled: true,
+      maxEdgeLengthRatio: 12,
+      maxAreaDriftPercent: 35,
+      maxSelfIntersectionCount: 0,
+      maxLineLengthDriftPercent: 45,
+    },
+    anomalyRetry: {
+      enabled: true,
+      maxRetries: 2,
+      toleranceScale: 0.7,
+      fallbackMode: 'best_score',
+    },
     enableFeatureFiltering: true,
     featureAreaThreshold: 1.0,
     minVertexCountForAreaFilter: 10,
@@ -52,6 +74,13 @@ export const DEFAULT_BUILD_CONFIG = {
       enabled: false,
       tiles: [],
       features: [],
+    },
+    outputQualityGuard: {
+      enabled: false,
+      minZoom: 0,
+      maxZoom: 22,
+      actionOnAnomaly: 'mark_warning',
+      enablePreviewOverlay: false,
     },
   },
   cleanupConfig: {

--- a/packages/vt-orchestrator/src/contexts.ts
+++ b/packages/vt-orchestrator/src/contexts.ts
@@ -1,10 +1,12 @@
 import type { EphemeralDB } from '@hierarchidb/gis-sdk';
-import type { GeometryEngine, TransformConfig, VTConfig } from '@hierarchidb/gis-sdk';
+import type { FetchConfig, GeometryEngine, TransformConfig, VTConfig } from '@hierarchidb/gis-sdk';
 import type { BandConfig } from './types/types.js';
 
 export type TransformByBandStageContext = {
   ephemeralDB: EphemeralDB;
+  fetchConfig: FetchConfig;
   transformConfig: TransformConfig;
+  vtConfig: VTConfig;
   bands: BandConfig[];
   featureIdAllowlist?: Set<string>;
   abortSignal?: AbortSignal;

--- a/packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts
+++ b/packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { assessAnomalyRisk, resolveSimplifyExecutionPath } from '../createTransformByBandHandler.js';
+
+describe('resolveSimplifyExecutionPath', () => {
+  it('returns topojson decode simplify path for topojson algorithm', () => {
+    expect(resolveSimplifyExecutionPath({
+      fetchFormat: 'topojson',
+      simplifyAlgorithm: 'topojson',
+    })).toBe('topojson_decode_simplify_geojson_skip');
+  });
+
+  it('returns topojson decode only path for geojson algorithm', () => {
+    expect(resolveSimplifyExecutionPath({
+      fetchFormat: 'topojson',
+      simplifyAlgorithm: 'geojson',
+    })).toBe('topojson_decode_only_geojson_run');
+  });
+
+  it('returns geojson decode path for non-topojson inputs', () => {
+    expect(resolveSimplifyExecutionPath({
+      fetchFormat: 'flatgeobuf',
+      simplifyAlgorithm: 'geojson',
+    })).toBe('geojson_decode_geojson_run');
+  });
+});
+
+describe('assessAnomalyRisk', () => {
+  it('detects polygon anomaly by edge ratio and area drift', () => {
+    const baseline = {
+      featureCount: 10,
+      vertexCount: 1000,
+      polygonCount: 10,
+      lineCount: 0,
+      totalArea: 100,
+      totalLength: 500,
+      maxEdgeLength: 10,
+      selfIntersectionCount: 0,
+    };
+    const candidate = {
+      ...baseline,
+      totalArea: 160,
+      maxEdgeLength: 200,
+      selfIntersectionCount: 3,
+    };
+
+    const assessed = assessAnomalyRisk({
+      profile: 'polygon',
+      baseline,
+      candidate,
+      thresholds: {
+        maxEdgeLengthRatio: 5,
+        maxAreaDriftPercent: 20,
+        maxSelfIntersectionCount: 0,
+        maxLineLengthDriftPercent: 50,
+      },
+    });
+
+    expect(assessed.isAnomalous).toBe(true);
+    expect(assessed.reasons).toContain('edgeLengthRatio>5');
+    expect(assessed.reasons).toContain('areaDriftPercent>20');
+    expect(assessed.reasons).toContain('selfIntersectionCount>0');
+  });
+
+  it('uses line drift threshold for line profile', () => {
+    const baseline = {
+      featureCount: 5,
+      vertexCount: 100,
+      polygonCount: 0,
+      lineCount: 5,
+      totalArea: 0,
+      totalLength: 100,
+      maxEdgeLength: 5,
+      selfIntersectionCount: 0,
+    };
+    const candidate = {
+      ...baseline,
+      totalLength: 200,
+      maxEdgeLength: 6,
+      totalArea: 1000,
+      selfIntersectionCount: 999,
+    };
+
+    const assessed = assessAnomalyRisk({
+      profile: 'line',
+      baseline,
+      candidate,
+      thresholds: {
+        maxEdgeLengthRatio: 10,
+        maxAreaDriftPercent: 1,
+        maxSelfIntersectionCount: 0,
+        maxLineLengthDriftPercent: 30,
+      },
+    });
+
+    expect(assessed.isAnomalous).toBe(true);
+    expect(assessed.reasons).toContain('lineLengthDriftPercent>30');
+    expect(assessed.reasons.some((reason) => reason.startsWith('areaDriftPercent'))).toBe(false);
+    expect(assessed.reasons.some((reason) => reason.startsWith('selfIntersectionCount'))).toBe(false);
+  });
+});

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts
@@ -183,6 +183,54 @@ const resolveSimplifyAlgorithm = (algorithm?: TransformSimplifyAlgorithm): Trans
   algorithm === 'geojson' ? 'geojson' : DEFAULT_SIMPLIFY_ALGORITHM
 );
 
+type SimplifyExecutionPath =
+  | 'topojson_decode_simplify_geojson_skip'
+  | 'topojson_decode_only_geojson_run'
+  | 'geojson_decode_geojson_run';
+
+export const resolveSimplifyExecutionPath = (params: {
+  fetchFormat?: string;
+  simplifyAlgorithm: TransformSimplifyAlgorithm;
+}): SimplifyExecutionPath => {
+  const isTopojsonInput = params.fetchFormat === 'topojson';
+  if (!isTopojsonInput) {
+    return 'geojson_decode_geojson_run';
+  }
+  return params.simplifyAlgorithm === 'topojson'
+    ? 'topojson_decode_simplify_geojson_skip'
+    : 'topojson_decode_only_geojson_run';
+};
+
+type TransformTraceLogLevel = 'off' | 'summary' | 'verbose';
+
+const TRACE_LOG_PRIORITY: Record<TransformTraceLogLevel, number> = {
+  off: 0,
+  summary: 1,
+  verbose: 2,
+};
+
+const normalizeTraceLogLevel = (level?: string): TransformTraceLogLevel => {
+  if (level === 'off' || level === 'summary' || level === 'verbose') {
+    return level;
+  }
+  return 'summary';
+};
+
+const shouldLogTransformTrace = (
+  configuredLevel: TransformTraceLogLevel,
+  requestedLevel: TransformTraceLogLevel,
+): boolean => TRACE_LOG_PRIORITY[configuredLevel] >= TRACE_LOG_PRIORITY[requestedLevel];
+
+const emitTransformTrace = (
+  configuredLevel: TransformTraceLogLevel,
+  requestedLevel: TransformTraceLogLevel,
+  message: string,
+  payload: Record<string, unknown>,
+): void => {
+  if (!shouldLogTransformTrace(configuredLevel, requestedLevel)) return;
+  console.info('[ShapeTransform][ExecutionTrace]', message, payload);
+};
+
 const metersPerPixel = (z: number): number => {
   return (2 * Math.PI * EARTH_RADIUS_METERS) / (MVT_EXTENT * Math.pow(2, z));
 };
@@ -207,7 +255,11 @@ type GeometryOps = {
   ) => boolean;
 };
 
-const createGeometryOps = (engine: GeometryEngine): GeometryOps => {
+const createGeometryOps = (
+  engine: GeometryEngine,
+  options?: { preserveTopology?: boolean },
+): GeometryOps => {
+  const preserveTopology = options?.preserveTopology ?? true;
   const simplifyCollection = (collection: FeatureCollection, zTarget: number, toleranceK: number): FeatureCollection => {
     const tolerance = resolveSimplifyToleranceDegrees(zTarget, toleranceK);
     if (!Number.isFinite(tolerance) || tolerance <= 0) return collection;
@@ -215,7 +267,7 @@ const createGeometryOps = (engine: GeometryEngine): GeometryOps => {
       tolerance,
       highQuality: false,
       mutate: false,
-      preserveTopology: true,
+      preserveTopology,
     });
     if (!simplified || simplified.type !== 'FeatureCollection') {
       throw new Error('simplify returned non-FeatureCollection');
@@ -230,7 +282,7 @@ const createGeometryOps = (engine: GeometryEngine): GeometryOps => {
       tolerance,
       highQuality: false,
       mutate: false,
-      preserveTopology: true,
+      preserveTopology,
     });
     if (!simplified || simplified.type !== 'Feature') {
       throw new Error('simplify returned non-Feature');
@@ -456,6 +508,253 @@ const countPolygonsFromGeometry = (geometry?: Geometry | null): number => {
     return Array.isArray(geometry.coordinates) ? geometry.coordinates.length : 0;
   }
   return 0;
+};
+
+const countLinesFromGeometry = (geometry?: Geometry | null): number => {
+  if (!geometry) return 0;
+  if (geometry.type === 'GeometryCollection') {
+    const geometries = Array.isArray(geometry.geometries) ? geometry.geometries : [];
+    return geometries.reduce((sum: number, child: Geometry) => sum + countLinesFromGeometry(child), 0);
+  }
+  if (geometry.type === 'LineString') return 1;
+  if (geometry.type === 'MultiLineString') {
+    return Array.isArray(geometry.coordinates) ? geometry.coordinates.length : 0;
+  }
+  return 0;
+};
+
+const segmentLength = (pointA: number[], pointB: number[]): number => {
+  const ax = pointA[0];
+  const ay = pointA[1];
+  const bx = pointB[0];
+  const by = pointB[1];
+  if (
+    ax === undefined
+    || ay === undefined
+    || bx === undefined
+    || by === undefined
+    || !Number.isFinite(ax)
+    || !Number.isFinite(ay)
+    || !Number.isFinite(bx)
+    || !Number.isFinite(by)
+  ) {
+    return 0;
+  }
+  const dx = bx - ax;
+  const dy = by - ay;
+  return Math.sqrt((dx * dx) + (dy * dy));
+};
+
+const collectLineLengths = (coords: number[][]): { total: number; max: number } => {
+  let total = 0;
+  let max = 0;
+  for (let index = 1; index < coords.length; index += 1) {
+    const current = coords[index];
+    const prev = coords[index - 1];
+    if (!current || !prev) continue;
+    const length = segmentLength(prev, current);
+    total += length;
+    if (length > max) {
+      max = length;
+    }
+  }
+  return { total, max };
+};
+
+const collectGeometryLengthMetrics = (geometry?: Geometry | null): { total: number; max: number } => {
+  if (!geometry) return { total: 0, max: 0 };
+  if (geometry.type === 'LineString') {
+    return collectLineLengths(Array.isArray(geometry.coordinates) ? geometry.coordinates as number[][] : []);
+  }
+  if (geometry.type === 'MultiLineString') {
+    let total = 0;
+    let max = 0;
+    const lines = Array.isArray(geometry.coordinates) ? geometry.coordinates : [];
+    for (const line of lines) {
+      const metrics = collectLineLengths(Array.isArray(line) ? line as number[][] : []);
+      total += metrics.total;
+      if (metrics.max > max) {
+        max = metrics.max;
+      }
+    }
+    return { total, max };
+  }
+  if (geometry.type === 'Polygon') {
+    let total = 0;
+    let max = 0;
+    const rings = Array.isArray(geometry.coordinates) ? geometry.coordinates : [];
+    for (const ring of rings) {
+      const metrics = collectLineLengths(Array.isArray(ring) ? ring as number[][] : []);
+      total += metrics.total;
+      if (metrics.max > max) {
+        max = metrics.max;
+      }
+    }
+    return { total, max };
+  }
+  if (geometry.type === 'MultiPolygon') {
+    let total = 0;
+    let max = 0;
+    const polygons = Array.isArray(geometry.coordinates) ? geometry.coordinates : [];
+    for (const polygon of polygons) {
+      if (!Array.isArray(polygon)) continue;
+      for (const ring of polygon) {
+        const metrics = collectLineLengths(Array.isArray(ring) ? ring as number[][] : []);
+        total += metrics.total;
+        if (metrics.max > max) {
+          max = metrics.max;
+        }
+      }
+    }
+    return { total, max };
+  }
+  if (geometry.type === 'GeometryCollection') {
+    let total = 0;
+    let max = 0;
+    const geometries = Array.isArray(geometry.geometries) ? geometry.geometries : [];
+    for (const child of geometries) {
+      const metrics = collectGeometryLengthMetrics(child);
+      total += metrics.total;
+      if (metrics.max > max) {
+        max = metrics.max;
+      }
+    }
+    return { total, max };
+  }
+  return { total: 0, max: 0 };
+};
+
+type CollectionAnomalyMetrics = {
+  featureCount: number;
+  vertexCount: number;
+  polygonCount: number;
+  lineCount: number;
+  totalArea: number;
+  totalLength: number;
+  maxEdgeLength: number;
+  selfIntersectionCount: number;
+};
+
+const collectCollectionAnomalyMetrics = (
+  collection: FeatureCollection,
+  geometryOps: GeometryOps,
+): CollectionAnomalyMetrics => {
+  let vertexCount = 0;
+  let polygonCount = 0;
+  let lineCount = 0;
+  let totalArea = 0;
+  let totalLength = 0;
+  let maxEdgeLength = 0;
+  let selfIntersectionCount = 0;
+  for (const feature of collection.features) {
+    if (!feature?.geometry) continue;
+    const geometry = feature.geometry;
+    vertexCount += countVerticesFromGeometry(geometry);
+    polygonCount += countPolygonsFromGeometry(geometry);
+    lineCount += countLinesFromGeometry(geometry);
+    if (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+      totalArea += Math.abs(geometryOps.area(feature as Feature<Geometry>));
+      selfIntersectionCount += geometryOps.countSelfIntersections(geometry);
+    }
+    const lineMetrics = collectGeometryLengthMetrics(geometry);
+    totalLength += lineMetrics.total;
+    if (lineMetrics.max > maxEdgeLength) {
+      maxEdgeLength = lineMetrics.max;
+    }
+  }
+  return {
+    featureCount: collection.features.length,
+    vertexCount,
+    polygonCount,
+    lineCount,
+    totalArea,
+    totalLength,
+    maxEdgeLength,
+    selfIntersectionCount,
+  };
+};
+
+type AnomalyProfile = 'polygon' | 'line';
+
+type AnomalyAssessment = {
+  isAnomalous: boolean;
+  score: number;
+  edgeLengthRatio: number;
+  areaDriftPercent: number;
+  lineLengthDriftPercent: number;
+  selfIntersectionCount: number;
+  reasons: string[];
+};
+
+const safeRatio = (numerator: number, denominator: number): number => {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) {
+    return 1;
+  }
+  return numerator / denominator;
+};
+
+export const assessAnomalyRisk = (params: {
+  profile: AnomalyProfile;
+  baseline: CollectionAnomalyMetrics;
+  candidate: CollectionAnomalyMetrics;
+  thresholds?: {
+    maxEdgeLengthRatio?: number;
+    maxAreaDriftPercent?: number;
+    maxSelfIntersectionCount?: number;
+    maxLineLengthDriftPercent?: number;
+  };
+}): AnomalyAssessment => {
+  const maxEdgeLengthRatio = params.thresholds?.maxEdgeLengthRatio ?? Number.POSITIVE_INFINITY;
+  const maxAreaDriftPercent = params.thresholds?.maxAreaDriftPercent ?? Number.POSITIVE_INFINITY;
+  const maxSelfIntersectionCount = params.thresholds?.maxSelfIntersectionCount ?? Number.POSITIVE_INFINITY;
+  const maxLineLengthDriftPercent = params.thresholds?.maxLineLengthDriftPercent ?? Number.POSITIVE_INFINITY;
+
+  const edgeLengthRatio = safeRatio(params.candidate.maxEdgeLength, params.baseline.maxEdgeLength);
+  const areaDriftPercent = params.profile === 'polygon' && params.baseline.totalArea > 0
+    ? Math.abs(params.candidate.totalArea - params.baseline.totalArea) / params.baseline.totalArea * 100
+    : 0;
+  const lineLengthDriftPercent = params.baseline.totalLength > 0
+    ? Math.abs(params.candidate.totalLength - params.baseline.totalLength) / params.baseline.totalLength * 100
+    : 0;
+  const selfIntersectionCount = params.candidate.selfIntersectionCount;
+
+  const reasons: string[] = [];
+  if (edgeLengthRatio > maxEdgeLengthRatio) {
+    reasons.push(`edgeLengthRatio>${maxEdgeLengthRatio}`);
+  }
+  if (params.profile === 'polygon' && areaDriftPercent > maxAreaDriftPercent) {
+    reasons.push(`areaDriftPercent>${maxAreaDriftPercent}`);
+  }
+  if (params.profile === 'polygon' && selfIntersectionCount > maxSelfIntersectionCount) {
+    reasons.push(`selfIntersectionCount>${maxSelfIntersectionCount}`);
+  }
+  if (params.profile === 'line' && lineLengthDriftPercent > maxLineLengthDriftPercent) {
+    reasons.push(`lineLengthDriftPercent>${maxLineLengthDriftPercent}`);
+  }
+
+  const edgeScore = Number.isFinite(maxEdgeLengthRatio) && maxEdgeLengthRatio > 0
+    ? edgeLengthRatio / maxEdgeLengthRatio
+    : 0;
+  const areaScore = params.profile === 'polygon' && Number.isFinite(maxAreaDriftPercent) && maxAreaDriftPercent > 0
+    ? areaDriftPercent / maxAreaDriftPercent
+    : 0;
+  const selfIntersectionScore = params.profile === 'polygon' && Number.isFinite(maxSelfIntersectionCount)
+    ? Math.max(0, selfIntersectionCount - maxSelfIntersectionCount)
+    : 0;
+  const lineScore = params.profile === 'line' && Number.isFinite(maxLineLengthDriftPercent) && maxLineLengthDriftPercent > 0
+    ? lineLengthDriftPercent / maxLineLengthDriftPercent
+    : 0;
+  const score = edgeScore + areaScore + selfIntersectionScore + lineScore;
+
+  return {
+    isAnomalous: reasons.length > 0,
+    score,
+    edgeLengthRatio,
+    areaDriftPercent,
+    lineLengthDriftPercent,
+    selfIntersectionCount,
+    reasons,
+  };
 };
 
 const repairCollectionSelfIntersections = (
@@ -810,6 +1109,185 @@ const computeRingArea = (ring: number[][]): number | null => {
     sum += (x1 * y2) - (x2 * y1);
   }
   return sum / 2;
+};
+
+const dedupeConsecutiveCoords = (coords: number[][], epsilon: number): number[][] => {
+  if (coords.length === 0) return coords;
+  if (epsilon <= 0) return coords;
+  const deduped: number[][] = [coords[0] as number[]];
+  for (let index = 1; index < coords.length; index += 1) {
+    const current = coords[index];
+    const previous = deduped[deduped.length - 1];
+    if (!current || !previous) continue;
+    const dx = Math.abs((current[0] ?? 0) - (previous[0] ?? 0));
+    const dy = Math.abs((current[1] ?? 0) - (previous[1] ?? 0));
+    if (dx <= epsilon && dy <= epsilon) continue;
+    deduped.push(current);
+  }
+  return deduped;
+};
+
+const ensureClosedRingCoords = (ring: number[][]): number[][] => {
+  if (ring.length === 0) return ring;
+  const first = ring[0];
+  const last = ring[ring.length - 1];
+  if (isSameCoord(first, last)) return ring;
+  return [...ring, first as number[]];
+};
+
+const normalizeRingOrientation = (ring: number[][], clockwise: boolean): number[][] => {
+  const area = computeRingArea(ring);
+  if (area === null || Math.abs(area) < 1e-15) return ring;
+  const isClockwise = area < 0;
+  if (isClockwise === clockwise) return ring;
+  return [...ring].reverse();
+};
+
+const sanitizePolygonRings = (params: {
+  rings: number[][][];
+  epsilon: number;
+  minRingAreaThreshold: number;
+  normalizeOrientation: boolean;
+}): number[][][] => {
+  const out: number[][][] = [];
+  for (let index = 0; index < params.rings.length; index += 1) {
+    const ring = params.rings[index];
+    if (!Array.isArray(ring)) continue;
+    let nextRing = dedupeConsecutiveCoords(ring as number[][], params.epsilon);
+    nextRing = ensureClosedRingCoords(nextRing);
+    if (nextRing.length < 4) continue;
+    const area = computeRingArea(nextRing);
+    if (area === null) continue;
+    if (params.minRingAreaThreshold > 0 && Math.abs(area) < params.minRingAreaThreshold) {
+      continue;
+    }
+    if (params.normalizeOrientation) {
+      const isOuter = index === 0;
+      nextRing = normalizeRingOrientation(nextRing, !isOuter);
+    }
+    out.push(nextRing);
+  }
+  return out;
+};
+
+const sanitizeGeometryForIntakeGuard = (params: {
+  geometry: Geometry;
+  epsilon: number;
+  minRingAreaThreshold: number;
+  normalizeRingOrientation: boolean;
+}): Geometry | null => {
+  const { geometry } = params;
+  if (geometry.type === 'LineString') {
+    const deduped = dedupeConsecutiveCoords(geometry.coordinates as number[][], params.epsilon);
+    if (deduped.length < 2) return null;
+    return { ...geometry, coordinates: deduped };
+  }
+  if (geometry.type === 'MultiLineString') {
+    const lines = (geometry.coordinates ?? [])
+      .map((line) => dedupeConsecutiveCoords(line as number[][], params.epsilon))
+      .filter((line) => line.length >= 2);
+    if (lines.length === 0) return null;
+    return { ...geometry, coordinates: lines };
+  }
+  if (geometry.type === 'Polygon') {
+    const rings = sanitizePolygonRings({
+      rings: geometry.coordinates as number[][][],
+      epsilon: params.epsilon,
+      minRingAreaThreshold: params.minRingAreaThreshold,
+      normalizeOrientation: params.normalizeRingOrientation,
+    });
+    if (rings.length === 0) return null;
+    return { ...geometry, coordinates: rings };
+  }
+  if (geometry.type === 'MultiPolygon') {
+    const polygons = (geometry.coordinates ?? [])
+      .map((polygon) => sanitizePolygonRings({
+        rings: polygon as number[][][],
+        epsilon: params.epsilon,
+        minRingAreaThreshold: params.minRingAreaThreshold,
+        normalizeOrientation: params.normalizeRingOrientation,
+      }))
+      .filter((polygon) => polygon.length > 0);
+    if (polygons.length === 0) return null;
+    return { ...geometry, coordinates: polygons };
+  }
+  if (geometry.type === 'GeometryCollection') {
+    const geometries = (geometry.geometries ?? [])
+      .map((child) => sanitizeGeometryForIntakeGuard({
+        geometry: child,
+        epsilon: params.epsilon,
+        minRingAreaThreshold: params.minRingAreaThreshold,
+        normalizeRingOrientation: params.normalizeRingOrientation,
+      }))
+      .filter((child): child is Geometry => Boolean(child));
+    if (geometries.length === 0) return null;
+    return { ...geometry, geometries };
+  }
+  return geometry;
+};
+
+const applyGeometryIntakeGuard = (params: {
+  collection: FeatureCollection;
+  validationLevel: 'off' | 'basic' | 'strict';
+  dedupeEpsilon: number;
+  minRingAreaThreshold: number;
+  normalizeRingOrientation: boolean;
+  geometryOps: GeometryOps;
+}): {
+  collection: FeatureCollection;
+  modifiedFeatureCount: number;
+  droppedFeatureCount: number;
+} => {
+  if (params.validationLevel === 'off') {
+    return {
+      collection: params.collection,
+      modifiedFeatureCount: 0,
+      droppedFeatureCount: 0,
+    };
+  }
+  let modifiedFeatureCount = 0;
+  let droppedFeatureCount = 0;
+  const features: Feature[] = [];
+  for (const feature of params.collection.features) {
+    if (!feature?.geometry) {
+      if (params.validationLevel === 'strict') {
+        droppedFeatureCount += 1;
+        continue;
+      }
+      features.push(feature);
+      continue;
+    }
+    const normalizedGeometry = sanitizeGeometryForIntakeGuard({
+      geometry: feature.geometry,
+      epsilon: Math.max(0, params.dedupeEpsilon),
+      minRingAreaThreshold: Math.max(0, params.minRingAreaThreshold),
+      normalizeRingOrientation: params.normalizeRingOrientation,
+    });
+    if (!normalizedGeometry) {
+      droppedFeatureCount += 1;
+      continue;
+    }
+    const valid = params.geometryOps.isValid(normalizedGeometry);
+    if (params.validationLevel === 'strict' && !valid) {
+      droppedFeatureCount += 1;
+      continue;
+    }
+    if (normalizedGeometry !== feature.geometry) {
+      modifiedFeatureCount += 1;
+    }
+    features.push({
+      ...feature,
+      geometry: normalizedGeometry,
+    });
+  }
+  return {
+    collection: {
+      ...params.collection,
+      features,
+    },
+    modifiedFeatureCount,
+    droppedFeatureCount,
+  };
 };
 
 const countSelfIntersections = (geometry: Geometry, geometryOps: GeometryOps): number => (
@@ -1252,7 +1730,15 @@ export const createTransformByBandHandler = (
     bandCount: context.bands.length,
     geometryEngine: context.transformConfig.geometryEngine ?? 'turf',
   });
-  const { ephemeralDB, transformConfig, bands, abortSignal, featureIdAllowlist } = context;
+  const {
+    ephemeralDB,
+    fetchConfig,
+    transformConfig,
+    vtConfig,
+    bands,
+    abortSignal,
+    featureIdAllowlist,
+  } = context;
   const taskQueue = new VtTaskQueueDb();
   const taskProgressRange = {
     transformStart: 0,
@@ -1468,10 +1954,33 @@ export const createTransformByBandHandler = (
   }
   const simplifyAlgorithm = resolveSimplifyAlgorithm(transformConfig.simplifyAlgorithm);
   const geometryEngine = transformConfig.geometryEngine ?? 'turf';
+  const preserveTopology = transformConfig.preserveTopology ?? true;
+  const traceLogLevel = normalizeTraceLogLevel(transformConfig.executionLogLevel);
+  const anomalyDetectionConfig = {
+    enabled: transformConfig.anomalyDetection?.enabled ?? false,
+    maxEdgeLengthRatio: transformConfig.anomalyDetection?.maxEdgeLengthRatio ?? 12,
+    maxAreaDriftPercent: transformConfig.anomalyDetection?.maxAreaDriftPercent ?? 35,
+    maxSelfIntersectionCount: transformConfig.anomalyDetection?.maxSelfIntersectionCount ?? 0,
+    maxLineLengthDriftPercent: transformConfig.anomalyDetection?.maxLineLengthDriftPercent ?? 45,
+  };
+  const anomalyRetryConfig = {
+    enabled: transformConfig.anomalyRetry?.enabled ?? false,
+    maxRetries: Math.max(0, transformConfig.anomalyRetry?.maxRetries ?? 0),
+    toleranceScale: Math.min(1, Math.max(0.1, transformConfig.anomalyRetry?.toleranceScale ?? 0.7)),
+    fallbackMode: transformConfig.anomalyRetry?.fallbackMode ?? 'best_score',
+  } as const;
+  const intakeGuardConfig = {
+    validationLevel: fetchConfig.geometryIntakeGuard?.validationLevel ?? 'off',
+    dedupeEpsilon: fetchConfig.geometryIntakeGuard?.dedupeEpsilon ?? 0,
+    minRingAreaThreshold: fetchConfig.geometryIntakeGuard?.minRingAreaThreshold ?? 0,
+    normalizeRingOrientation: fetchConfig.geometryIntakeGuard?.normalizeRingOrientation ?? false,
+    keepBaselineSnapshot: fetchConfig.geometryIntakeGuard?.keepBaselineSnapshot ?? false,
+  } as const;
+  const vtOutputQualityGuard = vtConfig.outputQualityGuard;
   if (geometryEngine !== 'turf') {
     throw new Error(`transform failed: unknown geometryEngine (${String(geometryEngine)})`);
   }
-  const geometryOps = createGeometryOps(geometryEngine);
+  const geometryOps = createGeometryOps(geometryEngine, { preserveTopology });
   const bandMap = new Map(bands.map((band) => [band.bandIndex, band] as const));
   let debugTaskId: string | null = null;
   let debugTaskStartedAt: number | null = null;
@@ -1529,10 +2038,24 @@ export const createTransformByBandHandler = (
         appliedTolerance: tolerance,
       }));
     }
+    emitTransformTrace(traceLogLevel, 'summary', 'task-config', {
+      sessionId: String(task.nodeId),
+      taskId,
+      stage: 'transform',
+      simplifyAlgorithm,
+      preserveTopology,
+      tolerance,
+      fetchIntakeGuard: intakeGuardConfig,
+      anomalyDetection: anomalyDetectionConfig,
+      anomalyRetry: anomalyRetryConfig,
+      vtOutputQualityGuard: vtOutputQualityGuard ?? null,
+    });
 
     let workingCollection: FeatureCollection | null = null;
     let simplified: FeatureCollection | null = null;
     let outputCollection: FeatureCollection | null = null;
+    let baselineMetrics: CollectionAnomalyMetrics | null = null;
+    let anomalyProfile: AnomalyProfile = input.domainType === 'route' ? 'line' : 'polygon';
     let stageLabel = 'start';
     let inputPolygonCount = 0;
     let inputVertexCount = 0;
@@ -1623,6 +2146,20 @@ export const createTransformByBandHandler = (
         byteLength: fetchCache.data.byteLength,
         elapsedMs: fetchWaitStartedAt ? Date.now() - fetchWaitStartedAt : null,
       });
+      const executionPath = resolveSimplifyExecutionPath({
+        fetchFormat: fetchCache.format,
+        simplifyAlgorithm,
+      });
+      emitTransformTrace(traceLogLevel, 'summary', 'execution-path', {
+        sessionId: String(task.nodeId),
+        taskId,
+        stage: 'decode',
+        algorithm: simplifyAlgorithm,
+        executionPath,
+        fetchFormat: fetchCache.format ?? 'unknown',
+        compression: fetchCache.compression ?? null,
+        preserveTopology,
+      });
       await updateTaskPhase(taskId, 'fetch-cache:done', taskProgressRange.fetchEnd);
 
       stageLabel = 'decode';
@@ -1645,6 +2182,16 @@ export const createTransformByBandHandler = (
         return { status: 'failed', errorMessage: 'transform failed: empty fetch cache' };
       }
       logDebugPhase('decode:done', { featureCount: collection.features.length });
+      emitTransformTrace(traceLogLevel, 'summary', 'decode-done', {
+        sessionId: String(task.nodeId),
+        taskId,
+        stage: 'decode',
+        outputFeatureCount: collection.features.length,
+        outputVertexCount: collection.features.reduce(
+          (sum, feature) => sum + countVerticesFromGeometry(feature?.geometry ?? null),
+          0,
+        ),
+      });
       await updateTaskPhase(taskId, 'decode:done', taskProgressRange.decodeEnd);
 
       if (featureIdAllowlist && featureIdAllowlist.size > 0) {
@@ -1684,6 +2231,29 @@ export const createTransformByBandHandler = (
         }
       }
       workingCollection = collection;
+      if (intakeGuardConfig.validationLevel !== 'off') {
+        stageLabel = 'intake-guard';
+        await updateTaskPhase(taskId, 'intake-guard:start', taskProgressRange.prepareStart);
+        const guarded = applyGeometryIntakeGuard({
+          collection: workingCollection,
+          validationLevel: intakeGuardConfig.validationLevel,
+          dedupeEpsilon: intakeGuardConfig.dedupeEpsilon,
+          minRingAreaThreshold: intakeGuardConfig.minRingAreaThreshold,
+          normalizeRingOrientation: intakeGuardConfig.normalizeRingOrientation,
+          geometryOps,
+        });
+        workingCollection = guarded.collection;
+        emitTransformTrace(traceLogLevel, 'summary', 'intake-guard', {
+          sessionId: String(task.nodeId),
+          taskId,
+          stage: 'prepare',
+          validationLevel: intakeGuardConfig.validationLevel,
+          modifiedFeatureCount: guarded.modifiedFeatureCount,
+          droppedFeatureCount: guarded.droppedFeatureCount,
+          outputFeatureCount: guarded.collection.features.length,
+        });
+        await updateTaskPhase(taskId, 'intake-guard:done', taskProgressRange.prepareEnd);
+      }
       if (enableFeatureFiltering && transformConfig.enableFeatureFiltering) {
         stageLabel = 'filter:featureFiltering';
         await updateTaskPhase(taskId, 'filtering:start', taskProgressRange.decodeEnd);
@@ -1736,6 +2306,21 @@ export const createTransformByBandHandler = (
       const inputPolygonCounts = inputStats.polygonCounts;
       inputPolygonCount = inputPolygonCounts.reduce((sum, value) => sum + value, 0);
       inputVertexCount = inputStats.vertexCount;
+      baselineMetrics = collectCollectionAnomalyMetrics(inputCollection, geometryOps);
+      if (input.domainType === 'route') {
+        anomalyProfile = 'line';
+      } else if (baselineMetrics.lineCount > 0 && baselineMetrics.polygonCount === 0) {
+        anomalyProfile = 'line';
+      } else {
+        anomalyProfile = 'polygon';
+      }
+      emitTransformTrace(traceLogLevel, 'verbose', 'baseline-metrics', {
+        sessionId: String(task.nodeId),
+        taskId,
+        stage: 'prepare',
+        profile: anomalyProfile,
+        metrics: baselineMetrics,
+      });
       await updateTaskPhase(taskId, 'prepare:counts:done', taskProgressRange.prepareEnd);
       await reportPolygonProgress(taskId, 0, inputPolygonCount);
       if (input.adminLevel === 0 && band.zMax >= 6) {
@@ -1814,6 +2399,17 @@ export const createTransformByBandHandler = (
           await reportPolygonProgress(taskId, processedPolygonCount, inputPolygonCount);
         };
         await updateTaskPhase(taskId, 'simplify-only:start', taskProgressRange.simplifyStart);
+        emitTransformTrace(traceLogLevel, 'summary', 'simplify-start', {
+          sessionId: String(task.nodeId),
+          taskId,
+          stage: 'simplify',
+          algorithm: simplifyAlgorithm,
+          tolerance,
+          preserveTopology,
+          inputFeatureCount,
+          inputPolygonCount,
+          inputVertexCount,
+        });
         const skipGeojsonSimplify = fetchCache.format === 'topojson' && simplifyAlgorithm === 'topojson';
         if (skipGeojsonSimplify) {
           simplified = inputCollection;
@@ -1837,11 +2433,170 @@ export const createTransformByBandHandler = (
           });
           processedPolygonCount = inputPolygonCount;
         }
+        if (simplified && baselineMetrics && anomalyDetectionConfig.enabled && intakeGuardConfig.keepBaselineSnapshot) {
+          type Candidate = {
+            label: string;
+            collection: FeatureCollection;
+            tolerance: number;
+            algorithm: TransformSimplifyAlgorithm;
+            assessment: AnomalyAssessment;
+          };
+          const evaluateCandidate = (
+            label: string,
+            collection: FeatureCollection,
+            candidateTolerance: number,
+            candidateAlgorithm: TransformSimplifyAlgorithm,
+          ): Candidate => {
+            const metrics = collectCollectionAnomalyMetrics(collection, geometryOps);
+            const assessment = assessAnomalyRisk({
+              profile: anomalyProfile,
+              baseline: baselineMetrics as CollectionAnomalyMetrics,
+              candidate: metrics,
+              thresholds: anomalyDetectionConfig,
+            });
+            return {
+              label,
+              collection,
+              tolerance: candidateTolerance,
+              algorithm: candidateAlgorithm,
+              assessment,
+            };
+          };
+
+          const candidates: Candidate[] = [evaluateCandidate('initial', simplified, tolerance, simplifyAlgorithm)];
+          if (anomalyRetryConfig.enabled && candidates[0]?.assessment.isAnomalous) {
+            for (let retryIndex = 0; retryIndex < anomalyRetryConfig.maxRetries; retryIndex += 1) {
+              const retryTolerance = tolerance * Math.pow(anomalyRetryConfig.toleranceScale, retryIndex + 1);
+              const retryCollection = await runWithStallTimeout({
+                promise: runStageWithLabel('simplify-only:retry-anomaly', () => (
+                  simplifyOnlyCollection(inputCollection, band.zMax, retryTolerance, geometryOps)
+                )),
+                stage: 'simplify-only:retry-anomaly',
+                nodeId: String(task.nodeId),
+                taskId,
+                timeoutMs: 300000,
+                getLastProgressAt: () => Date.now(),
+              });
+              const retryCandidate = evaluateCandidate(
+                `retry-${retryIndex + 1}`,
+                retryCollection,
+                retryTolerance,
+                simplifyAlgorithm,
+              );
+              candidates.push(retryCandidate);
+              emitTransformTrace(traceLogLevel, 'summary', 'anomaly-retry', {
+                sessionId: String(task.nodeId),
+                taskId,
+                stage: 'simplify',
+                retryIndex: retryIndex + 1,
+                profile: anomalyProfile,
+                tolerance: retryTolerance,
+                score: retryCandidate.assessment.score,
+                reasons: retryCandidate.assessment.reasons,
+                accepted: !retryCandidate.assessment.isAnomalous,
+              });
+              if (!retryCandidate.assessment.isAnomalous) {
+                break;
+              }
+            }
+          }
+
+          const initialCandidate = candidates[0];
+          if (!initialCandidate) {
+            throw new Error('transform failed: anomaly candidate initialization failed');
+          }
+          const pickBestCandidate = (list: Candidate[], fallback: Candidate): Candidate => {
+            const sorted = [...list].sort((a, b) => a.assessment.score - b.assessment.score);
+            return sorted[0] ?? fallback;
+          };
+          let selectedCandidate: Candidate = pickBestCandidate(candidates, initialCandidate);
+          const allAnomalous = candidates.every((candidate) => candidate.assessment.isAnomalous);
+          if (allAnomalous) {
+            if (anomalyRetryConfig.fallbackMode === 'disable_simplify') {
+              const fallbackCandidate = evaluateCandidate(
+                'fallback-disable-simplify',
+                inputCollection,
+                0,
+                simplifyAlgorithm,
+              );
+              candidates.push(fallbackCandidate);
+              selectedCandidate = fallbackCandidate;
+            } else if (anomalyRetryConfig.fallbackMode === 'switch_algorithm') {
+              const switchedAlgorithm: TransformSimplifyAlgorithm = simplifyAlgorithm === 'topojson'
+                ? 'geojson'
+                : 'topojson';
+              if (switchedAlgorithm === 'geojson') {
+                const switchedTolerance = tolerance * anomalyRetryConfig.toleranceScale;
+                const switchedCollection = await runWithStallTimeout({
+                  promise: runStageWithLabel('simplify-only:fallback-switch-geojson', () => (
+                    simplifyOnlyCollection(inputCollection, band.zMax, switchedTolerance, geometryOps)
+                  )),
+                  stage: 'simplify-only:fallback-switch-geojson',
+                  nodeId: String(task.nodeId),
+                  taskId,
+                  timeoutMs: 300000,
+                  getLastProgressAt: () => Date.now(),
+                });
+                const switchedCandidate = evaluateCandidate(
+                  'fallback-switch-algorithm',
+                  switchedCollection,
+                  switchedTolerance,
+                  switchedAlgorithm,
+                );
+                candidates.push(switchedCandidate);
+                selectedCandidate = pickBestCandidate([selectedCandidate, switchedCandidate], selectedCandidate);
+              } else {
+                const fallbackCandidate = evaluateCandidate(
+                  'fallback-switch-unavailable-use-input',
+                  inputCollection,
+                  0,
+                  switchedAlgorithm,
+                );
+                candidates.push(fallbackCandidate);
+                selectedCandidate = pickBestCandidate([selectedCandidate, fallbackCandidate], selectedCandidate);
+              }
+            }
+          }
+
+          simplified = selectedCandidate.collection;
+          emitTransformTrace(traceLogLevel, 'summary', 'anomaly-selection', {
+            sessionId: String(task.nodeId),
+            taskId,
+            stage: 'simplify',
+            profile: anomalyProfile,
+            selected: {
+              label: selectedCandidate.label,
+              algorithm: selectedCandidate.algorithm,
+              tolerance: selectedCandidate.tolerance,
+              score: selectedCandidate.assessment.score,
+              reasons: selectedCandidate.assessment.reasons,
+            },
+            totalCandidates: candidates.length,
+          });
+        } else if (anomalyDetectionConfig.enabled && !intakeGuardConfig.keepBaselineSnapshot) {
+          emitTransformTrace(traceLogLevel, 'summary', 'anomaly-skipped', {
+            sessionId: String(task.nodeId),
+            taskId,
+            stage: 'simplify',
+            reason: 'baseline snapshot disabled',
+          });
+        }
         logDebugPhase('simplify:done', {
           featureCount: simplified?.features.length ?? 0,
           polygonCount: inputPolygonCount,
           algorithm: simplifyAlgorithm,
           skipped: skipGeojsonSimplify,
+        });
+        emitTransformTrace(traceLogLevel, 'summary', 'simplify-done', {
+          sessionId: String(task.nodeId),
+          taskId,
+          stage: 'simplify',
+          algorithm: simplifyAlgorithm,
+          skipGeojsonSimplify,
+          outputFeatureCount: simplified?.features.length ?? 0,
+          outputVertexCount: simplified
+            ? simplified.features.reduce((sum, feature) => sum + countVerticesFromGeometry(feature.geometry), 0)
+            : 0,
         });
         console.log('[ShapeTransform][SimplifyOnlyMetrics] done', {
           nodeId: task.nodeId,
@@ -2206,21 +2961,31 @@ export const createTransformByBandHandler = (
         };
         vertexLimitStats = { maxVertexCount, overLimitFeatureCount };
       }
-      const repairedSimplified = repairCollectionSelfIntersections(
-        adjustedSimplified,
-        geometryOps,
-        geometryEngine,
-      );
-      if (repairedSimplified.repairedFeatureCount > 0) {
-        console.info('[ShapeTransform][SimplifyOnlyMetrics] repaired self-intersections after simplify', {
-          nodeId: task.nodeId,
+      if (anomalyProfile === 'polygon') {
+        const repairedSimplified = repairCollectionSelfIntersections(
+          adjustedSimplified,
+          geometryOps,
+          geometryEngine,
+        );
+        if (repairedSimplified.repairedFeatureCount > 0) {
+          console.info('[ShapeTransform][SimplifyOnlyMetrics] repaired self-intersections after simplify', {
+            nodeId: task.nodeId,
+            taskId,
+            bandIndex: input.bandIndex,
+            zTarget: band.zMax,
+            repairedFeatures: repairedSimplified.repairedFeatureCount,
+          });
+        }
+        simplified = repairedSimplified.collection;
+      } else {
+        simplified = adjustedSimplified;
+        emitTransformTrace(traceLogLevel, 'summary', 'polygon-repair-skipped', {
+          sessionId: String(task.nodeId),
           taskId,
-          bandIndex: input.bandIndex,
-          zTarget: band.zMax,
-          repairedFeatures: repairedSimplified.repairedFeatureCount,
+          stage: 'simplify',
+          profile: anomalyProfile,
         });
       }
-      simplified = repairedSimplified.collection;
 
       const simplifiedFeatureCount = simplified.features.length;
       stageLabel = 'validate:vertex-limit';
@@ -2333,7 +3098,7 @@ export const createTransformByBandHandler = (
         }
       }
 
-      const outputCollectionValue: FeatureCollection = {
+      let outputCollectionValue: FeatureCollection = {
         type: 'FeatureCollection',
         features,
       };
@@ -2355,6 +3120,47 @@ export const createTransformByBandHandler = (
             totalPolygons: inputPolygonCount,
           },
         };
+      }
+      if (vtOutputQualityGuard?.enabled && baselineMetrics) {
+        const isWithinZoomRange = band.zMax >= vtOutputQualityGuard.minZoom
+          && band.zMax <= vtOutputQualityGuard.maxZoom;
+        if (isWithinZoomRange) {
+          const outputMetrics = collectCollectionAnomalyMetrics(outputCollectionValue, geometryOps);
+          const outputAssessment = assessAnomalyRisk({
+            profile: anomalyProfile,
+            baseline: baselineMetrics,
+            candidate: outputMetrics,
+            thresholds: anomalyDetectionConfig,
+          });
+          emitTransformTrace(traceLogLevel, 'summary', 'vt-quality-guard', {
+            sessionId: String(task.nodeId),
+            taskId,
+            stage: 'output',
+            profile: anomalyProfile,
+            zTarget: band.zMax,
+            actionOnAnomaly: vtOutputQualityGuard.actionOnAnomaly,
+            assessment: outputAssessment,
+          });
+          if (outputAssessment.isAnomalous && vtOutputQualityGuard.actionOnAnomaly === 'drop_tile') {
+            await reportPolygonProgress(taskId, inputPolygonCount, inputPolygonCount);
+            return {
+              status: 'completed',
+              progress: 100,
+              display: {
+                kind: 'info',
+                key: 'stage.taskWarning.vtQualityGuardDropped',
+                params: {
+                  score: outputAssessment.score.toFixed(3),
+                  reasons: outputAssessment.reasons.join(','),
+                },
+              },
+              outputData: {
+                processedPolygons: inputPolygonCount,
+                totalPolygons: inputPolygonCount,
+              },
+            };
+          }
+        }
       }
 
       const boundaryDiagnostics = buildBoundaryDiagnostics(outputCollectionValue);

--- a/plans/shape-step4-anomaly-guard-controls-execplan.md
+++ b/plans/shape-step4-anomaly-guard-controls-execplan.md
@@ -1,0 +1,94 @@
+# Shape Step4 Anomaly Guard Controls and Transform Retry Diagnostics
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document is maintained under `PLANS.md` requirements in the repository root.
+
+## Purpose / Big Picture
+
+After this change, users can explicitly configure and observe how Step4 transform simplification is executed (`topojson` or `geojson`), detect anomalous geometry outputs (triangle-like distortions), and automatically retry with safer simplification parameters. The behavior is visible through structured logs and new Step4 cards for Fetch, Transform, and VT.
+
+## Progress
+
+- [x] (2026-02-16 08:45 JST) Created issue #318, set Project status to In Progress, and created branch `codex/feat/shape/step4-anomaly-guard-controls`.
+- [x] (2026-02-16 08:46 JST) Created this ExecPlan and aligned scope with approved DoD.
+- [x] (2026-02-16 08:51 JST) Implemented build-config type extensions for Fetch/Transform/VT guard settings in `packages/gis-sdk/src/config.ts` and defaults in `packages/shape-api/src/defaults.ts`.
+- [x] (2026-02-16 08:52 JST) Implemented Step4 UI cards for Fetch/Transform/VT and algorithm-specific control toggles.
+- [x] (2026-02-16 08:54 JST) Added transform execution tracing logs and path classification (`resolveSimplifyExecutionPath`).
+- [x] (2026-02-16 08:54 JST) Added anomaly scoring and auto-retry/fallback selection in transform handler, with route-like profiles skipping polygon repair.
+- [x] (2026-02-16 08:55 JST) Added/updated tests and ran build/typecheck plus targeted vitest commands successfully.
+- [x] (2026-02-16 08:55 JST) Updated `TASKS.md` operation log with success and blocked evidence.
+
+## Surprises & Discoveries
+
+- Observation: `createTransformByBandHandler.ts` already has extensive diagnostics, simplify retry for vertex limits, and post-simplify self-intersection repair.
+  Evidence: file inspection around `simplify-only` section and vertex-limit retry block.
+- Observation: workspace-wide `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` currently fails due unrelated pre-existing shape-plugin tests (`db.delete is not a function`).
+  Evidence: failures in `shapeFetchStage.unit.test.ts` and `shapePipeline*` helper tests, while newly added targeted tests pass.
+
+## Decision Log
+
+- Decision: Extend the existing transform diagnostics path instead of introducing a separate transform pipeline.
+  Rationale: Keeps risk low, preserves current behavior, and localizes changes to one stage handler.
+  Date/Author: 2026-02-16 / Codex
+
+## Outcomes & Retrospective
+
+The implementation now provides Step4 controls and runtime observability for simplification path diagnosis, plus anomaly scoring and deterministic retry fallback in transform. The key user-visible gain is immediate path discrimination in logs between topojson and geojson routes and configurable anomaly suppression behavior. A remaining gap is unrelated legacy test instability in parts of shape-plugin test suite; targeted tests around the new behavior are green.
+
+## Context and Orientation
+
+`plugins/shape-plugin/src/ui/components/build-config/ShapeBuildConfigStep.tsx` composes Step4 cards in the order Fetch → Transform → VT. `TransformConfigSection.tsx` currently exposes algorithm selection but not anomaly controls. Runtime transform behavior is implemented in `packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts`, and build-config types are defined in `packages/gis-sdk/src/config.ts` with defaults in `packages/shape-api/src/defaults.ts`.
+
+In this plan, “anomaly” means an output geometry that deviates beyond configured thresholds (for example, edge-length jump ratio, area drift, or unexpected self-intersections). “Auto-retry” means rerunning simplify with reduced tolerance and selecting a safer candidate by deterministic policy.
+
+## Plan of Work
+
+First, extend shared config types for three new control groups: Fetch intake guard, Transform anomaly detection/retry/logging, and VT output quality guard. Then, wire Step4 UI cards to these fields while preserving backward compatibility via defaults.
+
+Next, add structured transform execution logs that always include algorithm, stage, tolerance, preserve-topology flag, and in/out counts. The logs must clearly indicate path differences (`topojson decode simplify + geojson simplify skip` vs `topojson decode only + geojson simplify run`).
+
+Then, implement anomaly scoring on simplified results and auto-retry orchestration with configurable retries, tolerance scaling, and fallback mode. Keep shape/route shared in one path but apply polygon-only checks to shape-like geometries and line-focused checks to route-like geometries.
+
+Finally, add targeted tests in `packages/vt-orchestrator` and `plugins/shape-plugin`, run required commands, and record outcomes.
+
+## Concrete Steps
+
+From repository root `/Users/hiroya/WebstormProjects/hierarchidb`:
+
+1. Edit config/types/defaults.
+2. Edit Step4 UI card components and step composition.
+3. Edit transform handler and tests.
+4. Run:
+   pnpm -w turbo run build --filter @hierarchidb/gis-sdk --filter @hierarchidb/shape-api --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin
+   pnpm -w turbo run typecheck --filter @hierarchidb/gis-sdk --filter @hierarchidb/shape-api --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin
+   pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin
+
+Expected: all commands exit 0.
+
+## Validation and Acceptance
+
+1. In Step4, selecting `topojson` and `geojson` changes visible controls as designed and persists after reload.
+2. Running a transform task emits structured logs that explicitly show algorithm path and whether geojson simplify was skipped.
+3. With anomaly detection and retry enabled, logs show retry attempts and final candidate selection reason.
+4. Route-like input runs shared simplify path but skips polygon-only anomaly checks.
+
+## Idempotence and Recovery
+
+All changes are additive and can be reverted by commit revert. If retries cause regressions, set retry enabled to false in Step4 and rebuild to return to baseline behavior.
+
+## Artifacts and Notes
+
+- Issue: https://github.com/kubohiroya/hierarchidb/issues/318
+- Branch: `codex/feat/shape/step4-anomaly-guard-controls`
+
+## Interfaces and Dependencies
+
+- Type definitions: `packages/gis-sdk/src/config.ts`
+- Defaults: `packages/shape-api/src/defaults.ts`
+- UI cards: `plugins/shape-plugin/src/ui/components/build-config/*`
+- Runtime transform: `packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts`
+- Tests: `packages/vt-orchestrator/src/transform/__tests__/*`, `plugins/shape-plugin/src/__tests__/unit/*`
+
+Revision note (2026-02-16 08:46 JST): Initial plan created from approved DoD and current codebase reconnaissance.
+Revision note (2026-02-16 08:55 JST): Updated progress, discoveries, and outcomes after implementation and verification runs.

--- a/plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts
@@ -81,4 +81,48 @@ describe('mergeBuildConfig', () => {
 
     expect(merged.transformConfig.simplifyAlgorithm).toBe('geojson');
   });
+
+  it('merges intake guard and anomaly guard overrides', () => {
+    const merged = mergeBuildConfig(DEFAULT_BUILD_CONFIG, {
+      fetchConfig: {
+        geometryIntakeGuard: {
+          validationLevel: 'strict',
+          dedupeEpsilon: 0.00001,
+          minRingAreaThreshold: 0.0001,
+          normalizeRingOrientation: true,
+          keepBaselineSnapshot: true,
+        },
+      },
+      transformConfig: {
+        executionLogLevel: 'verbose',
+        anomalyDetection: {
+          enabled: true,
+          maxEdgeLengthRatio: 6,
+          maxAreaDriftPercent: 15,
+          maxSelfIntersectionCount: 0,
+          maxLineLengthDriftPercent: 20,
+        },
+        anomalyRetry: {
+          enabled: true,
+          maxRetries: 3,
+          toleranceScale: 0.8,
+          fallbackMode: 'switch_algorithm',
+        },
+      },
+      vtConfig: {
+        outputQualityGuard: {
+          enabled: true,
+          minZoom: 3,
+          maxZoom: 8,
+          actionOnAnomaly: 'mark_warning',
+          enablePreviewOverlay: true,
+        },
+      },
+    });
+
+    expect(merged.fetchConfig.geometryIntakeGuard?.validationLevel).toBe('strict');
+    expect(merged.transformConfig.executionLogLevel).toBe('verbose');
+    expect(merged.transformConfig.anomalyRetry?.fallbackMode).toBe('switch_algorithm');
+    expect(merged.vtConfig.outputQualityGuard?.enablePreviewOverlay).toBe(true);
+  });
 });

--- a/plugins/shape-plugin/src/services/utils/utils.ts
+++ b/plugins/shape-plugin/src/services/utils/utils.ts
@@ -332,7 +332,16 @@ export function mergeBuildConfig(
   if (!overrides) return base;
 
   const fetchConfig = overrides.fetchConfig
-    ? { ...base.fetchConfig, ...overrides.fetchConfig }
+    ? {
+      ...base.fetchConfig,
+      ...overrides.fetchConfig,
+      geometryIntakeGuard: overrides.fetchConfig.geometryIntakeGuard
+        ? {
+          ...(base.fetchConfig.geometryIntakeGuard ?? {}),
+          ...overrides.fetchConfig.geometryIntakeGuard,
+        }
+        : base.fetchConfig.geometryIntakeGuard,
+    }
     : base.fetchConfig;
 
   const bandOverrides = overrides.transformConfig;
@@ -357,6 +366,18 @@ export function mergeBuildConfig(
     ? {
       ...base.transformConfig,
       ...bandOverrides,
+      anomalyDetection: bandOverrides.anomalyDetection
+        ? {
+          ...(base.transformConfig.anomalyDetection ?? {}),
+          ...bandOverrides.anomalyDetection,
+        }
+        : base.transformConfig.anomalyDetection,
+      anomalyRetry: bandOverrides.anomalyRetry
+        ? {
+          ...(base.transformConfig.anomalyRetry ?? {}),
+          ...bandOverrides.anomalyRetry,
+        }
+        : base.transformConfig.anomalyRetry,
       hybridFilterConfig: bandOverrides.hybridFilterConfig
         ? { ...base.transformConfig.hybridFilterConfig, ...bandOverrides.hybridFilterConfig }
         : base.transformConfig.hybridFilterConfig,
@@ -371,7 +392,16 @@ export function mergeBuildConfig(
     : base.transformConfig;
 
   const vtConfig = overrides.vtConfig
-    ? { ...base.vtConfig, ...overrides.vtConfig }
+    ? {
+      ...base.vtConfig,
+      ...overrides.vtConfig,
+      outputQualityGuard: overrides.vtConfig.outputQualityGuard
+        ? {
+          ...(base.vtConfig.outputQualityGuard ?? {}),
+          ...overrides.vtConfig.outputQualityGuard,
+        }
+        : base.vtConfig.outputQualityGuard,
+    }
     : base.vtConfig;
 
   const cleanupConfig = overrides.cleanupConfig

--- a/plugins/shape-plugin/src/services/vt/shapePipelineTransformStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineTransformStage.ts
@@ -436,7 +436,9 @@ export const runShapeTransformStageSection = async (params: ShapeTransformStageP
     const transformByBandHandler = await runTransformStep(params, 'create-transform-handler', async () => (
       createTransformByBandHandler({
         ephemeralDB: params.ephemeralStore,
+        fetchConfig: params.buildConfig.fetchConfig,
         transformConfig,
+        vtConfig: params.buildConfig.vtConfig,
         bands: params.bands,
         featureIdAllowlist: params.diffBuildEnabled ? params.recyclingAllowlist : undefined,
         abortSignal: transformByBandAbortController.signal,

--- a/plugins/shape-plugin/src/ui/components/build-config/FetchGeometryIntakeGuardCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/FetchGeometryIntakeGuardCard.tsx
@@ -1,0 +1,136 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  FormControl,
+  FormControlLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  CloudDownload as CloudDownloadIcon,
+  ExpandMore as ExpandMoreIcon,
+} from '@mui/icons-material';
+import { useTranslation } from '../../i18n.js';
+import type { ShapeBuildConfig } from '../../../common/types/index.js';
+import { mergeBuildConfig } from '../../../common/types/index.js';
+
+type Props = {
+  config: ShapeBuildConfig;
+  onChange: (next: ShapeBuildConfig) => void;
+  disabled?: boolean;
+};
+
+export const FetchGeometryIntakeGuardCard: React.FC<Props> = ({ config, onChange, disabled }) => {
+  const { t } = useTranslation();
+  const guard = config.fetchConfig.geometryIntakeGuard;
+
+  const resolvedGuard = {
+    validationLevel: guard?.validationLevel ?? 'basic',
+    dedupeEpsilon: guard?.dedupeEpsilon ?? 0.000001,
+    minRingAreaThreshold: guard?.minRingAreaThreshold ?? 0,
+    normalizeRingOrientation: guard?.normalizeRingOrientation ?? true,
+    keepBaselineSnapshot: guard?.keepBaselineSnapshot ?? true,
+  } as const;
+
+  const updateGuard = (partial: Partial<typeof resolvedGuard>) => {
+    onChange(mergeBuildConfig(config, {
+      fetchConfig: {
+        ...config.fetchConfig,
+        geometryIntakeGuard: {
+          ...resolvedGuard,
+          ...partial,
+        },
+      },
+    }));
+  };
+
+  return (
+    <Accordion>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <CloudDownloadIcon color="primary" />
+          <Typography variant="subtitle1">
+            {t('processing.fetch.geometryIntakeGuard.title', 'Fetch Geometry Intake Guard')}
+          </Typography>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails sx={{ p: 3 }}>
+        <Stack spacing={2} sx={{ opacity: disabled ? 0.6 : 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            {t(
+              'processing.fetch.geometryIntakeGuard.description',
+              'Normalize and validate fetched geometry before transform to reduce unstable simplification artifacts.',
+            )}
+          </Typography>
+          <FormControl fullWidth disabled={disabled}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {t('processing.fetch.geometryIntakeGuard.validationLevel', 'Validation Level')}
+            </Typography>
+            <Select
+              size="small"
+              value={resolvedGuard.validationLevel}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (value !== 'off' && value !== 'basic' && value !== 'strict') return;
+                updateGuard({ validationLevel: value });
+              }}
+            >
+              <MenuItem value="off">{t('processing.fetch.geometryIntakeGuard.level.off', 'off')}</MenuItem>
+              <MenuItem value="basic">{t('processing.fetch.geometryIntakeGuard.level.basic', 'basic')}</MenuItem>
+              <MenuItem value="strict">{t('processing.fetch.geometryIntakeGuard.level.strict', 'strict')}</MenuItem>
+            </Select>
+          </FormControl>
+          <TextField
+            size="small"
+            type="number"
+            label={t('processing.fetch.geometryIntakeGuard.dedupeEpsilon', 'Duplicate vertex epsilon')}
+            value={resolvedGuard.dedupeEpsilon}
+            disabled={disabled}
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              if (!Number.isFinite(value)) return;
+              updateGuard({ dedupeEpsilon: Math.max(0, value) });
+            }}
+          />
+          <TextField
+            size="small"
+            type="number"
+            label={t('processing.fetch.geometryIntakeGuard.minRingAreaThreshold', 'Minimum ring area threshold')}
+            value={resolvedGuard.minRingAreaThreshold}
+            disabled={disabled}
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              if (!Number.isFinite(value)) return;
+              updateGuard({ minRingAreaThreshold: Math.max(0, value) });
+            }}
+          />
+          <FormControlLabel
+            control={(
+              <Switch
+                checked={resolvedGuard.normalizeRingOrientation}
+                onChange={(event) => updateGuard({ normalizeRingOrientation: event.target.checked })}
+              />
+            )}
+            disabled={disabled}
+            label={t('processing.fetch.geometryIntakeGuard.normalizeRingOrientation', 'Normalize ring orientation')}
+          />
+          <FormControlLabel
+            control={(
+              <Switch
+                checked={resolvedGuard.keepBaselineSnapshot}
+                onChange={(event) => updateGuard({ keepBaselineSnapshot: event.target.checked })}
+              />
+            )}
+            disabled={disabled}
+            label={t('processing.fetch.geometryIntakeGuard.keepBaselineSnapshot', 'Keep baseline snapshot for anomaly scoring')}
+          />
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+};

--- a/plugins/shape-plugin/src/ui/components/build-config/ShapeBuildConfigStep.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/ShapeBuildConfigStep.tsx
@@ -6,6 +6,8 @@ import { BuildConfigShell, FetchConfigSection, VTConfigSection } from '@hierarch
 import { TransformConfigSection } from './TransformConfigSection.js';
 import { ZoomBandConfigSection } from './ZoomBandConfigSection.js';
 import { CacheManagementSection } from './CacheManagementSection.tsx';
+import { FetchGeometryIntakeGuardCard } from './FetchGeometryIntakeGuardCard.tsx';
+import { VtOutputQualityGuardCard } from './VtOutputQualityGuardCard.tsx';
 import { useShapeBuildConfigStep } from './useShapeBuildConfigStep.js';
 import { useHeapPressureMonitor } from '@hierarchidb/ui-memory';
 import { useTranslation } from '../../i18n.js';
@@ -143,6 +145,11 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
         showRetryCard={false}
         disabled={disabled}
       />
+      <FetchGeometryIntakeGuardCard
+        config={config}
+        onChange={handleChange}
+        disabled={disabled}
+      />
       <TransformConfigSection
         config={config}
         onChange={handleChange}
@@ -153,6 +160,11 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
         buildConfig={runtimeBuildConfig}
         update={updateRuntimeBuildConfig}
         showConcurrencyCard={false}
+        disabled={disabled}
+      />
+      <VtOutputQualityGuardCard
+        config={config}
+        onChange={handleChange}
         disabled={disabled}
       />
       <CacheManagementSection config={config} fetchState={fetchState} disabled={disabled} />

--- a/plugins/shape-plugin/src/ui/components/build-config/TransformConfigSection.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/TransformConfigSection.tsx
@@ -4,9 +4,13 @@ import {
   AccordionSummary,
   FormControl,
   FormControlLabel,
+  MenuItem,
   Radio,
   RadioGroup,
+  Select,
   Stack,
+  Switch,
+  TextField,
   Typography,
   Tooltip,
 } from '@mui/material';
@@ -28,17 +32,42 @@ type Props = {
 export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disabled }) => {
   const { t } = useTranslation();
   const { baseTransformConfig, update } = useTransformConfigSection({ config, onChange });
+
   const simplifyAlgorithm = baseTransformConfig.simplifyAlgorithm ?? 'topojson';
+  const preserveTopology = baseTransformConfig.preserveTopology ?? true;
+  const executionLogLevel = baseTransformConfig.executionLogLevel ?? 'summary';
+  const anomalyDetection = {
+    enabled: baseTransformConfig.anomalyDetection?.enabled ?? true,
+    maxEdgeLengthRatio: baseTransformConfig.anomalyDetection?.maxEdgeLengthRatio ?? 12,
+    maxAreaDriftPercent: baseTransformConfig.anomalyDetection?.maxAreaDriftPercent ?? 35,
+    maxSelfIntersectionCount: baseTransformConfig.anomalyDetection?.maxSelfIntersectionCount ?? 0,
+    maxLineLengthDriftPercent: baseTransformConfig.anomalyDetection?.maxLineLengthDriftPercent ?? 45,
+  };
+  const anomalyRetry = {
+    enabled: baseTransformConfig.anomalyRetry?.enabled ?? true,
+    maxRetries: baseTransformConfig.anomalyRetry?.maxRetries ?? 2,
+    toleranceScale: baseTransformConfig.anomalyRetry?.toleranceScale ?? 0.7,
+    fallbackMode: baseTransformConfig.anomalyRetry?.fallbackMode ?? 'best_score',
+  };
 
   const summaryHelp = simplifyAlgorithm === 'topojson'
     ? t(
       'processing.transform.summaryHelpTopojson',
-      'Transform uses topojson simplify first, then runs topology repair checks.',
+      'Transform uses topology-preserving topojson simplify during decode and skips geojson simplify in the simplify stage.',
     )
     : t(
       'processing.transform.summaryHelpGeojson',
-      'Transform runs turf.simplify with the configured tolerance.',
+      'Transform decodes geometry first, then runs geojson simplify with the configured tolerance.',
     );
+
+  const updateTransformConfig = (partial: Partial<typeof baseTransformConfig>) => {
+    update({
+      transformConfig: {
+        ...baseTransformConfig,
+        ...partial,
+      },
+    });
+  };
 
   return (
     <Accordion defaultExpanded>
@@ -57,13 +86,14 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
         </Stack>
       </AccordionSummary>
       <AccordionDetails sx={{ p: 3 }}>
-        <Stack spacing={1} sx={{ opacity: disabled ? 0.6 : 1 }}>
+        <Stack spacing={2} sx={{ opacity: disabled ? 0.6 : 1 }}>
           <Typography variant="body2" color="text.secondary">
             {t(
               'processing.transform.concurrencyMovedToBuildStep',
               'Transform concurrency has moved to the Build step. Click the stage spinner in progress summary to edit it.',
             )}
           </Typography>
+
           <FormControl disabled={disabled}>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
               {t('processing.transform.algorithm', 'Simplify Algorithm')}
@@ -73,12 +103,7 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
               value={simplifyAlgorithm}
               onChange={(_event, value) => {
                 if (value !== 'geojson' && value !== 'topojson') return;
-                update({
-                  transformConfig: {
-                    ...baseTransformConfig,
-                    simplifyAlgorithm: value,
-                  },
-                });
+                updateTransformConfig({ simplifyAlgorithm: value });
               }}
             >
               <FormControlLabel
@@ -92,6 +117,221 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
                 label={t('processing.transform.algorithm.geojson', 'geojson (turf simplify)')}
               />
             </RadioGroup>
+          </FormControl>
+
+          <FormControlLabel
+            control={(
+              <Switch
+                checked={preserveTopology}
+                onChange={(event) => updateTransformConfig({ preserveTopology: event.target.checked })}
+              />
+            )}
+            disabled={disabled || simplifyAlgorithm === 'topojson'}
+            label={t('processing.transform.preserveTopology', 'Preserve topology')}
+          />
+          {simplifyAlgorithm === 'topojson' ? (
+            <Typography variant="caption" color="text.secondary">
+              {t(
+                'processing.transform.preserveTopology.topojsonHint',
+                'topojson mode always preserves topology in decode simplify path.',
+              )}
+            </Typography>
+          ) : null}
+
+          <FormControl fullWidth disabled={disabled}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {t('processing.transform.executionLogLevel', 'Execution Log Level')}
+            </Typography>
+            <Select
+              size="small"
+              value={executionLogLevel}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (value !== 'off' && value !== 'summary' && value !== 'verbose') return;
+                updateTransformConfig({ executionLogLevel: value });
+              }}
+            >
+              <MenuItem value="off">{t('processing.transform.executionLogLevel.off', 'off')}</MenuItem>
+              <MenuItem value="summary">{t('processing.transform.executionLogLevel.summary', 'summary')}</MenuItem>
+              <MenuItem value="verbose">{t('processing.transform.executionLogLevel.verbose', 'verbose')}</MenuItem>
+            </Select>
+          </FormControl>
+
+          <Typography variant="subtitle2">
+            {t('processing.transform.anomaly.title', 'Anomaly Detection & Auto Retry')}
+          </Typography>
+          <FormControlLabel
+            control={(
+              <Switch
+                checked={anomalyDetection.enabled}
+                onChange={(event) => updateTransformConfig({
+                  anomalyDetection: {
+                    ...anomalyDetection,
+                    enabled: event.target.checked,
+                  },
+                })}
+              />
+            )}
+            disabled={disabled}
+            label={t('processing.transform.anomaly.enabled', 'Enable anomaly detection')}
+          />
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.transform.anomaly.maxEdgeLengthRatio', 'Max edge length ratio')}
+              value={anomalyDetection.maxEdgeLengthRatio}
+              disabled={disabled || !anomalyDetection.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateTransformConfig({
+                  anomalyDetection: {
+                    ...anomalyDetection,
+                    maxEdgeLengthRatio: Math.max(1, value),
+                  },
+                });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.transform.anomaly.maxAreaDriftPercent', 'Max area drift (%)')}
+              value={anomalyDetection.maxAreaDriftPercent}
+              disabled={disabled || !anomalyDetection.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateTransformConfig({
+                  anomalyDetection: {
+                    ...anomalyDetection,
+                    maxAreaDriftPercent: Math.max(0, value),
+                  },
+                });
+              }}
+            />
+          </Stack>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.transform.anomaly.maxSelfIntersectionCount', 'Max self intersections')}
+              value={anomalyDetection.maxSelfIntersectionCount}
+              disabled={disabled || !anomalyDetection.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateTransformConfig({
+                  anomalyDetection: {
+                    ...anomalyDetection,
+                    maxSelfIntersectionCount: Math.max(0, Math.floor(value)),
+                  },
+                });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.transform.anomaly.maxLineLengthDriftPercent', 'Max line length drift (%)')}
+              value={anomalyDetection.maxLineLengthDriftPercent}
+              disabled={disabled || !anomalyDetection.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateTransformConfig({
+                  anomalyDetection: {
+                    ...anomalyDetection,
+                    maxLineLengthDriftPercent: Math.max(0, value),
+                  },
+                });
+              }}
+            />
+          </Stack>
+
+          <FormControlLabel
+            control={(
+              <Switch
+                checked={anomalyRetry.enabled}
+                onChange={(event) => updateTransformConfig({
+                  anomalyRetry: {
+                    ...anomalyRetry,
+                    enabled: event.target.checked,
+                  },
+                })}
+              />
+            )}
+            disabled={disabled || !anomalyDetection.enabled}
+            label={t('processing.transform.anomaly.retry.enabled', 'Enable automatic retry')}
+          />
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.transform.anomaly.retry.maxRetries', 'Max retries')}
+              value={anomalyRetry.maxRetries}
+              disabled={disabled || !anomalyDetection.enabled || !anomalyRetry.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateTransformConfig({
+                  anomalyRetry: {
+                    ...anomalyRetry,
+                    maxRetries: Math.max(0, Math.floor(value)),
+                  },
+                });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.transform.anomaly.retry.toleranceScale', 'Retry tolerance scale')}
+              value={anomalyRetry.toleranceScale}
+              disabled={disabled || !anomalyDetection.enabled || !anomalyRetry.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateTransformConfig({
+                  anomalyRetry: {
+                    ...anomalyRetry,
+                    toleranceScale: Math.min(1, Math.max(0.1, value)),
+                  },
+                });
+              }}
+            />
+          </Stack>
+
+          <FormControl fullWidth disabled={disabled || !anomalyDetection.enabled || !anomalyRetry.enabled}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {t('processing.transform.anomaly.retry.fallbackMode', 'Fallback mode')}
+            </Typography>
+            <Select
+              size="small"
+              value={anomalyRetry.fallbackMode}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (value !== 'switch_algorithm' && value !== 'disable_simplify' && value !== 'best_score') {
+                  return;
+                }
+                updateTransformConfig({
+                  anomalyRetry: {
+                    ...anomalyRetry,
+                    fallbackMode: value,
+                  },
+                });
+              }}
+            >
+              <MenuItem value="best_score">
+                {t('processing.transform.anomaly.retry.fallback.bestScore', 'Use best anomaly score')}
+              </MenuItem>
+              <MenuItem value="switch_algorithm">
+                {t('processing.transform.anomaly.retry.fallback.switchAlgorithm', 'Try switching algorithm')}
+              </MenuItem>
+              <MenuItem value="disable_simplify">
+                {t('processing.transform.anomaly.retry.fallback.disableSimplify', 'Disable simplify for this task')}
+              </MenuItem>
+            </Select>
           </FormControl>
         </Stack>
       </AccordionDetails>

--- a/plugins/shape-plugin/src/ui/components/build-config/VtOutputQualityGuardCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/VtOutputQualityGuardCard.tsx
@@ -1,0 +1,145 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  FormControl,
+  FormControlLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  Layers as LayersIcon,
+} from '@mui/icons-material';
+import { useTranslation } from '../../i18n.js';
+import type { ShapeBuildConfig } from '../../../common/types/index.js';
+import { mergeBuildConfig } from '../../../common/types/index.js';
+
+type Props = {
+  config: ShapeBuildConfig;
+  onChange: (next: ShapeBuildConfig) => void;
+  disabled?: boolean;
+};
+
+export const VtOutputQualityGuardCard: React.FC<Props> = ({ config, onChange, disabled }) => {
+  const { t } = useTranslation();
+  const guard = config.vtConfig.outputQualityGuard;
+  const resolvedGuard = {
+    enabled: guard?.enabled ?? false,
+    minZoom: guard?.minZoom ?? 0,
+    maxZoom: guard?.maxZoom ?? 22,
+    actionOnAnomaly: guard?.actionOnAnomaly ?? 'mark_warning',
+    enablePreviewOverlay: guard?.enablePreviewOverlay ?? false,
+  } as const;
+
+  const updateGuard = (partial: Partial<typeof resolvedGuard>) => {
+    onChange(mergeBuildConfig(config, {
+      vtConfig: {
+        ...config.vtConfig,
+        outputQualityGuard: {
+          ...resolvedGuard,
+          ...partial,
+        },
+      },
+    }));
+  };
+
+  return (
+    <Accordion>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <LayersIcon color="primary" />
+          <Typography variant="subtitle1">
+            {t('processing.vt.outputQualityGuard.title', 'Tile Output Quality Guard')}
+          </Typography>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails sx={{ p: 3 }}>
+        <Stack spacing={2} sx={{ opacity: disabled ? 0.6 : 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            {t(
+              'processing.vt.outputQualityGuard.description',
+              'Flag potentially unstable tile output ranges and choose anomaly handling behavior in VT stage.',
+            )}
+          </Typography>
+          <FormControlLabel
+            control={(
+              <Switch
+                checked={resolvedGuard.enabled}
+                onChange={(event) => updateGuard({ enabled: event.target.checked })}
+              />
+            )}
+            disabled={disabled}
+            label={t('processing.vt.outputQualityGuard.enabled', 'Enable tile quality guard')}
+          />
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.vt.outputQualityGuard.minZoom', 'Min zoom')}
+              value={resolvedGuard.minZoom}
+              disabled={disabled || !resolvedGuard.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateGuard({ minZoom: Math.max(0, Math.floor(value)) });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.vt.outputQualityGuard.maxZoom', 'Max zoom')}
+              value={resolvedGuard.maxZoom}
+              disabled={disabled || !resolvedGuard.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateGuard({ maxZoom: Math.max(0, Math.floor(value)) });
+              }}
+            />
+          </Stack>
+          <FormControl fullWidth disabled={disabled || !resolvedGuard.enabled}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {t('processing.vt.outputQualityGuard.actionOnAnomaly', 'When anomaly is detected')}
+            </Typography>
+            <Select
+              size="small"
+              value={resolvedGuard.actionOnAnomaly}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (value !== 'mark_warning' && value !== 'fallback_less_simplified' && value !== 'drop_tile') {
+                  return;
+                }
+                updateGuard({ actionOnAnomaly: value });
+              }}
+            >
+              <MenuItem value="mark_warning">
+                {t('processing.vt.outputQualityGuard.action.markWarning', 'Mark warning')}
+              </MenuItem>
+              <MenuItem value="fallback_less_simplified">
+                {t('processing.vt.outputQualityGuard.action.fallback', 'Fallback to less simplified')}
+              </MenuItem>
+              <MenuItem value="drop_tile">
+                {t('processing.vt.outputQualityGuard.action.dropTile', 'Drop tile')}
+              </MenuItem>
+            </Select>
+          </FormControl>
+          <FormControlLabel
+            control={(
+              <Switch
+                checked={resolvedGuard.enablePreviewOverlay}
+                onChange={(event) => updateGuard({ enablePreviewOverlay: event.target.checked })}
+              />
+            )}
+            disabled={disabled || !resolvedGuard.enabled}
+            label={t('processing.vt.outputQualityGuard.enablePreviewOverlay', 'Show warning overlay in preview')}
+          />
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+};


### PR DESCRIPTION
## Summary
- Add Step4 configuration cards for Fetch/Transform/VT anomaly guard controls
- Add transform execution-path traces for `topojson` and `geojson` branches
- Add anomaly scoring and auto-retry/fallback selection in transform stage
- Keep shared simplify path while skipping polygon-repair path for route-like line profiles
- Extend merge config tests and add transform anomaly assessment unit tests

## Verification
- `pnpm -w turbo run build --filter @hierarchidb/gis-sdk --filter @hierarchidb/shape-api --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/gis-sdk --filter @hierarchidb/shape-api --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm exec vitest run packages/vt-orchestrator/src/transform/__tests__/fetchCacheDecoder.unit.test.ts packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` has known unrelated pre-existing failures in shape-plugin (`db.delete is not a function`)

Closes #318
