### PR TITLE
fix(shape): stabilize build progress UI after transform cache reset

### DIFF
--- a/packages/ui/batch/src/hooks/useBuildTaskProgress.ts
+++ b/packages/ui/batch/src/hooks/useBuildTaskProgress.ts
@@ -6,7 +6,7 @@ import { buildTaskCountSummary } from '../utils/taskProgressSummary.js';
 type TaskStageCarrier = BuildTaskSummary & { taskType?: string; type?: string; stage?: string };
 
 const resolveTaskStage = (task: TaskStageCarrier): string | undefined => (
-  task.taskType ?? task.type ?? task.stage
+  task.stage ?? task.taskType ?? task.type
 );
 
 const toStageKey = (task: TaskStageCarrier): string => {

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveBuildStatusSource.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveBuildStatusSource.unit.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { resolveBuildStatusSource } from '../../../components/build-progress/resolveBuildStatusSource.ts';
 
 describe('resolveBuildStatusSource', () => {
+  it('keeps persisted processing when runtime reports stale completed', () => {
+    expect(resolveBuildStatusSource('processing', 'completed')).toBe('processing');
+  });
+
+  it('keeps persisted processing when runtime reports stale idle', () => {
+    expect(resolveBuildStatusSource('processing', 'idle')).toBe('processing');
+  });
+
   it('uses persisted completed when runtime status is stale processing', () => {
     expect(resolveBuildStatusSource('completed', 'processing')).toBe('completed');
   });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useBuildProgressPanelState.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useBuildProgressPanelState.unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { shouldUpdateElapsedSnapshot } from '../../../components/build-progress/useBuildProgressPanelState.ts';
+import {
+  resolveCompletionFailedStageLabel,
+  resolveActiveRunningStageId,
+  shouldUpdateElapsedSnapshot,
+} from '../../../components/build-progress/useBuildProgressPanelState.ts';
 
 describe('shouldUpdateElapsedSnapshot', () => {
   it('returns true when there is no snapshot yet', () => {
@@ -32,5 +36,71 @@ describe('shouldUpdateElapsedSnapshot', () => {
       totalElapsedMs: 8_000,
       buildStatus: 'paused',
     })).toBe(true);
+  });
+});
+
+describe('resolveCompletionFailedStageLabel', () => {
+  it('uses failed stage title when available', () => {
+    expect(resolveCompletionFailedStageLabel({
+      stages: [
+        { id: 'fetch', title: 'Fetch', icon: null },
+        { id: 'vt', title: 'VT', icon: null },
+      ],
+      failedStageId: 'vt',
+      fallbackStageLabel: 'Fetch',
+    })).toBe('VT');
+  });
+
+  it('falls back when failed stage is unavailable', () => {
+    expect(resolveCompletionFailedStageLabel({
+      stages: [{ id: 'fetch', title: 'Fetch', icon: null }],
+      failedStageId: undefined,
+      fallbackStageLabel: 'Fetch',
+    })).toBe('Fetch');
+  });
+});
+
+describe('resolveActiveRunningStageId', () => {
+  const stages = [
+    { id: 'fetch', title: 'Fetch', icon: null },
+    { id: 'transform', title: 'Transform', icon: null },
+    { id: 'vt', title: 'VT', icon: null },
+  ];
+
+  it('returns the most advanced running stage when overlap exists', () => {
+    expect(resolveActiveRunningStageId({
+      stages,
+      stageTaskScan: {
+        fetch: { hasRunning: false },
+        transform: { hasRunning: true },
+        vt: { hasRunning: true },
+      },
+    })).toBe('vt');
+  });
+
+  it('returns null when no stage is running', () => {
+    expect(resolveActiveRunningStageId({
+      stages,
+      stageTaskScan: {
+        fetch: { hasRunning: false },
+        transform: { hasRunning: false },
+        vt: { hasRunning: false },
+      },
+    })).toBeNull();
+  });
+
+  it('prefers canonical vt stage even when stage order is stale', () => {
+    expect(resolveActiveRunningStageId({
+      stages: [
+        { id: 'fetch', title: 'Fetch', icon: null },
+        { id: 'vt', title: 'VT', icon: null },
+        { id: 'transform', title: 'Transform', icon: null },
+      ],
+      stageTaskScan: {
+        fetch: { hasRunning: false },
+        transform: { hasRunning: true },
+        vt: { hasRunning: true },
+      },
+    })).toBe('vt');
   });
 });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildProgressSummary.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildProgressSummary.unit.test.tsx
@@ -42,4 +42,94 @@ describe('useShapeBuildProgressSummary', () => {
     expect(result.current.displayCounts.completed).toBe(0);
     expect(result.current.displayCounts.percentage).toBe(0);
   });
+
+  it('groups tasks by canonical stage even when legacy taskType is stale', () => {
+    const multiStages: BuildStage[] = [
+      { id: 'fetch', title: 'Fetch', icon: null },
+      { id: 'transform', title: 'Transform', icon: null },
+      { id: 'vt', title: 'VT', icon: null },
+    ];
+    const tasks: ShapeBuildTaskSummary[] = [
+      {
+        taskId: 'task-vt-running',
+        nodeId: 'node-2',
+        stage: 'vt',
+        taskType: 'fetch',
+        type: 'fetch',
+        status: 'running',
+        progress: 10,
+      } as ShapeBuildTaskSummary,
+    ];
+
+    const { result } = renderHook(() => useShapeBuildProgressSummary({
+      stages: multiStages,
+      resolvedTaskType: 'vt',
+      overallProgress: 10,
+      buildStatus: 'running',
+      effectiveProgress: null,
+      effectiveStatus: null,
+      taskType: 'vt',
+      tasks,
+      normalizeStageKey,
+      isSkippedTask: () => false,
+      timingStageMs: 0,
+    }));
+
+    expect(result.current.tasksByStage.vt).toHaveLength(1);
+    expect(result.current.tasksByStage.fetch ?? []).toHaveLength(0);
+  });
+
+  it('keeps display stage on in-flight transform when vt is only planned', () => {
+    const multiStages: BuildStage[] = [
+      { id: 'fetch', title: 'Fetch', icon: null },
+      { id: 'transform', title: 'Transform', icon: null },
+      { id: 'vt', title: 'VT', icon: null },
+    ];
+    const tasks: ShapeBuildTaskSummary[] = [
+      {
+        taskId: 'task-fetch-completed',
+        nodeId: 'node-3',
+        stage: 'fetch',
+        taskType: 'fetch',
+        status: 'completed',
+        progress: 100,
+      } as ShapeBuildTaskSummary,
+      {
+        taskId: 'task-transform-running',
+        nodeId: 'node-3',
+        stage: 'transform',
+        taskType: 'transform',
+        status: 'running',
+        progress: 5,
+      } as ShapeBuildTaskSummary,
+    ];
+
+    const { result } = renderHook(() => useShapeBuildProgressSummary({
+      stages: multiStages,
+      resolvedTaskType: 'fetch',
+      overallProgress: 5,
+      buildStatus: 'running',
+      effectiveProgress: {
+        total: 8,
+        completed: 1,
+        failed: 0,
+        skipped: 0,
+        percentage: 12,
+        taskType: 'fetch',
+        stageTotals: {
+          fetch: { total: 2, completed: 1, failed: 0, skipped: 0 },
+          transform: { total: 4, completed: 0, failed: 0, skipped: 0 },
+          vt: { total: 2, completed: 0, failed: 0, skipped: 0 },
+        },
+      },
+      effectiveStatus: { status: 'processing', progress: 12 },
+      taskType: 'fetch',
+      tasks,
+      normalizeStageKey,
+      isSkippedTask: () => false,
+      timingStageMs: 0,
+    }));
+
+    expect(result.current.displayStageId).toBe('transform');
+  });
 });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { shouldResetElapsedState } from '../../../components/build-progress/useShapeBuildStep.ts';
