### PR TITLE
feat(shape-build): add anomaly scoring params and path-aware controls

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #323 / `codex/feat/shape/vt-anomaly-detection-params-323` / start: 2026-02-16 10:40 JST
 - #320 / `codex/fix/shape/intake-guard-stall-preview-errors` / start: 2026-02-16 09:18 JST
 - #318 / `codex/feat/shape/step4-anomaly-guard-controls` / start: 2026-02-16 08:40 JST
 - #315 / `codex/fix/shape-build-duration-summary-stable` / start: 2026-02-16 02:57 JST
@@ -105,6 +106,8 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- update: 2026-02-16 10:56 JST #323 作業を専用worktree `/Users/hiroya/WebstormProjects/hierarchidb-issue-323-shape-anomaly-params` へ再配置し、差分を再生。`packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts` の型安全化（triangle ring座標のタプル化と index guard）と関連テスト調整を実施。検証: `pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/ui-map` exit 0、`pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/ui-map` exit 0、`pnpm exec vitest run packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts` exit 0。
+- start: 2026-02-16 10:40 JST #323 を起票し（https://github.com/kubohiroya/hierarchidb/issues/323）、Project `hierarchidb` の Status を `In Progress` に設定。ブランチ `codex/feat/shape/vt-anomaly-detection-params-323` を作成して着手。
 - update: 2026-02-16 09:44 JST #320 ズーム帯サマリーアイコン変更を shape 専用化するため、`@hierarchidb/ui-accordion-config` の `ZoomBandConfigSection` に `summaryIcon` prop を追加し、`plugins/shape-plugin/src/ui/components/build-config/ZoomBandConfigSection.tsx` から `Search` アイコンを注入する構成へ調整（route 側は既定 `Settings` を維持）。検証: `pnpm -w turbo run build --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-plugin` exit 0。
 - update: 2026-02-16 09:41 JST #320 Step4設定UIをi18n化（`processing.fetch.geometryIntakeGuard.*` / `processing.transform.*` / `processing.vt.outputQualityGuard.*` ほか `ja/en` 追加）し、アコーディオンサマリーアイコンをズーム帯=`Search`・Transform=`Tune`へ変更。`Tile Output Quality Guard` を独立アコーディオンから VT ステージ内カードへ移設し、`Min/Max zoom` をレンジスライダーUIに置換。検証: `pnpm -w turbo run build --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-plugin` exit 0。
 - blocked: 2026-02-16 09:32 JST #320 `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` は差分外既知失敗 `plugins/shape-plugin/src/__tests__/unit/shapeFetchStage.unit.test.ts` ほかで `TypeError: db.delete is not a function` により exit 1（今回差分由来ではない）。

--- a/packages/gis-sdk/src/config.ts
+++ b/packages/gis-sdk/src/config.ts
@@ -90,12 +90,25 @@ export type TransformSimplifyAlgorithm = 'geojson' | 'topojson';
 export type TransformExecutionLogLevel = 'off' | 'summary' | 'verbose';
 export type TransformFallbackMode = 'switch_algorithm' | 'disable_simplify' | 'best_score';
 