+import {
+  resolveMostAdvancedInFlightStageId,
+  resolveMostAdvancedRunningStageId,
+  resolveDisplayBuildStatus,
+  shouldRefreshTasksSnapshot,
+  shouldResetElapsedState,
+} from '../../../components/build-progress/useShapeBuildStep.ts';
 
 describe('shouldResetElapsedState', () => {
   it('returns false while build is running', () => {
@@ -49,5 +55,92 @@ describe('shouldResetElapsedState', () => {
       stageElapsedByStage: {},
       localElapsedByStage: {},
     })).toBe(false);
+  });
+});
+
+describe('resolveDisplayBuildStatus', () => {
+  it('keeps running while base status is running even when current tasks are completed', () => {
+    expect(resolveDisplayBuildStatus({
+      baseBuildStatus: 'running',
+      tasksCompletionStatus: 'completed',
+      hasInFlightTasks: false,
+    })).toBe('running');
+  });
+
+  it('promotes to completed when base status is idle and tasks are completed', () => {
+    expect(resolveDisplayBuildStatus({
+      baseBuildStatus: 'idle',
+      tasksCompletionStatus: 'completed',
+      hasInFlightTasks: false,
+    })).toBe('completed');
+  });
+});
+
+describe('shouldRefreshTasksSnapshot', () => {
+  it('returns true when running but visible tasks are stale completed-only entries', () => {
+    expect(shouldRefreshTasksSnapshot({
+      displayTaskCount: 2,
+      hasInFlightTasks: false,
+      hasProgressTaskSignal: false,
+      buildStatus: 'running',
+      runtimeStatus: 'running',
+      processingStatus: 'processing',
+      buildSessionTransitionActive: false,
+    })).toBe(true);
+  });
+
+  it('returns false when tasks are already running in UI', () => {
+    expect(shouldRefreshTasksSnapshot({
+      displayTaskCount: 2,
+      hasInFlightTasks: true,
+      hasProgressTaskSignal: true,
+      buildStatus: 'running',
+      runtimeStatus: 'running',
+      processingStatus: 'processing',
+      buildSessionTransitionActive: false,
+    })).toBe(false);
+  });
+});
+
+describe('resolveMostAdvancedRunningStageId', () => {
+  it('prefers vt when transform and vt both report running', () => {
+    expect(resolveMostAdvancedRunningStageId({
+      stages: [{ id: 'fetch' }, { id: 'transform' }, { id: 'vt' }],
+      tasks: [
+        { stage: 'transform', taskType: 'transform', type: 'transform', status: 'running' },
+        { stage: 'vt', taskType: 'fetch', type: 'fetch', status: 'running' },
+      ],
+    })).toBe('vt');
+  });
+
+  it('returns null when no running tasks exist', () => {
+    expect(resolveMostAdvancedRunningStageId({
+      stages: [{ id: 'fetch' }, { id: 'transform' }, { id: 'vt' }],
+      tasks: [
+        { stage: 'fetch', taskType: 'fetch', type: 'fetch', status: 'completed' },
+      ],
+    })).toBeNull();
+  });
+
+  it('uses canonical stage priority even when stage array order is stale', () => {
+    expect(resolveMostAdvancedRunningStageId({
+      stages: [{ id: 'fetch' }, { id: 'vt' }, { id: 'transform' }],
+      tasks: [
+        { stage: 'transform', taskType: 'transform', type: 'transform', status: 'running' },
+        { stage: 'vt', taskType: 'vt', type: 'vt', status: 'running' },
+      ],
+    })).toBe('vt');
+  });
+});
+
+describe('resolveMostAdvancedInFlightStageId', () => {
+  it('promotes queued transform above completed fetch during handoff', () => {
+    expect(resolveMostAdvancedInFlightStageId({
+      stages: [{ id: 'fetch' }, { id: 'transform' }, { id: 'vt' }],
+      tasks: [
+        { stage: 'fetch', taskType: 'fetch', type: 'fetch', status: 'completed' },
+        { stage: 'transform', taskType: 'transform', type: 'transform', status: 'queued' },
+      ],
+    })).toBe('transform');
   });
 });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
@@ -159,6 +159,38 @@ describe('useShapeBuildTasks', () => {
     });
   });
 
+  it('prioritizes canonical stage over legacy taskType when they differ', async () => {
+    const { result } = renderHook(() => useShapeBuildTasks('node-stage-priority'));
+
+    await waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalled();
+    });
+
+    act(() => {
+      subscriber?.({
+        type: 'snapshot',
+        nodeId: 'node-stage-priority',
+        tasks: [
+          {
+            taskId: 'task-stage-priority',
+            stage: 'vt',
+            taskType: 'fetch',
+            status: 'queued',
+            progress: 0,
+            index: 1,
+            sequence: 1,
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks[0]?.stage).toBe('vt');
+      expect(result.current.tasks[0]?.taskType).toBe('vt');
+      expect(result.current.tasks[0]?.type).toBe('vt');
+    });
+  });
+
   it('keeps completed 100% when a running 100% update arrives later', async () => {
     const { result } = renderHook(() => useShapeBuildTasks('node-2'));
 

--- a/plugins/shape-plugin/src/ui/atoms/shapeBuildProgressAtoms.ts
+++ b/plugins/shape-plugin/src/ui/atoms/shapeBuildProgressAtoms.ts
@@ -6,6 +6,8 @@ import type { TaskStage } from '@hierarchidb/batch-api';
 
 export type ShapeBuildTaskSummary = Omit<BuildTaskSummary, 'stage'> & {
   stage: TaskStage;
+  taskType?: TaskStage;
+  type?: TaskStage;
   index?: number;
   stagePriority?: number;
   metadata?: Record<string, unknown>;

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItem.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItem.tsx
@@ -6,6 +6,7 @@ type Props = {
   leadingIcon?: React.ReactNode;
   statusLabel: string;
   statusColor: 'default' | 'success' | 'error' | 'warning' | 'info';
+  isRunning?: boolean;
   message?: string;
   detailLines?: string[];
   progress?: number;
@@ -19,12 +20,15 @@ export const TaskItem: React.FC<Props> = ({
   leadingIcon,
   statusLabel,
   statusColor,
+  isRunning = false,
   message,
   detailLines,
   progress,
   fallbackProgress,
 }) => {
   const displayMessage = message ?? detailLines?.[0] ?? '';
+  const progressValue = Math.min(100, Math.max(0, progress ?? fallbackProgress));
+  const showRunningOverlay = isRunning && progressValue < 100;
 
   return (
     <Box
@@ -49,11 +53,24 @@ export const TaskItem: React.FC<Props> = ({
           <Chip label={statusLabel} color={statusColor} size="small" variant="outlined" />
         </Stack>
       </Box>
-      <LinearProgress
-        variant="determinate"
-        value={Math.min(100, Math.max(0, progress ?? fallbackProgress))}
-        color={statusColor === 'default' ? 'primary' : statusColor}
-      />
+      <Box sx={{ position: 'relative' }}>
+        <LinearProgress
+          variant="determinate"
+          value={progressValue}
+          color={statusColor === 'default' ? 'primary' : statusColor}
+        />
+        {showRunningOverlay ? (
+          <LinearProgress
+            variant="indeterminate"
+            color="info"
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              opacity: 0.35,
+            }}
+          />
+        ) : null}
+      </Box>
       <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
         <Tooltip
           title={displayMessage}

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard.tsx
@@ -79,6 +79,7 @@ export const TaskItemCard = ({
       leadingIcon={leadingIcon}
       statusLabel={statusLabelValue}
       statusColor={statusColor}
+      isRunning={task.status === 'running'}
       message={taskMessage}
       detailLines={detailLines}
       progress={displayProgress}

--- a/plugins/shape-plugin/src/ui/components/build-progress/resolveBuildStatusSource.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/resolveBuildStatusSource.ts
@@ -5,6 +5,10 @@ export const resolveBuildStatusSource = (
   runtimeStatus: BuildStatusSource | null,
 ): BuildStatusSource => {
   if (!runtimeStatus) return persistedStatus;
+  const hasPersistedProcessing = persistedStatus === 'processing';
+  if (hasPersistedProcessing && (runtimeStatus === 'completed' || runtimeStatus === 'idle')) {
+    return persistedStatus;
+  }
   const hasPersistedTerminalOrPaused = (
     persistedStatus === 'completed'
     || persistedStatus === 'failed'

--- a/plugins/shape-plugin/src/ui/components/build-progress/stagePriority.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/stagePriority.ts
@@ -1,0 +1,39 @@
+type StageRef = { id: string };
+
+const CANONICAL_STAGE_ORDER = ['fetch', 'transform', 'vt'] as const;
+
+const resolveCanonicalStageRank = (stageId: string): number | null => {
+  const index = CANONICAL_STAGE_ORDER.indexOf(stageId as (typeof CANONICAL_STAGE_ORDER)[number]);
+  return index >= 0 ? index : null;
+};
+
+export const resolveStagePriority = (
+  stageId: string,
+  stages: StageRef[],
+): number => {
+  const canonicalRank = resolveCanonicalStageRank(stageId);
+  if (canonicalRank !== null) {
+    return canonicalRank;
+  }
+  const stageIndex = stages.findIndex((stage) => stage.id === stageId);
+  if (stageIndex >= 0) {
+    return CANONICAL_STAGE_ORDER.length + stageIndex;
+  }
+  return Number.MIN_SAFE_INTEGER;
+};
+
+export const resolveMostAdvancedStageId = (
+  stageIds: Iterable<string>,
+  stages: StageRef[],
+): string | null => {
+  let selectedStageId: string | null = null;
+  let selectedPriority = Number.MIN_SAFE_INTEGER;
+  for (const stageId of stageIds) {
+    const priority = resolveStagePriority(stageId, stages);
+    if (priority > selectedPriority) {
+      selectedPriority = priority;
+      selectedStageId = stageId;
+    }
+  }
+  return selectedStageId;
+};

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { NodeId } from '@hierarchidb/core-types';
 import { useAtomValue } from 'jotai';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
+import type { BuildStage } from '@hierarchidb/components/build-stage';
 import { flushSync } from 'react-dom';
 import { useTranslation } from '../../i18n.js';
 import { resolveShapeTaskTitle } from '../../../common/utils/taskTitles.ts';
@@ -29,6 +30,7 @@ import type { ShapeEntity } from '../../../common/types/ShapeEntity.ts';
 import { DEFAULT_PROCESSING_CONFIG, mergeProcessingConfig } from '../../../common/types/index.js';
 import type { ShapeBuildTaskSummary } from '../../atoms/shapeBuildProgressAtoms.js';
 import { isTaskPhaseDisplay, isTaskPhaseMessage } from '../../../common/utils/taskMessages.ts';
+import { resolveMostAdvancedStageId } from './stagePriority.ts';
 
 const isDev = import.meta.env.DEV;
 const START_RESUME_TRACE_PREFIX = '[ShapeBuildStartResumeTrace]';
@@ -90,6 +92,26 @@ export const shouldUpdateElapsedSnapshot = (params: {
   // Reset Session may zero elapsed before build status settles to idle/paused.
   if (totalElapsedMs === 0) return true;
   return totalElapsedMs > snapshot.elapsedMs;
+};
+
+export const resolveCompletionFailedStageLabel = (params: {
+  stages: BuildStage[];
+  failedStageId?: string;
+  fallbackStageLabel: string;
+}): string => {
+  if (!params.failedStageId) return params.fallbackStageLabel;
+  const failedStage = params.stages.find((stage) => stage.id === params.failedStageId);
+  return failedStage?.title ?? params.failedStageId;
+};
+
+export const resolveActiveRunningStageId = (params: {
+  stages: BuildStage[];
+  stageTaskScan: Record<string, { hasRunning: boolean }>;
+}): string | null => {
+  const runningStageIds = params.stages
+    .filter((stage) => params.stageTaskScan[stage.id]?.hasRunning)
+    .map((stage) => stage.id);
+  return resolveMostAdvancedStageId(runningStageIds, params.stages);
 };
 
 export const useBuildProgressPanelState = (params: {
@@ -170,12 +192,7 @@ export const useBuildProgressPanelState = (params: {
   }, [stages, tasksByStage]);
   const activeStageId = useMemo(() => {
     if (summary.buildStatus !== 'running') return null;
-    for (const stage of stages) {
-      if (stageTaskScan[stage.id]?.hasRunning) {
-        return stage.id;
-      }
-    }
-    return null;
+    return resolveActiveRunningStageId({ stages, stageTaskScan });
   }, [stageTaskScan, stages, summary.buildStatus]);
   const {
     startWarning,
@@ -222,6 +239,7 @@ export const useBuildProgressPanelState = (params: {
       const failureMessage = resolveFailureMessage(failedTask);
       if (!failureMessage) continue;
       return {
+        stageId: stage.id,
         title: resolveTaskTitle(failedTask as TaskItemWithMetadata),
         message: failureMessage,
       };
@@ -241,6 +259,11 @@ export const useBuildProgressPanelState = (params: {
     ?? t('stage.tasks.unknown', '(Task unavailable)');
   const completionTaskMessage = failedTaskInfo?.message
     ?? t('stage.progress.failedReason', 'Build failed due to task errors.');
+  const completionFailedStageLabel = resolveCompletionFailedStageLabel({
+    stages,
+    failedStageId: failedTaskInfo?.stageId,
+    fallbackStageLabel: completionStageLabel,
+  });
   const completionReason = (() => {
     if (summary.buildStatus === 'failed') {
       const candidate = summary.taskLabel?.trim();
@@ -271,12 +294,12 @@ export const useBuildProgressPanelState = (params: {
       if (!failedTaskInfo?.message) {
         return;
       }
-      const key = `${summary.buildStatus}:${completionStageLabel}:${completionTaskTitle ?? ''}:${completionTaskMessage ?? ''}`;
+      const key = `${summary.buildStatus}:${completionFailedStageLabel}:${completionTaskTitle ?? ''}:${completionTaskMessage ?? ''}`;
       if (completionKeyRef.current === key) return;
       completionKeyRef.current = key;
       setCompletionSnapshot({
         status: summary.buildStatus,
-        stageLabel: completionStageLabel,
+        stageLabel: completionFailedStageLabel,
         taskTitle: completionTaskTitle,
         taskMessage: completionTaskMessage,
       });
@@ -287,6 +310,7 @@ export const useBuildProgressPanelState = (params: {
   }, [
     completionReason,
     completionStageLabel,
+    completionFailedStageLabel,
     completionTaskMessage,
     completionTaskTitle,
     failedTaskInfo?.message,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildProgressSummary.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildProgressSummary.ts
@@ -12,6 +12,7 @@ import {
 import type { TaskStage } from '@hierarchidb/batch-api';
 import type { BuildProgress, BuildProgressStatus } from './shapeBuildProgressMapping.ts';
 import type { BuildTaskSummary } from '@hierarchidb/batch-api';
+import { resolveMostAdvancedStageId } from './stagePriority.ts';
 
 type CountsWithPercentage = TaskCountSummary & { percentage: number };
 
@@ -224,7 +225,17 @@ export const useShapeBuildProgressSummary = <T extends BuildTaskSummary & TaskSt
     return candidate;
   }, [buildStatus, stageCountsWithPlan, stages]);
 
-  const displayStageId = lastUnfinishedStageId ?? resolvedTaskType;
+  const inFlightStageId = useMemo(() => {
+    if (buildStatus !== 'running') return undefined;
+    const stageIds = stages
+      .filter((stage) => (
+        (tasksByStage[stage.id] ?? []).some((task) => task.status === 'running' || task.status === 'queued')
+      ))
+      .map((stage) => stage.id);
+    return resolveMostAdvancedStageId(stageIds, stages) ?? undefined;
+  }, [buildStatus, stages, tasksByStage]);
+
+  const displayStageId = inFlightStageId ?? lastUnfinishedStageId ?? resolvedTaskType;
 
   const derivedCounts = useMemo(() => {
     if (!lastUnfinishedStageId) return null;

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts
@@ -47,6 +47,7 @@ import {
 import type { ShapeBuildSessionRecord } from '@hierarchidb/shape-api';
 import { shapeMutationAPIImpl, shapeQueryAPIImpl } from '../../../services/batch/ShapeBuildAPIClient.ts';
 import { persistedTasksAtom } from '../../atoms/shapeBuildProgressAtoms.js';
+import { resolveMostAdvancedStageId } from './stagePriority.ts';
 
 const SHAPE_NODE_TYPE = 'shape' as NodeType;
 const PAUSE_COMMAND_TIMEOUT_MS = 60_000;
@@ -94,6 +95,10 @@ type StageLikeTask = {
   taskType?: TaskStage;
   type?: TaskStage;
   stage: TaskStage;
+};
+
+type StageLikeRunningTask = StageLikeTask & {
+  status?: string;
 };
 
 const runWithTimeout = async <T>(
@@ -160,7 +165,96 @@ export const shouldResetElapsedState = (params: {
   return true;
 };
 
-const normalizeStageKey = (task: StageLikeTask): TaskStage => task.taskType ?? task.type ?? task.stage;
+export const resolveDisplayBuildStatus = (params: {
+  baseBuildStatus: BuildStatus;
+  tasksCompletionStatus: BuildStatus | null;
+  hasInFlightTasks: boolean;
+}): BuildStatus => {
+  if (params.tasksCompletionStatus === 'failed') {
+    return 'failed';
+  }
+  if (params.baseBuildStatus === 'running') {
+    return 'running';
+  }
+  if (params.tasksCompletionStatus === 'completed') {
+    return params.baseBuildStatus === 'paused' ? 'paused' : 'completed';
+  }
+  if (params.baseBuildStatus === 'paused') {
+    return 'paused';
+  }
+  if (params.hasInFlightTasks) {
+    return 'running';
+  }
+  return params.baseBuildStatus;
+};
+
+export const shouldRefreshTasksSnapshot = (params: {
+  displayTaskCount: number;
+  hasInFlightTasks: boolean;
+  hasProgressTaskSignal: boolean;
+  buildStatus: BuildStatus;
+  runtimeStatus: string | null;
+  processingStatus: 'idle' | 'processing' | 'paused' | 'completed' | 'failed';
+  buildSessionTransitionActive: boolean;
+}): boolean => {
+  const hasProcessingSignal = (
+    params.buildStatus === 'running'
+    || params.runtimeStatus === 'processing'
+    || params.processingStatus === 'processing'
+    || params.buildSessionTransitionActive
+  );
+  if (params.displayTaskCount === 0) {
+    return (
+      params.hasProgressTaskSignal
+      || params.buildStatus === 'running'
+      || params.buildStatus === 'completed'
+      || params.runtimeStatus === 'processing'
+      || params.processingStatus === 'processing'
+      || params.buildSessionTransitionActive
+    );
+  }
+  if (params.hasInFlightTasks) {
+    return false;
+  }
+  return hasProcessingSignal;
+};
+
+const normalizeStageKey = (task: StageLikeTask): TaskStage => task.stage ?? task.taskType ?? task.type;
+
+const resolveMostAdvancedStageIdByStatus = (params: {
+  stages: Array<{ id: string }>;
+  tasks: StageLikeRunningTask[];
+  statuses: Set<string>;
+}): string | null => {
+  const stageIds = new Set<string>();
+  params.tasks.forEach((task) => {
+    if (!task.status || !params.statuses.has(task.status)) return;
+    stageIds.add(normalizeStageKey(task));
+  });
+  return resolveMostAdvancedStageId(stageIds, params.stages);
+};
+
+export const resolveMostAdvancedRunningStageId = (params: {
+  stages: Array<{ id: string }>;
+  tasks: StageLikeRunningTask[];
+}): string | null => {
+  return resolveMostAdvancedStageIdByStatus({
+    stages: params.stages,
+    tasks: params.tasks,
+    statuses: new Set(['running']),
+  });
+};
+
+export const resolveMostAdvancedInFlightStageId = (params: {
+  stages: Array<{ id: string }>;
+  tasks: StageLikeRunningTask[];
+}): string | null => {
+  return resolveMostAdvancedStageIdByStatus({
+    stages: params.stages,
+    tasks: params.tasks,
+    statuses: new Set(['running', 'queued']),
+  });
+};
 
 const toBuildStatus = (status?: string | null): BuildStatus => {
   switch (status) {
@@ -733,33 +827,23 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     const hasFailed = displayTasks.some((task) => task.status === 'failed');
     return hasFailed ? 'failed' : 'completed';
   }, [displayTasks, hasInFlightTasks]);
-  const buildStatus = useMemo<BuildStatus>(() => {
-    if (tasksCompletionStatus === 'failed') {
-      return 'failed';
-    }
-    if (tasksCompletionStatus === 'completed') {
-      return baseBuildStatus === 'paused' ? 'paused' : 'completed';
-    }
-    if (baseBuildStatus === 'paused') {
-      return 'paused';
-    }
-    if (hasInFlightTasks) {
-      return 'running';
-    }
-    return baseBuildStatus;
-  }, [baseBuildStatus, hasInFlightTasks, tasksCompletionStatus]);
+  const buildStatus = useMemo<BuildStatus>(() => resolveDisplayBuildStatus({
+    baseBuildStatus,
+    tasksCompletionStatus,
+    hasInFlightTasks,
+  }), [baseBuildStatus, hasInFlightTasks, tasksCompletionStatus]);
   const lastTaskRefreshRef = useRef<{ nodeId: string; at: number } | null>(null);
   useEffect(() => {
     if (!activeNodeId) return;
-    if (displayTasks.length > 0) return;
-    const shouldRefresh = (
-      hasProgressTaskSignal
-      || buildStatus === 'running'
-      || buildStatus === 'completed'
-      || runtimeStatus === 'processing'
-      || processingStatus === 'processing'
-      || buildSessionTransition.active
-    );
+    const shouldRefresh = shouldRefreshTasksSnapshot({
+      displayTaskCount: displayTasks.length,
+      hasInFlightTasks,
+      hasProgressTaskSignal,
+      buildStatus,
+      runtimeStatus,
+      processingStatus,
+      buildSessionTransitionActive: buildSessionTransition.active,
+    });
     if (!shouldRefresh) return;
     const now = Date.now();
     const last = lastTaskRefreshRef.current;
@@ -773,6 +857,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     buildStatus,
     buildSessionTransition.active,
     displayTasks.length,
+    hasInFlightTasks,
     hasProgressTaskSignal,
     processingStatus,
     refreshTasks,
@@ -804,6 +889,14 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
 
   const taskType = effectiveProgress?.taskType;
   const liveTaskType = taskType ?? effectiveStatus?.stage;
+  const runningStageIdFromTasks = useMemo(() => resolveMostAdvancedRunningStageId({
+    stages,
+    tasks: displayTasks,
+  }), [displayTasks, stages]);
+  const inFlightStageIdFromTasks = useMemo(() => resolveMostAdvancedInFlightStageId({
+    stages,
+    tasks: displayTasks,
+  }), [displayTasks, stages]);
   const resolvedTaskType = liveTaskType ?? stages[0]?.id;
   const overallProgress = effectiveProgress?.percentage ?? effectiveStatus?.progress ?? 0;
   const isElapsedResetState = useMemo(() => shouldResetElapsedState({
@@ -825,7 +918,13 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
       return;
     }
     const fallbackStageId = buildStatus === 'running' ? resolvedTaskType : null;
-    const nextStageId = liveTaskType ?? timingStageId ?? persistedStageElapsedStageId ?? fallbackStageId ?? null;
+    const nextStageId = runningStageIdFromTasks
+      ?? inFlightStageIdFromTasks
+      ?? liveTaskType
+      ?? timingStageId
+      ?? persistedStageElapsedStageId
+      ?? fallbackStageId
+      ?? null;
     if (nextStageId && nextStageId !== timingStageId) {
       setTimingStageId(nextStageId);
     }
@@ -835,6 +934,8 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     liveTaskType,
     persistedStageElapsedStageId,
     resolvedTaskType,
+    inFlightStageIdFromTasks,
+    runningStageIdFromTasks,
     timingStageId,
   ]);
 
@@ -963,7 +1064,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     effectiveStatus: effectiveStatus ?? null,
     effectiveProgress: effectiveProgress ?? null,
     stages,
-    resolvedTaskType,
+    resolvedTaskType: timingStageId ?? resolvedTaskType,
     displayStageId: progressSummary.displayStageId,
     rawDisplayCounts: progressSummary.rawDisplayCounts,
   });

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync.ts
@@ -39,11 +39,13 @@ const isTaskStage = (value: unknown): value is TaskStage => (
 );
 
 const resolveTaskStage = (task: RawTaskSummary): TaskStage => {
-  const candidate = task.taskType ?? task.type ?? task.stage;
-  if (isTaskStage(candidate)) {
-    return candidate;
+  const candidates: Array<unknown> = [task.stage, task.taskType, task.type];
+  for (const candidate of candidates) {
+    if (isTaskStage(candidate)) {
+      return candidate;
+    }
   }
-  throw new Error(`[ShapeBuildStep] Invalid task stage: ${String(candidate ?? 'undefined')}`);
+  throw new Error(`[ShapeBuildStep] Invalid task stage: ${String(task.stage ?? task.taskType ?? task.type ?? 'undefined')}`);
 };
 
 const resolveProgressValue = (value: number | undefined): number => (
@@ -745,9 +747,14 @@ export const useShapeBuildTaskSync = ({
 
   const resolveTaskSummary = useCallback((task: RawTaskSummary): ShapeBuildTaskSummary => {
     const progress = resolveProgressValue(task.progress);
+    const stage = resolveTaskStage(task);
     const normalized: ShapeBuildTaskSummary = {
       ...task,
-      stage: resolveTaskStage(task),
+      // Keep legacy fields aligned with canonical stage so downstream grouping
+      // does not regress to stale taskType/type values during stage transitions.
+      stage,
+      taskType: stage,
+      type: stage,
       status: normalizeTaskStatus(task.status, progress),
       progress: progress >= 100 ? 100 : task.progress,
     };


### PR DESCRIPTION
## Summary
- prioritize canonical stage (`stage`) over stale legacy fields (`taskType`/`type`) in build task grouping
- add canonical stage-priority resolver and use it for active running stage/in-flight stage selection
- keep `processing` when runtime status temporarily reports stale `completed`/`idle`
- improve long-running task UX with running overlay on task progress bars
- add unit tests for stage selection, summary display stage, and status-source stability

## Verification
- pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run useBuildProgressPanelState.unit.test.ts useShapeBuildStep.elapsed.unit.test.ts useShapeBuildProgressSummary.unit.test.tsx useShapeBuildTasks.unit.test.tsx resolveBuildStatusSource.unit.test.ts
- pnpm -w turbo run typecheck --filter @hierarchidb/ui-batch-progress --filter @hierarchidb/shape-plugin
- pnpm -w turbo run build --filter @hierarchidb/ui-batch-progress --filter @hierarchidb/shape-plugin
- pnpm -w turbo run test --filter @hierarchidb/ui-batch-progress

Refs #301