+export type TransformAnomalyGeojsonConfig = {
+  maxTriangleShareDriftPercent: number;
+  maxTriangleEdgeToBBoxRatio: number;
+};
+
+export type TransformAnomalyTopojsonConfig = {
+  minSharedArcRatioPercent: number;
+};
+
 export type TransformAnomalyDetectionConfig = {
   enabled: boolean;
+  scoreThreshold: number;
   maxEdgeLengthRatio: number;
   maxAreaDriftPercent: number;
   maxSelfIntersectionCount: number;
   maxLineLengthDriftPercent: number;
+  maxVertexDriftPercent: number;
+  geojson?: TransformAnomalyGeojsonConfig;
+  topojson?: TransformAnomalyTopojsonConfig;
 };
 
 export type TransformAnomalyRetryConfig = {

--- a/packages/shape-api/src/defaults.ts
+++ b/packages/shape-api/src/defaults.ts
@@ -21,10 +21,19 @@ export const DEFAULT_BUILD_CONFIG = {
     executionLogLevel: 'summary',
     anomalyDetection: {
       enabled: true,
+      scoreThreshold: 2.2,
       maxEdgeLengthRatio: 12,
       maxAreaDriftPercent: 35,
       maxSelfIntersectionCount: 0,
       maxLineLengthDriftPercent: 45,
+      maxVertexDriftPercent: 40,
+      geojson: {
+        maxTriangleShareDriftPercent: 2,
+        maxTriangleEdgeToBBoxRatio: 1.15,
+      },
+      topojson: {
+        minSharedArcRatioPercent: 12,
+      },
     },
     anomalyRetry: {
       enabled: true,

--- a/packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts
+++ b/packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts
@@ -39,6 +39,9 @@ describe('assessAnomalyRisk', () => {
       totalLength: 500,
       maxEdgeLength: 10,
       selfIntersectionCount: 0,
+      triangleRingCount: 0,
+      triangleRingSharePercent: 0,
+      maxTriangleEdgeToBBoxRatio: 0,
     };
     const candidate = {
       ...baseline,
@@ -56,6 +59,14 @@ describe('assessAnomalyRisk', () => {
         maxAreaDriftPercent: 20,
         maxSelfIntersectionCount: 0,
         maxLineLengthDriftPercent: 50,
+        maxVertexDriftPercent: 30,
+        geojson: {
+          maxTriangleShareDriftPercent: 2,
+          maxTriangleEdgeToBBoxRatio: 1.15,
+        },
+        topojson: {
+          minSharedArcRatioPercent: 10,
+        },
       },
     });
 
@@ -75,6 +86,9 @@ describe('assessAnomalyRisk', () => {
       totalLength: 100,
       maxEdgeLength: 5,
       selfIntersectionCount: 0,
+      triangleRingCount: 0,
+      triangleRingSharePercent: 0,
+      maxTriangleEdgeToBBoxRatio: 0,
     };
     const candidate = {
       ...baseline,
@@ -93,6 +107,14 @@ describe('assessAnomalyRisk', () => {
         maxAreaDriftPercent: 1,
         maxSelfIntersectionCount: 0,
         maxLineLengthDriftPercent: 30,
+        maxVertexDriftPercent: 35,
+        geojson: {
+          maxTriangleShareDriftPercent: 2,
+          maxTriangleEdgeToBBoxRatio: 1.15,
+        },
+        topojson: {
+          minSharedArcRatioPercent: 10,
+        },
       },
     });
 
@@ -100,6 +122,94 @@ describe('assessAnomalyRisk', () => {
     expect(assessed.reasons).toContain('lineLengthDriftPercent>30');
     expect(assessed.reasons.some((reason) => reason.startsWith('areaDriftPercent'))).toBe(false);
     expect(assessed.reasons.some((reason) => reason.startsWith('selfIntersectionCount'))).toBe(false);
+  });
+
+  it('detects geojson triangle drift anomaly using bbox-relative edge ratio', () => {
+    const baseline = {
+      featureCount: 8,
+      vertexCount: 1000,
+      polygonCount: 8,
+      lineCount: 0,
+      totalArea: 120,
+      totalLength: 480,
+      maxEdgeLength: 12,
+      selfIntersectionCount: 0,
+      triangleRingCount: 0,
+      triangleRingSharePercent: 0,
+      maxTriangleEdgeToBBoxRatio: 0.9,
+    };
+    const candidate = {
+      ...baseline,
+      triangleRingCount: 2,
+      triangleRingSharePercent: 25,
+      maxTriangleEdgeToBBoxRatio: 1.4,
+    };
+    const assessed = assessAnomalyRisk({
+      profile: 'polygon',
+      baseline,
+      candidate,
+      thresholds: {
+        scoreThreshold: 0.75,
+        maxEdgeLengthRatio: 100,
+        maxAreaDriftPercent: 100,
+        maxSelfIntersectionCount: 100,
+        maxLineLengthDriftPercent: 100,
+        maxVertexDriftPercent: 100,
+        geojson: {
+          maxTriangleShareDriftPercent: 5,
+          maxTriangleEdgeToBBoxRatio: 1.1,
+        },
+        topojson: {
+          minSharedArcRatioPercent: 5,
+        },
+      },
+    });
+    expect(assessed.isAnomalous).toBe(true);
+    expect(assessed.reasons.some((reason) => reason.includes('triangleShareDriftPercent'))).toBe(true);
+  });
+
+  it('detects topojson shared-arc continuity anomaly', () => {
+    const baseline = {
+      featureCount: 8,
+      vertexCount: 1000,
+      polygonCount: 8,
+      lineCount: 0,
+      totalArea: 120,
+      totalLength: 480,
+      maxEdgeLength: 12,
+      selfIntersectionCount: 0,
+      triangleRingCount: 0,
+      triangleRingSharePercent: 0,
+      maxTriangleEdgeToBBoxRatio: 0.9,
+    };
+    const candidate = {
+      ...baseline,
+    };
+    const assessed = assessAnomalyRisk({
+      profile: 'polygon',
+      baseline,
+      candidate,
+      thresholds: {
+        scoreThreshold: 0.75,
+        maxEdgeLengthRatio: 100,
+        maxAreaDriftPercent: 100,
+        maxSelfIntersectionCount: 100,
+        maxLineLengthDriftPercent: 100,
+        maxVertexDriftPercent: 100,
+        geojson: {
+          maxTriangleShareDriftPercent: 10,
+          maxTriangleEdgeToBBoxRatio: 2,
+        },
+        topojson: {
+          minSharedArcRatioPercent: 25,
+        },
+      },
+      diagnostics: {
+        topoSharedArcRatioPercent: 5,
+      },
+    });
+    expect(assessed.isAnomalous).toBe(true);
+    expect(assessed.reasons).toContain('topoSharedArcRatioPercent<25');
   });
 });
 

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts
@@ -633,6 +633,113 @@ type CollectionAnomalyMetrics = {
   totalLength: number;
   maxEdgeLength: number;
   selfIntersectionCount: number;
+  triangleRingCount: number;
+  triangleRingSharePercent: number;
+  maxTriangleEdgeToBBoxRatio: number;
+};
+
+type TriangleRingMetrics = {
+  triangleRingCount: number;
+  maxTriangleEdgeToBBoxRatio: number;
+};
+
+type CoordinatePair = [number, number];
+
+const normalizeRingVertices = (ring: number[][]): CoordinatePair[] => {
+  if (!Array.isArray(ring) || ring.length < 4) return [];
+  const normalized: CoordinatePair[] = [];
+  ring.forEach((coord) => {
+    if (!Array.isArray(coord)) return;
+    const x = coord[0];
+    const y = coord[1];
+    if (typeof x !== 'number' || !Number.isFinite(x)) return;
+    if (typeof y !== 'number' || !Number.isFinite(y)) return;
+    normalized.push([x, y]);
+  });
+  if (normalized.length < 4) return [];
+  const deduped: CoordinatePair[] = [];
+  normalized.forEach((coord) => {
+    const prev = deduped[deduped.length - 1];
+    if (!prev) {
+      deduped.push(coord);
+      return;
+    }
+    if (prev[0] === coord[0] && prev[1] === coord[1]) return;
+    deduped.push(coord);
+  });
+  const first = deduped[0];
+  const last = deduped[deduped.length - 1];
+  if (!first || !last) return [];
+  if (first[0] !== last[0] || first[1] !== last[1]) return [];
+  const openRing = deduped.slice(0, deduped.length - 1);
+  if (openRing.length < 3) return [];
+  return openRing;
+};
+
+const collectTriangleRingMetricsFromPolygonCoordinates = (coordinates: number[][][]): TriangleRingMetrics => {
+  let triangleRingCount = 0;
+  let maxTriangleEdgeToBBoxRatio = 0;
+  for (const ring of coordinates) {
+    const vertices = normalizeRingVertices(ring);
+    if (vertices.length !== 3) continue;
+    triangleRingCount += 1;
+    const xs = vertices.map((vertex) => vertex[0]);
+    const ys = vertices.map((vertex) => vertex[1]);
+    const spanX = Math.max(...xs) - Math.min(...xs);
+    const spanY = Math.max(...ys) - Math.min(...ys);
+    const bboxSpan = Math.max(spanX, spanY);
+    if (!Number.isFinite(bboxSpan) || bboxSpan <= 0) continue;
+    const [vertexA, vertexB, vertexC] = vertices;
+    if (!vertexA || !vertexB || !vertexC) continue;
+    const edges = [
+      segmentLength(vertexA, vertexB),
+      segmentLength(vertexB, vertexC),
+      segmentLength(vertexC, vertexA),
+    ];
+    const longestEdge = Math.max(...edges);
+    if (!Number.isFinite(longestEdge) || longestEdge <= 0) continue;
+    const ratio = longestEdge / bboxSpan;
+    if (ratio > maxTriangleEdgeToBBoxRatio) {
+      maxTriangleEdgeToBBoxRatio = ratio;
+    }
+  }
+  return { triangleRingCount, maxTriangleEdgeToBBoxRatio };
+};
+
+const collectTriangleRingMetricsFromGeometry = (geometry?: Geometry | null): TriangleRingMetrics => {
+  if (!geometry) return { triangleRingCount: 0, maxTriangleEdgeToBBoxRatio: 0 };
+  if (geometry.type === 'Polygon') {
+    return collectTriangleRingMetricsFromPolygonCoordinates(
+      Array.isArray(geometry.coordinates) ? geometry.coordinates : [],
+    );
+  }
+  if (geometry.type === 'MultiPolygon') {
+    let triangleRingCount = 0;
+    let maxTriangleEdgeToBBoxRatio = 0;
+    const polygons = Array.isArray(geometry.coordinates) ? geometry.coordinates : [];
+    for (const polygon of polygons) {
+      const metrics = collectTriangleRingMetricsFromPolygonCoordinates(Array.isArray(polygon) ? polygon : []);
+      triangleRingCount += metrics.triangleRingCount;
+      if (metrics.maxTriangleEdgeToBBoxRatio > maxTriangleEdgeToBBoxRatio) {
+        maxTriangleEdgeToBBoxRatio = metrics.maxTriangleEdgeToBBoxRatio;
+      }
+    }
+    return { triangleRingCount, maxTriangleEdgeToBBoxRatio };
+  }
+  if (geometry.type === 'GeometryCollection') {
+    let triangleRingCount = 0;
+    let maxTriangleEdgeToBBoxRatio = 0;
+    const geometries = Array.isArray(geometry.geometries) ? geometry.geometries : [];
+    for (const child of geometries) {
+      const metrics = collectTriangleRingMetricsFromGeometry(child);
+      triangleRingCount += metrics.triangleRingCount;
+      if (metrics.maxTriangleEdgeToBBoxRatio > maxTriangleEdgeToBBoxRatio) {
+        maxTriangleEdgeToBBoxRatio = metrics.maxTriangleEdgeToBBoxRatio;
+      }
+    }
+    return { triangleRingCount, maxTriangleEdgeToBBoxRatio };
+  }
+  return { triangleRingCount: 0, maxTriangleEdgeToBBoxRatio: 0 };
 };
 
 const collectCollectionAnomalyMetrics = (
@@ -646,6 +753,8 @@ const collectCollectionAnomalyMetrics = (
   let totalLength = 0;
   let maxEdgeLength = 0;
   let selfIntersectionCount = 0;
+  let triangleRingCount = 0;
+  let maxTriangleEdgeToBBoxRatio = 0;
   for (const feature of collection.features) {
     if (!feature?.geometry) continue;
     const geometry = feature.geometry;
@@ -661,7 +770,15 @@ const collectCollectionAnomalyMetrics = (
     if (lineMetrics.max > maxEdgeLength) {
       maxEdgeLength = lineMetrics.max;
     }
+    const triangleMetrics = collectTriangleRingMetricsFromGeometry(geometry);
+    triangleRingCount += triangleMetrics.triangleRingCount;
+    if (triangleMetrics.maxTriangleEdgeToBBoxRatio > maxTriangleEdgeToBBoxRatio) {
+      maxTriangleEdgeToBBoxRatio = triangleMetrics.maxTriangleEdgeToBBoxRatio;
+    }
   }
+  const triangleRingSharePercent = polygonCount > 0
+    ? triangleRingCount / polygonCount * 100
+    : 0;
   return {
     featureCount: collection.features.length,
     vertexCount,
@@ -671,17 +788,88 @@ const collectCollectionAnomalyMetrics = (
     totalLength,
     maxEdgeLength,
     selfIntersectionCount,
+    triangleRingCount,
+    triangleRingSharePercent,
+    maxTriangleEdgeToBBoxRatio,
   };
 };
 
 type AnomalyProfile = 'polygon' | 'line';
 
+type TopojsonSharedArcDiagnostics = {
+  totalArcRefs: number;
+  sharedArcRefs: number;
+  uniqueArcCount: number;
+  sharedUniqueArcCount: number;
+  sharedArcRatioPercent: number;
+};
+
+const normalizeTopojsonArcIndex = (value: number): number | null => {
+  if (!Number.isInteger(value)) return null;
+  return value < 0 ? ~value : value;
+};
+
+const collectTopojsonSharedArcDiagnostics = (topology: Topology): TopojsonSharedArcDiagnostics | null => {
+  const arcUsage = new Map<number, number>();
+  let totalArcRefs = 0;
+  const visitArcNode = (node: unknown): void => {
+    if (typeof node === 'number') {
+      const arcIndex = normalizeTopojsonArcIndex(node);
+      if (arcIndex === null) return;
+      totalArcRefs += 1;
+      arcUsage.set(arcIndex, (arcUsage.get(arcIndex) ?? 0) + 1);
+      return;
+    }
+    if (!Array.isArray(node)) return;
+    node.forEach((child) => visitArcNode(child));
+  };
+  const visitGeometryObject = (geometryObject: unknown): void => {
+    if (!geometryObject || typeof geometryObject !== 'object') return;
+    const record = geometryObject as {
+      type?: string;
+      arcs?: unknown;
+      geometries?: unknown[];
+    };
+    if (record.type === 'GeometryCollection') {
+      const geometries = Array.isArray(record.geometries) ? record.geometries : [];
+      geometries.forEach((child) => visitGeometryObject(child));
+      return;
+    }
+    if ('arcs' in record) {
+      visitArcNode(record.arcs);
+    }
+  };
+  Object.values(topology.objects ?? {}).forEach((objectValue) => visitGeometryObject(objectValue));
+  if (totalArcRefs <= 0) return null;
+  let sharedArcRefs = 0;
+  let sharedUniqueArcCount = 0;
+  arcUsage.forEach((count) => {
+    if (count < 2) return;
+    sharedArcRefs += count;
+    sharedUniqueArcCount += 1;
+  });
+  const uniqueArcCount = arcUsage.size;
+  const sharedArcRatioPercent = sharedArcRefs / totalArcRefs * 100;
+  return {
+    totalArcRefs,
+    sharedArcRefs,
+    uniqueArcCount,
+    sharedUniqueArcCount,
+    sharedArcRatioPercent,
+  };
+};
+
 type AnomalyAssessment = {
   isAnomalous: boolean;
   score: number;
+  scoreThreshold: number;
   edgeLengthRatio: number;
   areaDriftPercent: number;
   lineLengthDriftPercent: number;
+  vertexDriftPercent: number;
+  triangleShareDriftPercent: number;
+  triangleEdgeToBBoxRatio: number;
+  topoSharedArcRatioPercent: number | null;
   selfIntersectionCount: number;
   reasons: string[];
 };
@@ -698,16 +886,36 @@ export const assessAnomalyRisk = (params: {
   baseline: CollectionAnomalyMetrics;
   candidate: CollectionAnomalyMetrics;
   thresholds?: {
+    scoreThreshold?: number;
     maxEdgeLengthRatio?: number;
     maxAreaDriftPercent?: number;
     maxSelfIntersectionCount?: number;
     maxLineLengthDriftPercent?: number;
+    maxVertexDriftPercent?: number;
+    geojson?: {
+      maxTriangleShareDriftPercent?: number;
+      maxTriangleEdgeToBBoxRatio?: number;
+    };
+    topojson?: {
+      minSharedArcRatioPercent?: number;
+    };
+  };
+  diagnostics?: {
+    topoSharedArcRatioPercent?: number | null;
   };
 }): AnomalyAssessment => {
+  const scoreThreshold = params.thresholds?.scoreThreshold ?? 2.2;
   const maxEdgeLengthRatio = params.thresholds?.maxEdgeLengthRatio ?? Number.POSITIVE_INFINITY;
   const maxAreaDriftPercent = params.thresholds?.maxAreaDriftPercent ?? Number.POSITIVE_INFINITY;
   const maxSelfIntersectionCount = params.thresholds?.maxSelfIntersectionCount ?? Number.POSITIVE_INFINITY;
   const maxLineLengthDriftPercent = params.thresholds?.maxLineLengthDriftPercent ?? Number.POSITIVE_INFINITY;
+  const maxVertexDriftPercent = params.thresholds?.maxVertexDriftPercent ?? Number.POSITIVE_INFINITY;
+  const maxTriangleShareDriftPercent = params.thresholds?.geojson?.maxTriangleShareDriftPercent
+    ?? Number.POSITIVE_INFINITY;
+  const maxTriangleEdgeToBBoxRatio = params.thresholds?.geojson?.maxTriangleEdgeToBBoxRatio
+    ?? Number.POSITIVE_INFINITY;
+  const minSharedArcRatioPercent = params.thresholds?.topojson?.minSharedArcRatioPercent
+    ?? Number.NEGATIVE_INFINITY;
 
   const edgeLengthRatio = safeRatio(params.candidate.maxEdgeLength, params.baseline.maxEdgeLength);
   const areaDriftPercent = params.profile === 'polygon' && params.baseline.totalArea > 0
@@ -716,6 +924,22 @@ export const assessAnomalyRisk = (params: {
   const lineLengthDriftPercent = params.baseline.totalLength > 0
     ? Math.abs(params.candidate.totalLength - params.baseline.totalLength) / params.baseline.totalLength * 100
     : 0;
+  const vertexDriftPercent = params.baseline.vertexCount > 0
+    ? Math.abs(params.candidate.vertexCount - params.baseline.vertexCount) / params.baseline.vertexCount * 100
+    : 0;
+  const triangleShareDriftPercent = params.profile === 'polygon'
+    ? Math.max(0, params.candidate.triangleRingSharePercent - params.baseline.triangleRingSharePercent)
+    : 0;
+  const triangleEdgeToBBoxRatio = params.profile === 'polygon'
+    ? params.candidate.maxTriangleEdgeToBBoxRatio
+    : 0;
+  const topoSharedArcRatioPercent = typeof params.diagnostics?.topoSharedArcRatioPercent === 'number'
+    && Number.isFinite(params.diagnostics.topoSharedArcRatioPercent)
+    ? params.diagnostics.topoSharedArcRatioPercent
+    : null;
+  const topoSharedArcDeficitPercent = topoSharedArcRatioPercent === null
+    ? 0
+    : Math.max(0, minSharedArcRatioPercent - topoSharedArcRatioPercent);
   const selfIntersectionCount = params.candidate.selfIntersectionCount;
 
   const reasons: string[] = [];
@@ -731,27 +955,62 @@ export const assessAnomalyRisk = (params: {
   if (params.profile === 'line' && lineLengthDriftPercent > maxLineLengthDriftPercent) {
     reasons.push(`lineLengthDriftPercent>${maxLineLengthDriftPercent}`);
   }
+  if (vertexDriftPercent > maxVertexDriftPercent) {
+    reasons.push(`vertexDriftPercent>${maxVertexDriftPercent}`);
+  }
+  if (
+    params.profile === 'polygon'
+    && triangleShareDriftPercent > maxTriangleShareDriftPercent
+    && triangleEdgeToBBoxRatio > maxTriangleEdgeToBBoxRatio
+  ) {
+    reasons.push(
+      `triangleShareDriftPercent>${maxTriangleShareDriftPercent}&triangleEdgeToBBoxRatio>${maxTriangleEdgeToBBoxRatio}`,
+    );
+  }
+  if (params.profile === 'polygon' && topoSharedArcRatioPercent !== null && topoSharedArcRatioPercent < minSharedArcRatioPercent) {
+    reasons.push(`topoSharedArcRatioPercent<${minSharedArcRatioPercent}`);
+  }
 
-  const edgeScore = Number.isFinite(maxEdgeLengthRatio) && maxEdgeLengthRatio > 0
-    ? edgeLengthRatio / maxEdgeLengthRatio
+  const normalized = (value: number, threshold: number): number => {
+    if (!Number.isFinite(value) || !Number.isFinite(threshold) || threshold <= 0) return 0;
+    return Math.min(3, value / threshold);
+  };
+  const edgeScore = normalized(edgeLengthRatio, maxEdgeLengthRatio);
+  const areaScore = params.profile === 'polygon'
+    ? normalized(areaDriftPercent, maxAreaDriftPercent)
     : 0;
-  const areaScore = params.profile === 'polygon' && Number.isFinite(maxAreaDriftPercent) && maxAreaDriftPercent > 0
-    ? areaDriftPercent / maxAreaDriftPercent
+  const lineScore = params.profile === 'line'
+    ? normalized(lineLengthDriftPercent, maxLineLengthDriftPercent)
     : 0;
+  const vertexScore = normalized(vertexDriftPercent, maxVertexDriftPercent);
   const selfIntersectionScore = params.profile === 'polygon' && Number.isFinite(maxSelfIntersectionCount)
-    ? Math.max(0, selfIntersectionCount - maxSelfIntersectionCount)
+    ? Math.min(3, Math.max(0, selfIntersectionCount - maxSelfIntersectionCount))
     : 0;
-  const lineScore = params.profile === 'line' && Number.isFinite(maxLineLengthDriftPercent) && maxLineLengthDriftPercent > 0
-    ? lineLengthDriftPercent / maxLineLengthDriftPercent
+  const triangleShareScore = params.profile === 'polygon'
+    ? normalized(triangleShareDriftPercent, maxTriangleShareDriftPercent)
     : 0;
-  const score = edgeScore + areaScore + selfIntersectionScore + lineScore;
+  const triangleEdgeScore = params.profile === 'polygon'
+    ? normalized(triangleEdgeToBBoxRatio, maxTriangleEdgeToBBoxRatio)
+    : 0;
+  const topoSharedArcScore = params.profile === 'polygon'
+    ? normalized(topoSharedArcDeficitPercent, Math.max(1, minSharedArcRatioPercent))
+    : 0;
+  const triangleCompositeScore = triangleShareScore > 0
+    ? (triangleShareScore + triangleEdgeScore) / 2
+    : 0;
+  const score = edgeScore + areaScore + lineScore + vertexScore + selfIntersectionScore + triangleCompositeScore + topoSharedArcScore;
 
   return {
-    isAnomalous: reasons.length > 0,
+    isAnomalous: score >= scoreThreshold,
     score,
+    scoreThreshold,
     edgeLengthRatio,
     areaDriftPercent,
     lineLengthDriftPercent,
+    vertexDriftPercent,
+    triangleShareDriftPercent,
+    triangleEdgeToBBoxRatio,
+    topoSharedArcRatioPercent,
     selfIntersectionCount,
     reasons,
   };
@@ -2208,10 +2467,22 @@ export const createTransformByBandHandler = (
   const traceLogLevel = normalizeTraceLogLevel(transformConfig.executionLogLevel);
   const anomalyDetectionConfig = {
     enabled: transformConfig.anomalyDetection?.enabled ?? false,
+    scoreThreshold: transformConfig.anomalyDetection?.scoreThreshold ?? 2.2,
     maxEdgeLengthRatio: transformConfig.anomalyDetection?.maxEdgeLengthRatio ?? 12,
     maxAreaDriftPercent: transformConfig.anomalyDetection?.maxAreaDriftPercent ?? 35,
     maxSelfIntersectionCount: transformConfig.anomalyDetection?.maxSelfIntersectionCount ?? 0,
     maxLineLengthDriftPercent: transformConfig.anomalyDetection?.maxLineLengthDriftPercent ?? 45,
+    maxVertexDriftPercent: transformConfig.anomalyDetection?.maxVertexDriftPercent ?? 40,
+    geojson: {
+      maxTriangleShareDriftPercent:
+        transformConfig.anomalyDetection?.geojson?.maxTriangleShareDriftPercent ?? 2,
+      maxTriangleEdgeToBBoxRatio:
+        transformConfig.anomalyDetection?.geojson?.maxTriangleEdgeToBBoxRatio ?? 1.15,
+    },
+    topojson: {
+      minSharedArcRatioPercent:
+        transformConfig.anomalyDetection?.topojson?.minSharedArcRatioPercent ?? 12,
+    },
   };
   const anomalyRetryConfig = {
     enabled: transformConfig.anomalyRetry?.enabled ?? false,
@@ -2305,6 +2576,7 @@ export const createTransformByBandHandler = (
     let simplified: FeatureCollection | null = null;
     let outputCollection: FeatureCollection | null = null;
     let baselineMetrics: CollectionAnomalyMetrics | null = null;
+    let topoSharedArcDiagnostics: TopojsonSharedArcDiagnostics | null = null;
     let anomalyProfile: AnomalyProfile = input.domainType === 'route' ? 'line' : 'polygon';
     let stageLabel = 'start';
     let inputPolygonCount = 0;
@@ -2396,6 +2668,28 @@ export const createTransformByBandHandler = (
         byteLength: fetchCache.data.byteLength,
         elapsedMs: fetchWaitStartedAt ? Date.now() - fetchWaitStartedAt : null,
       });
+      if (fetchCache.format === 'topojson' && anomalyDetectionConfig.enabled) {
+        try {
+          const decodedBuffer = fetchCache.compression === 'gzip'
+            ? await decompressGzip(fetchCache.data)
+            : fetchCache.data;
+          const topology = decodeTopoJson(decodedBuffer);
+          topoSharedArcDiagnostics = collectTopojsonSharedArcDiagnostics(topology);
+          emitTransformTrace(traceLogLevel, 'summary', 'topology-arc-diagnostics', {
+            sessionId: String(task.nodeId),
+            taskId,
+            stage: 'decode',
+            diagnostics: topoSharedArcDiagnostics,
+          });
+        } catch (topologyError) {
+          console.warn('[ShapeTransform] failed to collect topojson shared-arc diagnostics', {
+            nodeId: task.nodeId,
+            taskId,
+            sourceKey: input.sourceKey,
+            error: topologyError instanceof Error ? topologyError.message : String(topologyError),
+          });
+        }
+      }
       const executionPath = resolveSimplifyExecutionPath({
         fetchFormat: fetchCache.format,
         simplifyAlgorithm,
@@ -2719,6 +3013,11 @@ export const createTransformByBandHandler = (
               baseline: baselineMetrics as CollectionAnomalyMetrics,
               candidate: metrics,
               thresholds: anomalyDetectionConfig,
+              diagnostics: {
+                topoSharedArcRatioPercent: candidateAlgorithm === 'topojson'
+                  ? (topoSharedArcDiagnostics?.sharedArcRatioPercent ?? null)
+                  : null,
+              },
             });
             return {
               label,
@@ -2758,6 +3057,7 @@ export const createTransformByBandHandler = (
                 profile: anomalyProfile,
                 tolerance: retryTolerance,
                 score: retryCandidate.assessment.score,
+                scoreThreshold: retryCandidate.assessment.scoreThreshold,
                 reasons: retryCandidate.assessment.reasons,
                 accepted: !retryCandidate.assessment.isAnomalous,
               });
@@ -2835,6 +3135,7 @@ export const createTransformByBandHandler = (
               algorithm: selectedCandidate.algorithm,
               tolerance: selectedCandidate.tolerance,
               score: selectedCandidate.assessment.score,
+              scoreThreshold: selectedCandidate.assessment.scoreThreshold,
               reasons: selectedCandidate.assessment.reasons,
             },
             totalCandidates: candidates.length,

--- a/packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts
+++ b/packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts
@@ -157,4 +157,66 @@ describe('vtStage summary helpers', () => {
     expect(totals.polygonCount).toBeGreaterThan(0);
     expect(totals.vertexCount).toBeGreaterThan(0);
   });
+
+  it('detects boundary-attached triangle issues as vt-origin', () => {
+    const issues = vtStageTestUtils.collectTileTriangleIssues({
+      layers: {
+        admin1: {
+          features: [
+            {
+              type: 3,
+              geometry: [
+                [
+                  [0, 100],
+                  [4096, 101],
+                  [0, 102],
+                  [0, 100],
+                ],
+              ],
+              tags: { __hdbFeatureId: 'JP:1:osaka' },
+            },
+          ],
+        } as unknown as import('geojson-vt').Tile,
+      },
+      z: 5,
+      x: 28,
+      y: 12,
+      extent: 4096,
+    });
+
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.originStage).toBe('vt');
+    expect(issues[0]?.featureId).toBe('JP:1:osaka');
+  });
+
+  it('detects interior triangle issues as transform-or-earlier', () => {
+    const issues = vtStageTestUtils.collectTileTriangleIssues({
+      layers: {
+        admin1: {
+          features: [
+            {
+              type: 3,
+              geometry: [
+                [
+                  [120, 160],
+                  [3900, 162],
+                  [180, 220],
+                  [120, 160],
+                ],
+              ],
+              tags: { __hdbFeatureId: 'JP:1:hiroshima' },
+            },
+          ],
+        } as unknown as import('geojson-vt').Tile,
+      },
+      z: 6,
+      x: 56,
+      y: 25,
+      extent: 4096,
+    });
+
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.originStage).toBe('transform-or-earlier');
+    expect(issues[0]?.featureId).toBe('JP:1:hiroshima');
+  });
 });

--- a/packages/vt-orchestrator/src/vt/vtStage.ts
+++ b/packages/vt-orchestrator/src/vt/vtStage.ts
@@ -9,6 +9,7 @@ import type {
   Point,
   Polygon,
 } from 'geojson';
+import type { ShapeTransformErrorRecord } from '@hierarchidb/shape-api';
 import { geojson as geojsonApi } from 'flatgeobuf';
 import type { Tile } from 'geojson-vt';
 import type vtPbfNS = require('@maplibre/vt-pbf');
@@ -562,6 +563,171 @@ const countTileLineStrings = (geometry: unknown): number => {
   return geometry.length;
 };
 
+const VT_TRIANGLE_MIN_ANGLE_DEGREES = 8;
+const VT_TRIANGLE_MIN_SPAN_RATIO = 0.04;
+const VT_TRIANGLE_ISSUE_RECORD_LIMIT = 240;
+const VT_ORIGIN_BOUNDARY_VERTEX_THRESHOLD = 2;
+
+type VtTriangleOriginStage = 'vt' | 'transform-or-earlier';
+
+type VtTriangleIssue = {
+  featureId: string;
+  layerName: string;
+  ringIndex: number;
+  minAngleDeg: number;
+  maxSpan: number;
+  boundaryVertexCount: number;
+  originStage: VtTriangleOriginStage;
+};
+
+type TileVertex = [number, number];
+
+const normalizeTileCoord = (value: unknown): number | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value;
+};
+
+const normalizeRingVertices = (ring: number[][]): TileVertex[] => {
+  if (!Array.isArray(ring) || ring.length < 3) return [];
+  const normalized: TileVertex[] = [];
+  ring.forEach((coord) => {
+    const x = normalizeTileCoord(coord?.[0]);
+    const y = normalizeTileCoord(coord?.[1]);
+    if (x === null || y === null) return;
+    normalized.push([x, y]);
+  });
+  if (normalized.length < 3) return [];
+  const deduped: TileVertex[] = [];
+  normalized.forEach((coord) => {
+    const last = deduped[deduped.length - 1];
+    if (!last) {
+      deduped.push(coord);
+      return;
+    }
+    if (last[0] === coord[0] && last[1] === coord[1]) return;
+    deduped.push(coord);
+  });
+  if (deduped.length >= 3) {
+    const first = deduped[0];
+    const last = deduped[deduped.length - 1];
+    if (first && last && first[0] === last[0] && first[1] === last[1]) {
+      deduped.pop();
+    }
+  }
+  return deduped;
+};
+
+const resolveTriangleAngle = (a: TileVertex, b: TileVertex, c: TileVertex): number | null => {
+  const bax = a[0] - b[0];
+  const bay = a[1] - b[1];
+  const bcx = c[0] - b[0];
+  const bcy = c[1] - b[1];
+  const leftNorm = Math.hypot(bax, bay);
+  const rightNorm = Math.hypot(bcx, bcy);
+  if (!Number.isFinite(leftNorm) || !Number.isFinite(rightNorm)) return null;
+  if (leftNorm === 0 || rightNorm === 0) return null;
+  const dot = bax * bcx + bay * bcy;
+  const cos = Math.max(-1, Math.min(1, dot / (leftNorm * rightNorm)));
+  const radians = Math.acos(cos);
+  if (!Number.isFinite(radians)) return null;
+  return radians * 180 / Math.PI;
+};
+
+const resolveTriangleDiagnostics = (
+  vertices: TileVertex[],
+  extent: number,
+): {
+  minAngleDeg: number;
+  maxSpan: number;
+  boundaryVertexCount: number;
+  originStage: VtTriangleOriginStage;
+} | null => {
+  if (vertices.length !== 3) return null;
+  const [a, b, c] = vertices;
+  if (!a || !b || !c) return null;
+  const angleA = resolveTriangleAngle(b, a, c);
+  const angleB = resolveTriangleAngle(a, b, c);
+  const angleC = resolveTriangleAngle(a, c, b);
+  if (angleA == null || angleB == null || angleC == null) return null;
+  const minAngleDeg = Math.min(angleA, angleB, angleC);
+  const xs = [a[0], b[0], c[0]];
+  const ys = [a[1], b[1], c[1]];
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const maxSpan = Math.max(maxX - minX, maxY - minY);
+  const boundaryVertexCount = [a, b, c].reduce((count, vertex) => {
+    const x = vertex[0];
+    const y = vertex[1];
+    const isBoundary = x <= 0 || x >= extent || y <= 0 || y >= extent;
+    return isBoundary ? count + 1 : count;
+  }, 0);
+  return {
+    minAngleDeg,
+    maxSpan,
+    boundaryVertexCount,
+    originStage: boundaryVertexCount >= VT_ORIGIN_BOUNDARY_VERTEX_THRESHOLD ? 'vt' : 'transform-or-earlier',
+  };
+};
+
+const resolveTileFeatureIdFromVt = (feature: Tile['features'][number], fallback: string): string => {
+  const featureRecord = feature as { id?: unknown; tags?: Record<string, unknown> };
+  const tags = featureRecord.tags;
+  const candidates = [
+    tags?.__hdbFeatureId,
+    tags?.featureId,
+    tags?.id,
+    featureRecord.id,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) return candidate.trim();
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) return String(candidate);
+  }
+  return fallback;
+};
+
+const collectTileTriangleIssues = (params: {
+  layers: Record<string, Tile>;
+  z: number;
+  x: number;
+  y: number;
+  extent: number;
+}): VtTriangleIssue[] => {
+  const issues: VtTriangleIssue[] = [];
+  const minSpan = Math.max(1, params.extent * VT_TRIANGLE_MIN_SPAN_RATIO);
+  Object.entries(params.layers).forEach(([layerName, layerTile]) => {
+    const features = Array.isArray(layerTile.features) ? layerTile.features : [];
+    features.forEach((feature, featureIndex) => {
+      if (feature.type !== 3) return;
+      const rings = normalizeTileRings(feature.geometry);
+      if (rings.length === 0) return;
+      const featureId = resolveTileFeatureIdFromVt(
+        feature,
+        `tile:${params.z}/${params.x}/${params.y}:${layerName}:${featureIndex}`,
+      );
+      rings.forEach((ring, ringIndex) => {
+        const vertices = normalizeRingVertices(ring);
+        if (vertices.length !== 3) return;
+        const diagnostics = resolveTriangleDiagnostics(vertices, params.extent);
+        if (!diagnostics) return;
+        if (diagnostics.maxSpan < minSpan) return;
+        if (diagnostics.minAngleDeg > VT_TRIANGLE_MIN_ANGLE_DEGREES) return;
+        issues.push({
+          featureId,
+          layerName,
+          ringIndex,
+          minAngleDeg: diagnostics.minAngleDeg,
+          maxSpan: diagnostics.maxSpan,
+          boundaryVertexCount: diagnostics.boundaryVertexCount,
+          originStage: diagnostics.originStage,
+        });
+      });
+    });
+  });
+  return issues;
+};
+
 const buildBufferSetHash = (bufferIds: string[]): string => {
   const sorted = [...bufferIds].sort();
   const json = JSON.stringify(sorted);
@@ -1019,6 +1185,7 @@ export const vtStageTestUtils = {
   buildGeojsonVtEmptyTileSummaryReason,
   resolveVtDebugFocusConfig,
   resolveVtDebugFocusMatch,
+  collectTileTriangleIssues,
   computeOutputTileTotals,
 };
 type FeatureWithBBox = { feature: Feature; bbox: TileBBox };
@@ -1832,6 +1999,46 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
       };
       await reportTileProgress(true, `tiles 0/${totalTiles}`);
 
+      const vtTriangleIssueRecords: ShapeTransformErrorRecord[] = [];
+      const vtTriangleIssueKeys = new Set<string>();
+      let triangleIssueTotalCount = 0;
+      let vtOriginIssueCount = 0;
+      let preVtOriginIssueCount = 0;
+      const normalizeIssueToken = (value: string): string => value.replace(/[^A-Za-z0-9:_-]/g, '_');
+      const appendVtTriangleIssueRecord = (issue: VtTriangleIssue, z: number, x: number, y: number) => {
+        const issueKey = `${z}/${x}/${y}:${issue.layerName}:${issue.featureId}:${issue.ringIndex}`;
+        if (vtTriangleIssueKeys.has(issueKey)) return;
+        vtTriangleIssueKeys.add(issueKey);
+        triangleIssueTotalCount += 1;
+        if (issue.originStage === 'vt') {
+          vtOriginIssueCount += 1;
+        } else {
+          preVtOriginIssueCount += 1;
+        }
+        if (vtTriangleIssueRecords.length >= VT_TRIANGLE_ISSUE_RECORD_LIMIT) return;
+        const featureToken = normalizeIssueToken(issue.featureId).slice(0, 72);
+        vtTriangleIssueRecords.push({
+          id: `${task.taskId}:vt-diagnostic:${z}:${x}:${y}:${issue.ringIndex}:${featureToken}`,
+          nodeId: task.nodeId,
+          taskId: task.taskId,
+          stage: 'vt',
+          issueStage: 'tile-diagnostic',
+          issueKind: issue.originStage === 'vt' ? 'vt-boundary-triangle-suspect' : 'pre-vt-triangle-suspect',
+          bandIndex: input.bandIndex,
+          sourceKey: input.sourceKey,
+          featureId: issue.featureId,
+          featureIndex: issue.ringIndex,
+          geometryType: 'Polygon',
+          polygonCount: 1,
+          ringCount: 1,
+          polygonErrorCount: 1,
+          ringErrorCount: 1,
+          message: `[vt-diagnostic] originStage=${issue.originStage} tile=${z}/${x}/${y} layer=${issue.layerName} ring=${issue.ringIndex} minAngleDeg=${issue.minAngleDeg.toFixed(3)} boundaryVertices=${issue.boundaryVertexCount}/3 maxSpan=${issue.maxSpan.toFixed(1)}`,
+          createdAt: Date.now(),
+          lineFeatures: { type: 'FeatureCollection', features: [] },
+        });
+      };
+
       const computeInputTileStats = (bbox: TileBBox) => {
         let featureCount = 0;
         let vertexCount = 0;
@@ -1921,6 +2128,16 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
             if (!layers) {
               await reportTileProgress(false);
               continue;
+            }
+            const triangleIssues = collectTileTriangleIssues({
+              layers,
+              z,
+              x,
+              y,
+              extent: context.vtConfig.extent,
+            });
+            if (triangleIssues.length > 0) {
+              triangleIssues.forEach((issue) => appendVtTriangleIssueRecord(issue, z, x, y));
             }
             const tileBBox = tileToBBox(z, x, y);
             const inputStats = computeInputTileStats(
@@ -2049,6 +2266,28 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
         generatedTiles,
         outputTotals: totalOutputStats,
       }));
+      if (triangleIssueTotalCount > 0) {
+        if (vtTriangleIssueRecords.length > 0) {
+          try {
+            await context.ephemeralDB.transformErrors.bulkPut(vtTriangleIssueRecords);
+          } catch (error) {
+            console.warn('[vt][diagnostic] failed to persist triangle issue records', JSON.stringify({
+              ...taskContext,
+              triangleIssueCount: triangleIssueTotalCount,
+              persistedCount: vtTriangleIssueRecords.length,
+              error: error instanceof Error ? error.message : String(error),
+            }));
+          }
+        }
+        console.warn('[vt][diagnostic] triangle issue summary', JSON.stringify({
+          ...taskContext,
+          triangleIssueCount: triangleIssueTotalCount,
+          vtOriginIssueCount,
+          preVtOriginIssueCount,
+          persistedCount: vtTriangleIssueRecords.length,
+          droppedCount: Math.max(0, triangleIssueTotalCount - vtTriangleIssueRecords.length),
+        }));
+      }
       console.info('[vt] task completed', JSON.stringify({
         ...taskContext,
         processedTiles,

--- a/plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts
@@ -97,10 +97,19 @@ describe('mergeBuildConfig', () => {
         executionLogLevel: 'verbose',
         anomalyDetection: {
           enabled: true,
+          scoreThreshold: 1.8,
           maxEdgeLengthRatio: 6,
           maxAreaDriftPercent: 15,
           maxSelfIntersectionCount: 0,
           maxLineLengthDriftPercent: 20,
+          maxVertexDriftPercent: 18,
+          geojson: {
+            maxTriangleShareDriftPercent: 4,
+            maxTriangleEdgeToBBoxRatio: 1.2,
+          },
+          topojson: {
+            minSharedArcRatioPercent: 14,
+          },
         },
         anomalyRetry: {
           enabled: true,
@@ -122,6 +131,9 @@ describe('mergeBuildConfig', () => {
 
     expect(merged.fetchConfig.geometryIntakeGuard?.validationLevel).toBe('strict');
     expect(merged.transformConfig.executionLogLevel).toBe('verbose');
+    expect(merged.transformConfig.anomalyDetection?.scoreThreshold).toBe(1.8);
+    expect(merged.transformConfig.anomalyDetection?.geojson?.maxTriangleShareDriftPercent).toBe(4);
+    expect(merged.transformConfig.anomalyDetection?.topojson?.minSharedArcRatioPercent).toBe(14);
     expect(merged.transformConfig.anomalyRetry?.fallbackMode).toBe('switch_algorithm');
     expect(merged.vtConfig.outputQualityGuard?.enablePreviewOverlay).toBe(true);
   });

--- a/plugins/shape-plugin/src/services/utils/utils.ts
+++ b/plugins/shape-plugin/src/services/utils/utils.ts
@@ -370,6 +370,18 @@ export function mergeBuildConfig(
         ? {
           ...(base.transformConfig.anomalyDetection ?? {}),
           ...bandOverrides.anomalyDetection,
+          geojson: bandOverrides.anomalyDetection.geojson
+            ? {
+              ...(base.transformConfig.anomalyDetection?.geojson ?? {}),
+              ...bandOverrides.anomalyDetection.geojson,
+            }
+            : base.transformConfig.anomalyDetection?.geojson,
+          topojson: bandOverrides.anomalyDetection.topojson
+            ? {
+              ...(base.transformConfig.anomalyDetection?.topojson ?? {}),
+              ...bandOverrides.anomalyDetection.topojson,
+            }
+            : base.transformConfig.anomalyDetection?.topojson,
         }
         : base.transformConfig.anomalyDetection,
       anomalyRetry: bandOverrides.anomalyRetry

--- a/plugins/shape-plugin/src/ui/components/build-config/TransformConfigSection.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/TransformConfigSection.tsx
@@ -38,10 +38,22 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
   const executionLogLevel = baseTransformConfig.executionLogLevel ?? 'summary';
   const anomalyDetection = {
     enabled: baseTransformConfig.anomalyDetection?.enabled ?? true,
+    scoreThreshold: baseTransformConfig.anomalyDetection?.scoreThreshold ?? 2.2,
     maxEdgeLengthRatio: baseTransformConfig.anomalyDetection?.maxEdgeLengthRatio ?? 12,
     maxAreaDriftPercent: baseTransformConfig.anomalyDetection?.maxAreaDriftPercent ?? 35,
     maxSelfIntersectionCount: baseTransformConfig.anomalyDetection?.maxSelfIntersectionCount ?? 0,
     maxLineLengthDriftPercent: baseTransformConfig.anomalyDetection?.maxLineLengthDriftPercent ?? 45,
+    maxVertexDriftPercent: baseTransformConfig.anomalyDetection?.maxVertexDriftPercent ?? 40,
+    geojson: {
+      maxTriangleShareDriftPercent:
+        baseTransformConfig.anomalyDetection?.geojson?.maxTriangleShareDriftPercent ?? 2,
+      maxTriangleEdgeToBBoxRatio:
+        baseTransformConfig.anomalyDetection?.geojson?.maxTriangleEdgeToBBoxRatio ?? 1.15,
+    },
+    topojson: {
+      minSharedArcRatioPercent:
+        baseTransformConfig.anomalyDetection?.topojson?.minSharedArcRatioPercent ?? 12,
+    },
   };
   const anomalyRetry = {
     enabled: baseTransformConfig.anomalyRetry?.enabled ?? true,
@@ -180,6 +192,23 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
             <TextField
               size="small"
               type="number"
+              label={t('processing.transform.anomaly.scoreThreshold', 'Anomaly score threshold')}
+              value={anomalyDetection.scoreThreshold}
+              disabled={disabled || !anomalyDetection.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateTransformConfig({
+                  anomalyDetection: {
+                    ...anomalyDetection,
+                    scoreThreshold: Math.max(0.1, value),
+                  },
+                });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
               label={t('processing.transform.anomaly.maxEdgeLengthRatio', 'Max edge length ratio')}
               value={anomalyDetection.maxEdgeLengthRatio}
               disabled={disabled || !anomalyDetection.enabled}
@@ -247,7 +276,117 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
                 });
               }}
             />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.transform.anomaly.maxVertexDriftPercent', 'Max vertex drift (%)')}
+              value={anomalyDetection.maxVertexDriftPercent}
+              disabled={disabled || !anomalyDetection.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateTransformConfig({
+                  anomalyDetection: {
+                    ...anomalyDetection,
+                    maxVertexDriftPercent: Math.max(0, value),
+                  },
+                });
+              }}
+            />
           </Stack>
+
+          {simplifyAlgorithm === 'geojson' ? (
+            <Stack spacing={1.5}>
+              <Typography variant="body2" color="text.secondary">
+                {t(
+                  'processing.transform.anomaly.geojson.caption',
+                  'GeoJSON path checks triangle-shape drift using edge length against polygon BBox span.',
+                )}
+              </Typography>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                <TextField
+                  size="small"
+                  type="number"
+                  label={t(
+                    'processing.transform.anomaly.geojson.maxTriangleShareDriftPercent',
+                    'Max triangle share drift (%)',
+                  )}
+                  value={anomalyDetection.geojson.maxTriangleShareDriftPercent}
+                  disabled={disabled || !anomalyDetection.enabled}
+                  onChange={(event) => {
+                    const value = Number(event.target.value);
+                    if (!Number.isFinite(value)) return;
+                    updateTransformConfig({
+                      anomalyDetection: {
+                        ...anomalyDetection,
+                        geojson: {
+                          ...anomalyDetection.geojson,
+                          maxTriangleShareDriftPercent: Math.max(0, value),
+                        },
+                      },
+                    });
+                  }}
+                />
+                <TextField
+                  size="small"
+                  type="number"
+                  label={t(
+                    'processing.transform.anomaly.geojson.maxTriangleEdgeToBBoxRatio',
+                    'Max triangle edge/BBox ratio',
+                  )}
+                  value={anomalyDetection.geojson.maxTriangleEdgeToBBoxRatio}
+                  disabled={disabled || !anomalyDetection.enabled}
+                  onChange={(event) => {
+                    const value = Number(event.target.value);
+                    if (!Number.isFinite(value)) return;
+                    updateTransformConfig({
+                      anomalyDetection: {
+                        ...anomalyDetection,
+                        geojson: {
+                          ...anomalyDetection.geojson,
+                          maxTriangleEdgeToBBoxRatio: Math.max(0.1, value),
+                        },
+                      },
+                    });
+                  }}
+                />
+              </Stack>
+            </Stack>
+          ) : null}
+
+          {simplifyAlgorithm === 'topojson' ? (
+            <Stack spacing={1.5}>
+              <Typography variant="body2" color="text.secondary">
+                {t(
+                  'processing.transform.anomaly.topojson.caption',
+                  'TopoJSON path uses shared-arc continuity diagnostics from topology references.',
+                )}
+              </Typography>
+              <TextField
+                size="small"
+                type="number"
+                label={t(
+                  'processing.transform.anomaly.topojson.minSharedArcRatioPercent',
+                  'Min shared arc ratio (%)',
+                )}
+                value={anomalyDetection.topojson.minSharedArcRatioPercent}
+                disabled={disabled || !anomalyDetection.enabled}
+                onChange={(event) => {
+                  const value = Number(event.target.value);
+                  if (!Number.isFinite(value)) return;
+                  updateTransformConfig({
+                    anomalyDetection: {
+                      ...anomalyDetection,
+                      topojson: {
+                        ...anomalyDetection.topojson,
+                        minSharedArcRatioPercent: Math.min(100, Math.max(0, value)),
+                      },
+                    },
+                  });
+                }}
+              />
+            </Stack>
+          ) : null}
 
           <FormControlLabel
             control={(

--- a/plugins/shape-plugin/src/ui/locales/en.json
+++ b/plugins/shape-plugin/src/ui/locales/en.json
@@ -108,15 +108,26 @@
         "verbose": "verbose"
       },
       "anomaly": {
-        "title": "Anomaly detection & auto retry",
-        "enabled": "Enable anomaly detection",
-        "maxEdgeLengthRatio": "Max edge length ratio",
-        "maxAreaDriftPercent": "Max area drift (%)",
-        "maxSelfIntersectionCount": "Max self intersections",
-        "maxLineLengthDriftPercent": "Max line length drift (%)",
-        "retry": {
-          "enabled": "Enable automatic retry",
-          "maxRetries": "Max retries",
+      "title": "Anomaly detection & auto retry",
+      "enabled": "Enable anomaly detection",
+      "scoreThreshold": "Anomaly score threshold",
+      "maxEdgeLengthRatio": "Max edge length ratio",
+      "maxAreaDriftPercent": "Max area drift (%)",
+      "maxSelfIntersectionCount": "Max self intersections",
+      "maxLineLengthDriftPercent": "Max line length drift (%)",
+      "maxVertexDriftPercent": "Max vertex drift (%)",
+      "geojson": {
+        "caption": "GeoJSON path checks triangle-shape drift using edge length against polygon BBox span.",
+        "maxTriangleShareDriftPercent": "Max triangle share drift (%)",
+        "maxTriangleEdgeToBBoxRatio": "Max triangle edge/BBox ratio"
+      },
+      "topojson": {
+        "caption": "TopoJSON path uses shared-arc continuity diagnostics from topology references.",
+        "minSharedArcRatioPercent": "Min shared arc ratio (%)"
+      },
+      "retry": {
+        "enabled": "Enable automatic retry",
+        "maxRetries": "Max retries",
           "toleranceScale": "Retry tolerance scale",
           "fallbackMode": "Fallback mode",
           "fallback": {

--- a/plugins/shape-plugin/src/ui/locales/ja.json
+++ b/plugins/shape-plugin/src/ui/locales/ja.json
@@ -108,15 +108,26 @@
         "verbose": "verbose"
       },
       "anomaly": {
-        "title": "異常検出と自動リトライ",
-        "enabled": "異常検出を有効化",
-        "maxEdgeLengthRatio": "最大辺長比",
-        "maxAreaDriftPercent": "最大面積差分 (%)",
-        "maxSelfIntersectionCount": "自己交差の許容数",
-        "maxLineLengthDriftPercent": "最大線長差分 (%)",
-        "retry": {
-          "enabled": "自動リトライを有効化",
-          "maxRetries": "最大リトライ回数",
+      "title": "異常検出と自動リトライ",
+      "enabled": "異常検出を有効化",
+      "scoreThreshold": "異常スコア閾値",
+      "maxEdgeLengthRatio": "最大辺長比",
+      "maxAreaDriftPercent": "最大面積差分 (%)",
+      "maxSelfIntersectionCount": "自己交差の許容数",
+      "maxLineLengthDriftPercent": "最大線長差分 (%)",
+      "maxVertexDriftPercent": "最大頂点数差分 (%)",
+      "geojson": {
+        "caption": "GeoJSON 経路では、ポリゴンBBoxに対する三角形辺長の変動を監視します。",
+        "maxTriangleShareDriftPercent": "最大三角形シェア差分 (%)",
+        "maxTriangleEdgeToBBoxRatio": "最大三角形辺長/BBox比"
+      },
+      "topojson": {
+        "caption": "TopoJSON 経路では、トポロジー参照の共有弧連続性を診断します。",
+        "minSharedArcRatioPercent": "最小共有弧比率 (%)"
+      },
+      "retry": {
+        "enabled": "自動リトライを有効化",
+        "maxRetries": "最大リトライ回数",
           "toleranceScale": "リトライ時の tolerance 係数",
           "fallbackMode": "フォールバックモード",
           "fallback": {


### PR DESCRIPTION
## Summary
- add transform anomaly detection parameters (score threshold, vertex drift, geojson/topojson-specific thresholds) to shared config and defaults
- add Step4 Transform UI controls with topojson/geojson conditional fields and i18n labels
- extend transform anomaly assessment to include triangle edge-to-bbox, triangle share drift, vertex drift, and topo shared-arc diagnostics
- include execution-path diagnostics in VT stage and update unit tests

## Verification
- pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/ui-map
- pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/ui-map
- pnpm exec vitest run packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts

## Rollback
- revert commit `f3f77aa0b`

Refs #323
