### PR TITLE
feat(shape): add vt output quality guard threshold controls

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #325 / `codex/fix/shape/tile-boundary-anomaly-325` / start: 2026-02-16 12:50 JST
 - #323 / `codex/feat/shape/vt-anomaly-detection-params-323` / start: 2026-02-16 10:40 JST
 - #320 / `codex/fix/shape/intake-guard-stall-preview-errors` / start: 2026-02-16 09:18 JST
 - #318 / `codex/feat/shape/step4-anomaly-guard-controls` / start: 2026-02-16 08:40 JST
@@ -106,6 +107,8 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- update: 2026-02-16 13:07 JST #325 VT異常三角形検出ロジックの閾値拡張とStep4設定UI反映後の検証を実施。`pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/gis-sdk --filter @hierarchidb/ui-map` exit 0、`pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/gis-sdk --filter @hierarchidb/ui-map` exit 0、`pnpm exec vitest run packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts` exit 0。
+- start: 2026-02-16 12:50 JST #325 を起票し（https://github.com/kubohiroya/hierarchidb/issues/325）、Project `hierarchidb` の Status を `In Progress` に設定。ブランチ `codex/fix/shape/tile-boundary-anomaly-325` を作成して着手。
 - update: 2026-02-16 10:56 JST #323 作業を専用worktree `/Users/hiroya/WebstormProjects/hierarchidb-issue-323-shape-anomaly-params` へ再配置し、差分を再生。`packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts` の型安全化（triangle ring座標のタプル化と index guard）と関連テスト調整を実施。検証: `pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/ui-map` exit 0、`pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/ui-map` exit 0、`pnpm exec vitest run packages/vt-orchestrator/src/transform/__tests__/transformAnomalyAssessment.unit.test.ts plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts` exit 0。
 - start: 2026-02-16 10:40 JST #323 を起票し（https://github.com/kubohiroya/hierarchidb/issues/323）、Project `hierarchidb` の Status を `In Progress` に設定。ブランチ `codex/feat/shape/vt-anomaly-detection-params-323` を作成して着手。
 - update: 2026-02-16 09:44 JST #320 ズーム帯サマリーアイコン変更を shape 専用化するため、`@hierarchidb/ui-accordion-config` の `ZoomBandConfigSection` に `summaryIcon` prop を追加し、`plugins/shape-plugin/src/ui/components/build-config/ZoomBandConfigSection.tsx` から `Search` アイコンを注入する構成へ調整（route 側は既定 `Settings` を維持）。検証: `pnpm -w turbo run build --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-plugin` exit 0。

--- a/packages/gis-sdk/src/config.ts
+++ b/packages/gis-sdk/src/config.ts
@@ -187,6 +187,12 @@ export type VTOutputQualityGuardConfig = {
   maxZoom: number;
   actionOnAnomaly: VTGuardAction;
   enablePreviewOverlay: boolean;
+  scoreThreshold?: number;
+  minTriangleAngleDeg?: number;
+  minEdgeToBaseRatio?: number;
+  maxAreaToBBoxRatio?: number;
+  minSpanRatio?: number;
+  minBoundaryVertexCount?: number;
 };
 
 export interface RouteTransformConfig {

--- a/packages/shape-api/src/defaults.ts
+++ b/packages/shape-api/src/defaults.ts
@@ -90,6 +90,12 @@ export const DEFAULT_BUILD_CONFIG = {
       maxZoom: 22,
       actionOnAnomaly: 'mark_warning',
       enablePreviewOverlay: false,
+      scoreThreshold: 2.5,
+      minTriangleAngleDeg: 12,
+      minEdgeToBaseRatio: 2.8,
+      maxAreaToBBoxRatio: 0.18,
+      minSpanRatio: 0.03,
+      minBoundaryVertexCount: 1,
     },
   },
   cleanupConfig: {

--- a/packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts
+++ b/packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts
@@ -198,10 +198,10 @@ describe('vtStage summary helpers', () => {
               type: 3,
               geometry: [
                 [
-                  [120, 160],
-                  [3900, 162],
                   [180, 220],
-                  [120, 160],
+                  [3900, 3900],
+                  [260, 300],
+                  [180, 220],
                 ],
               ],
               tags: { __hdbFeatureId: 'JP:1:hiroshima' },
@@ -218,5 +218,81 @@ describe('vtStage summary helpers', () => {
     expect(issues.length).toBe(1);
     expect(issues[0]?.originStage).toBe('transform-or-earlier');
     expect(issues[0]?.featureId).toBe('JP:1:hiroshima');
+  });
+
+  it('detects spike anomalies from non-triangle polygon rings', () => {
+    const issues = vtStageTestUtils.collectTileTriangleIssues({
+      layers: {
+        admin1: {
+          features: [
+            {
+              type: 3,
+              geometry: [
+                [
+                  [120, 220],
+                  [180, 260],
+                  [3900, 3900],
+                  [260, 300],
+                  [120, 232],
+                  [120, 220],
+                ],
+              ],
+              tags: { __hdbFeatureId: 'JP:1:spike' },
+            },
+          ],
+        } as unknown as import('geojson-vt').Tile,
+      },
+      z: 6,
+      x: 56,
+      y: 25,
+      extent: 4096,
+    });
+
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.featureId).toBe('JP:1:spike');
+    expect((issues[0]?.ringVertexCount ?? 0) > 3).toBe(true);
+  });
+
+  it('repairs detected spike anomalies by removing suspect ring vertices', () => {
+    const layers = {
+      admin1: {
+        features: [
+          {
+            type: 3,
+            geometry: [
+              [
+                [120, 220],
+                [180, 260],
+                [3900, 3900],
+                [260, 300],
+                [120, 232],
+                [120, 220],
+              ],
+            ],
+            tags: { __hdbFeatureId: 'JP:1:spike-repair' },
+          },
+        ],
+      } as unknown as import('geojson-vt').Tile,
+    };
+    const issues = vtStageTestUtils.collectTileTriangleIssues({
+      layers,
+      z: 6,
+      x: 56,
+      y: 25,
+      extent: 4096,
+    });
+    expect(issues.length).toBeGreaterThan(0);
+
+    const repaired = vtStageTestUtils.repairTileLayersForTriangleIssues({ layers, issues });
+    expect(repaired.repairedIssueKeys.size).toBeGreaterThan(0);
+
+    const remaining = vtStageTestUtils.collectTileTriangleIssues({
+      layers: repaired.layers,
+      z: 6,
+      x: 56,
+      y: 25,
+      extent: 4096,
+    });
+    expect(remaining.length).toBe(0);
   });
 });

--- a/packages/vt-orchestrator/src/vt/vtStage.ts
+++ b/packages/vt-orchestrator/src/vt/vtStage.ts
@@ -13,7 +13,7 @@ import type { ShapeTransformErrorRecord } from '@hierarchidb/shape-api';
 import { geojson as geojsonApi } from 'flatgeobuf';
 import type { Tile } from 'geojson-vt';
 import type vtPbfNS = require('@maplibre/vt-pbf');
-import { geometryBboxClip } from '@hierarchidb/gis-sdk';
+import { geometryBboxClip, type VTOutputQualityGuardConfig } from '@hierarchidb/gis-sdk';
 import { packTileId, parentToChildRange, unpackTileId } from '../tiles/tileId.js';
 import { NobleSha3HashPort } from '@hierarchidb/chunk-store';
 import type { VTStageContext } from '../contexts.js';
@@ -563,21 +563,41 @@ const countTileLineStrings = (geometry: unknown): number => {
   return geometry.length;
 };
 
-const VT_TRIANGLE_MIN_ANGLE_DEGREES = 8;
-const VT_TRIANGLE_MIN_SPAN_RATIO = 0.04;
+const VT_TRIANGLE_MIN_ANGLE_DEGREES = 12;
+const VT_TRIANGLE_MIN_EDGE_TO_BASE_RATIO = 2.8;
+const VT_TRIANGLE_MAX_AREA_TO_BBOX_RATIO = 0.18;
+const VT_TRIANGLE_MIN_SPAN_RATIO = 0.03;
+const VT_TRIANGLE_SCORE_THRESHOLD = 2.5;
+const VT_TRIANGLE_MIN_BOUNDARY_VERTEX_COUNT = 1;
 const VT_TRIANGLE_ISSUE_RECORD_LIMIT = 240;
 const VT_ORIGIN_BOUNDARY_VERTEX_THRESHOLD = 2;
 
 type VtTriangleOriginStage = 'vt' | 'transform-or-earlier';
 
 type VtTriangleIssue = {
+  key: string;
   featureId: string;
+  featureIndex: number;
   layerName: string;
   ringIndex: number;
+  ringVertexCount: number;
+  suspectVertexIndex: number;
+  score: number;
   minAngleDeg: number;
+  edgeToBaseRatio: number;
+  areaToBBoxRatio: number;
   maxSpan: number;
   boundaryVertexCount: number;
   originStage: VtTriangleOriginStage;
+};
+
+type VtTriangleIssueThresholds = {
+  scoreThreshold: number;
+  minTriangleAngleDeg: number;
+  minEdgeToBaseRatio: number;
+  maxAreaToBBoxRatio: number;
+  minSpanRatio: number;
+  minBoundaryVertexCount: number;
 };
 
 type TileVertex = [number, number];
@@ -617,6 +637,17 @@ const normalizeRingVertices = (ring: number[][]): TileVertex[] => {
   return deduped;
 };
 
+const resolveVtTriangleIssueThresholds = (
+  guard?: VTOutputQualityGuardConfig,
+): VtTriangleIssueThresholds => ({
+  scoreThreshold: guard?.scoreThreshold ?? VT_TRIANGLE_SCORE_THRESHOLD,
+  minTriangleAngleDeg: guard?.minTriangleAngleDeg ?? VT_TRIANGLE_MIN_ANGLE_DEGREES,
+  minEdgeToBaseRatio: guard?.minEdgeToBaseRatio ?? VT_TRIANGLE_MIN_EDGE_TO_BASE_RATIO,
+  maxAreaToBBoxRatio: guard?.maxAreaToBBoxRatio ?? VT_TRIANGLE_MAX_AREA_TO_BBOX_RATIO,
+  minSpanRatio: guard?.minSpanRatio ?? VT_TRIANGLE_MIN_SPAN_RATIO,
+  minBoundaryVertexCount: guard?.minBoundaryVertexCount ?? VT_TRIANGLE_MIN_BOUNDARY_VERTEX_COUNT,
+});
+
 const resolveTriangleAngle = (a: TileVertex, b: TileVertex, c: TileVertex): number | null => {
   const bax = a[0] - b[0];
   const bay = a[1] - b[1];
@@ -633,11 +664,23 @@ const resolveTriangleAngle = (a: TileVertex, b: TileVertex, c: TileVertex): numb
   return radians * 180 / Math.PI;
 };
 
+const resolveDistance = (pointA: TileVertex, pointB: TileVertex): number => {
+  const dx = pointA[0] - pointB[0];
+  const dy = pointA[1] - pointB[1];
+  return Math.hypot(dx, dy);
+};
+
+const resolveTriangleArea = (a: TileVertex, b: TileVertex, c: TileVertex): number => (
+  Math.abs(((a[0] * (b[1] - c[1])) + (b[0] * (c[1] - a[1])) + (c[0] * (a[1] - b[1]))) / 2)
+);
+
 const resolveTriangleDiagnostics = (
   vertices: TileVertex[],
   extent: number,
 ): {
   minAngleDeg: number;
+  edgeToBaseRatio: number;
+  areaToBBoxRatio: number;
   maxSpan: number;
   boundaryVertexCount: number;
   originStage: VtTriangleOriginStage;
@@ -657,6 +700,14 @@ const resolveTriangleDiagnostics = (
   const minY = Math.min(...ys);
   const maxY = Math.max(...ys);
   const maxSpan = Math.max(maxX - minX, maxY - minY);
+  const baseLength = resolveDistance(a, c);
+  const edgeLengthAB = resolveDistance(a, b);
+  const edgeLengthBC = resolveDistance(b, c);
+  const longestEdge = Math.max(edgeLengthAB, edgeLengthBC);
+  const edgeToBaseRatio = longestEdge > 0 && baseLength > 0 ? longestEdge / baseLength : Number.POSITIVE_INFINITY;
+  const bboxArea = Math.max(0, (maxX - minX) * (maxY - minY));
+  const triangleArea = resolveTriangleArea(a, b, c);
+  const areaToBBoxRatio = bboxArea > 0 ? triangleArea / bboxArea : 0;
   const boundaryVertexCount = [a, b, c].reduce((count, vertex) => {
     const x = vertex[0];
     const y = vertex[1];
@@ -665,10 +716,29 @@ const resolveTriangleDiagnostics = (
   }, 0);
   return {
     minAngleDeg,
+    edgeToBaseRatio,
+    areaToBBoxRatio,
     maxSpan,
     boundaryVertexCount,
     originStage: boundaryVertexCount >= VT_ORIGIN_BOUNDARY_VERTEX_THRESHOLD ? 'vt' : 'transform-or-earlier',
   };
+};
+
+const resolveTriangleIssueScore = (
+  diagnostics: {
+    minAngleDeg: number;
+    edgeToBaseRatio: number;
+    areaToBBoxRatio: number;
+    boundaryVertexCount: number;
+  },
+  thresholds: VtTriangleIssueThresholds,
+): number => {
+  let score = 0;
+  if (diagnostics.minAngleDeg <= thresholds.minTriangleAngleDeg) score += 1;
+  if (diagnostics.edgeToBaseRatio >= thresholds.minEdgeToBaseRatio) score += 1;
+  if (diagnostics.areaToBBoxRatio <= thresholds.maxAreaToBBoxRatio) score += 1;
+  if (diagnostics.boundaryVertexCount >= thresholds.minBoundaryVertexCount) score += 0.5;
+  return score;
 };
 
 const resolveTileFeatureIdFromVt = (feature: Tile['features'][number], fallback: string): string => {
@@ -693,9 +763,11 @@ const collectTileTriangleIssues = (params: {
   x: number;
   y: number;
   extent: number;
+  thresholds?: VtTriangleIssueThresholds;
 }): VtTriangleIssue[] => {
   const issues: VtTriangleIssue[] = [];
-  const minSpan = Math.max(1, params.extent * VT_TRIANGLE_MIN_SPAN_RATIO);
+  const thresholds = params.thresholds ?? resolveVtTriangleIssueThresholds(undefined);
+  const minSpan = Math.max(1, params.extent * thresholds.minSpanRatio);
   Object.entries(params.layers).forEach(([layerName, layerTile]) => {
     const features = Array.isArray(layerTile.features) ? layerTile.features : [];
     features.forEach((feature, featureIndex) => {
@@ -708,24 +780,230 @@ const collectTileTriangleIssues = (params: {
       );
       rings.forEach((ring, ringIndex) => {
         const vertices = normalizeRingVertices(ring);
-        if (vertices.length !== 3) return;
-        const diagnostics = resolveTriangleDiagnostics(vertices, params.extent);
-        if (!diagnostics) return;
-        if (diagnostics.maxSpan < minSpan) return;
-        if (diagnostics.minAngleDeg > VT_TRIANGLE_MIN_ANGLE_DEGREES) return;
-        issues.push({
-          featureId,
-          layerName,
-          ringIndex,
-          minAngleDeg: diagnostics.minAngleDeg,
-          maxSpan: diagnostics.maxSpan,
-          boundaryVertexCount: diagnostics.boundaryVertexCount,
-          originStage: diagnostics.originStage,
-        });
+        if (vertices.length < 3) return;
+        const ringVertexCount = vertices.length;
+        let bestIssue: VtTriangleIssue | null = null;
+        for (let vertexIndex = 0; vertexIndex < ringVertexCount; vertexIndex += 1) {
+          const prev = vertices[(vertexIndex + ringVertexCount - 1) % ringVertexCount];
+          const current = vertices[vertexIndex];
+          const next = vertices[(vertexIndex + 1) % ringVertexCount];
+          if (!prev || !current || !next) continue;
+          const diagnostics = resolveTriangleDiagnostics([prev, current, next], params.extent);
+          if (!diagnostics) continue;
+          if (diagnostics.maxSpan < minSpan) continue;
+          const score = resolveTriangleIssueScore(diagnostics, thresholds);
+          if (score < thresholds.scoreThreshold) continue;
+          const issue: VtTriangleIssue = {
+            key: `${layerName}:${featureIndex}:${ringIndex}:${vertexIndex}`,
+            featureId,
+            featureIndex,
+            layerName,
+            ringIndex,
+            ringVertexCount,
+            suspectVertexIndex: vertexIndex,
+            score,
+            minAngleDeg: diagnostics.minAngleDeg,
+            edgeToBaseRatio: diagnostics.edgeToBaseRatio,
+            areaToBBoxRatio: diagnostics.areaToBBoxRatio,
+            maxSpan: diagnostics.maxSpan,
+            boundaryVertexCount: diagnostics.boundaryVertexCount,
+            originStage: diagnostics.originStage,
+          };
+          if (
+            !bestIssue
+            || issue.score > bestIssue.score
+            || (issue.score === bestIssue.score && issue.minAngleDeg < bestIssue.minAngleDeg)
+          ) {
+            bestIssue = issue;
+          }
+        }
+        if (bestIssue) issues.push(bestIssue);
       });
     });
   });
   return issues;
+};
+
+type TileRingReference = {
+  flatRingIndex: number;
+  ring: number[][];
+  remove: () => void;
+  replace: (next: number[][]) => void;
+};
+
+const isTilePoint = (value: unknown): value is number[] => (
+  Array.isArray(value)
+  && value.length >= 2
+  && typeof value[0] === 'number'
+  && typeof value[1] === 'number'
+);
+
+const isTileRing = (value: unknown): value is number[][] => (
+  Array.isArray(value)
+  && value.length > 0
+  && isTilePoint(value[0])
+);
+
+const isTilePolygon = (value: unknown): value is number[][][] => (
+  Array.isArray(value)
+  && value.length > 0
+  && isTileRing(value[0])
+);
+
+const isTileMultiPolygon = (value: unknown): value is number[][][][] => (
+  Array.isArray(value)
+  && value.length > 0
+  && isTilePolygon(value[0])
+);
+
+const cloneTileGeometry = (geometry: unknown): unknown => (
+  Array.isArray(geometry)
+    ? geometry.map((child) => cloneTileGeometry(child))
+    : geometry
+);
+
+const collectTileRingReferences = (geometry: unknown): TileRingReference[] => {
+  const refs: TileRingReference[] = [];
+  let flatRingIndex = 0;
+  if (isTilePolygon(geometry)) {
+    const polygon = geometry;
+    polygon.forEach((ring, ringIndex) => {
+      if (!isTileRing(ring)) return;
+      const currentIndex = flatRingIndex;
+      flatRingIndex += 1;
+      refs.push({
+        flatRingIndex: currentIndex,
+        ring,
+        remove: () => {
+          polygon.splice(ringIndex, 1);
+        },
+        replace: (next) => {
+          polygon[ringIndex] = next;
+        },
+      });
+    });
+    return refs;
+  }
+  if (isTileMultiPolygon(geometry)) {
+    const multiPolygon = geometry;
+    multiPolygon.forEach((polygon, polygonIndex) => {
+      polygon.forEach((ring, ringIndex) => {
+        if (!isTileRing(ring)) return;
+        const currentIndex = flatRingIndex;
+        flatRingIndex += 1;
+        refs.push({
+          flatRingIndex: currentIndex,
+          ring,
+          remove: () => {
+            const polygonRef = multiPolygon[polygonIndex];
+            if (!polygonRef) return;
+            polygonRef.splice(ringIndex, 1);
+            if (polygonRef.length === 0) {
+              multiPolygon.splice(polygonIndex, 1);
+            }
+          },
+          replace: (next) => {
+            const polygonRef = multiPolygon[polygonIndex];
+            if (!polygonRef) return;
+            polygonRef[ringIndex] = next;
+          },
+        });
+      });
+    });
+  }
+  return refs;
+};
+
+const cleanupTilePolygonGeometry = (geometry: unknown): unknown | null => {
+  if (isTilePolygon(geometry)) {
+    const cleanedRings = geometry.filter((ring) => normalizeRingVertices(ring).length >= 3);
+    return cleanedRings.length > 0 ? cleanedRings : null;
+  }
+  if (isTileMultiPolygon(geometry)) {
+    const cleanedPolygons = geometry
+      .map((polygon) => polygon.filter((ring) => normalizeRingVertices(ring).length >= 3))
+      .filter((polygon) => polygon.length > 0);
+    return cleanedPolygons.length > 0 ? cleanedPolygons : null;
+  }
+  return null;
+};
+
+const rebuildRingWithoutVertex = (ring: number[][], suspectVertexIndex: number): number[][] | null => {
+  const vertices = normalizeRingVertices(ring);
+  if (vertices.length <= 3) return null;
+  if (!Number.isInteger(suspectVertexIndex) || suspectVertexIndex < 0 || suspectVertexIndex >= vertices.length) {
+    return null;
+  }
+  const nextVertices = vertices.filter((_, index) => index !== suspectVertexIndex);
+  if (nextVertices.length < 3) return null;
+  const first = nextVertices[0];
+  if (!first) return null;
+  return [...nextVertices, [...first]];
+};
+
+const repairTileLayersForTriangleIssues = (params: {
+  layers: Record<string, Tile>;
+  issues: VtTriangleIssue[];
+}): {
+  layers: Record<string, Tile>;
+  repairedIssueKeys: Set<string>;
+} => {
+  const issuesByLayerAndFeature = new Map<string, VtTriangleIssue[]>();
+  params.issues.forEach((issue) => {
+    const key = `${issue.layerName}:${issue.featureIndex}`;
+    const bucket = issuesByLayerAndFeature.get(key);
+    if (bucket) {
+      bucket.push(issue);
+    } else {
+      issuesByLayerAndFeature.set(key, [issue]);
+    }
+  });
+  const repairedIssueKeys = new Set<string>();
+  const repairedLayers: Record<string, Tile> = {};
+  Object.entries(params.layers).forEach(([layerName, layerTile]) => {
+    const features = Array.isArray(layerTile.features) ? layerTile.features : [];
+    const nextFeatures: Tile['features'] = [];
+    features.forEach((feature, featureIndex) => {
+      const featureIssues = issuesByLayerAndFeature.get(`${layerName}:${featureIndex}`);
+      if (!featureIssues || featureIssues.length === 0 || feature.type !== 3) {
+        nextFeatures.push(feature);
+        return;
+      }
+      const geometryClone = cloneTileGeometry(feature.geometry);
+      const ringRefs = collectTileRingReferences(geometryClone);
+      if (ringRefs.length === 0) {
+        nextFeatures.push(feature);
+        return;
+      }
+      const sortedIssues = [...featureIssues].sort((a, b) => b.ringIndex - a.ringIndex);
+      sortedIssues.forEach((issue) => {
+        const ringRef = ringRefs.find((candidate) => candidate.flatRingIndex === issue.ringIndex);
+        if (!ringRef) return;
+        if (issue.ringVertexCount <= 3) {
+          ringRef.remove();
+          repairedIssueKeys.add(issue.key);
+          return;
+        }
+        const rebuiltRing = rebuildRingWithoutVertex(ringRef.ring, issue.suspectVertexIndex);
+        if (!rebuiltRing) return;
+        ringRef.replace(rebuiltRing);
+        repairedIssueKeys.add(issue.key);
+      });
+      const cleanedGeometry = cleanupTilePolygonGeometry(geometryClone);
+      if (!cleanedGeometry) {
+        return;
+      }
+      nextFeatures.push({
+        ...feature,
+        geometry: cleanedGeometry as Tile['features'][number]['geometry'],
+      });
+    });
+    repairedLayers[layerName] = {
+      ...layerTile,
+      features: nextFeatures,
+    };
+  });
+  return { layers: repairedLayers, repairedIssueKeys };
 };
 
 const buildBufferSetHash = (bufferIds: string[]): string => {
@@ -1185,7 +1463,9 @@ export const vtStageTestUtils = {
   buildGeojsonVtEmptyTileSummaryReason,
   resolveVtDebugFocusConfig,
   resolveVtDebugFocusMatch,
+  resolveVtTriangleIssueThresholds,
   collectTileTriangleIssues,
+  repairTileLayersForTriangleIssues,
   computeOutputTileTotals,
 };
 type FeatureWithBBox = { feature: Feature; bbox: TileBBox };
@@ -1302,6 +1582,15 @@ const buildLayerIndexes = async (
 export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInput> => {
   const { bands, vtConfig, tileWriter, abortSignal } = context;
   const layerSetName = vtConfig.layerSetName;
+  const outputQualityGuard = vtConfig.outputQualityGuard;
+  const outputQualityThresholds = resolveVtTriangleIssueThresholds(outputQualityGuard);
+  const isOutputQualityGuardEnabledAtZoom = (z: number): boolean => {
+    if (!outputQualityGuard?.enabled) return false;
+    if (!Number.isFinite(outputQualityGuard.minZoom) || !Number.isFinite(outputQualityGuard.maxZoom)) return false;
+    const minZoom = Math.min(outputQualityGuard.minZoom, outputQualityGuard.maxZoom);
+    const maxZoom = Math.max(outputQualityGuard.minZoom, outputQualityGuard.maxZoom);
+    return z >= minZoom && z <= maxZoom;
+  };
   if (!layerSetName) {
     throw new Error('vt stage requires layerSetName');
   }
@@ -1353,6 +1642,15 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
         zRange: [band.zMin, band.zMax],
         layerSetName,
         bufferIdSample,
+        outputQualityGuard: outputQualityGuard
+          ? {
+            enabled: outputQualityGuard.enabled,
+            minZoom: outputQualityGuard.minZoom,
+            maxZoom: outputQualityGuard.maxZoom,
+            actionOnAnomaly: outputQualityGuard.actionOnAnomaly,
+            thresholds: outputQualityThresholds,
+          }
+          : null,
       }));
       if (debugFocusConfig.enabled) {
         console.info('[vt][focus] enabled', JSON.stringify({
@@ -2002,38 +2300,53 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
       const vtTriangleIssueRecords: ShapeTransformErrorRecord[] = [];
       const vtTriangleIssueKeys = new Set<string>();
       let triangleIssueTotalCount = 0;
+      let triangleRepairedTotalCount = 0;
       let vtOriginIssueCount = 0;
       let preVtOriginIssueCount = 0;
       const normalizeIssueToken = (value: string): string => value.replace(/[^A-Za-z0-9:_-]/g, '_');
-      const appendVtTriangleIssueRecord = (issue: VtTriangleIssue, z: number, x: number, y: number) => {
-        const issueKey = `${z}/${x}/${y}:${issue.layerName}:${issue.featureId}:${issue.ringIndex}`;
+      const appendVtTriangleIssueRecord = (
+        issue: VtTriangleIssue,
+        z: number,
+        x: number,
+        y: number,
+        status: 'suspect' | 'repaired',
+      ) => {
+        const issueKey = `${status}:${z}/${x}/${y}:${issue.layerName}:${issue.featureId}:${issue.ringIndex}:${issue.suspectVertexIndex}`;
         if (vtTriangleIssueKeys.has(issueKey)) return;
         vtTriangleIssueKeys.add(issueKey);
-        triangleIssueTotalCount += 1;
-        if (issue.originStage === 'vt') {
-          vtOriginIssueCount += 1;
+        if (status === 'repaired') {
+          triangleRepairedTotalCount += 1;
         } else {
-          preVtOriginIssueCount += 1;
+          triangleIssueTotalCount += 1;
+          if (issue.originStage === 'vt') {
+            vtOriginIssueCount += 1;
+          } else {
+            preVtOriginIssueCount += 1;
+          }
         }
         if (vtTriangleIssueRecords.length >= VT_TRIANGLE_ISSUE_RECORD_LIMIT) return;
         const featureToken = normalizeIssueToken(issue.featureId).slice(0, 72);
+        const kindPrefix = issue.originStage === 'vt' ? 'vt-boundary-spike' : 'pre-vt-spike';
+        const issueKind = status === 'repaired' ? `${kindPrefix}-repaired` : `${kindPrefix}-suspect`;
+        const issueStage = status === 'repaired' ? 'tile-repair' : 'tile-diagnostic';
+        const messagePrefix = status === 'repaired' ? '[vt-repair]' : '[vt-diagnostic]';
         vtTriangleIssueRecords.push({
-          id: `${task.taskId}:vt-diagnostic:${z}:${x}:${y}:${issue.ringIndex}:${featureToken}`,
+          id: `${task.taskId}:vt-${status}:${z}:${x}:${y}:${issue.ringIndex}:${issue.suspectVertexIndex}:${featureToken}`,
           nodeId: task.nodeId,
           taskId: task.taskId,
           stage: 'vt',
-          issueStage: 'tile-diagnostic',
-          issueKind: issue.originStage === 'vt' ? 'vt-boundary-triangle-suspect' : 'pre-vt-triangle-suspect',
+          issueStage,
+          issueKind,
           bandIndex: input.bandIndex,
           sourceKey: input.sourceKey,
           featureId: issue.featureId,
-          featureIndex: issue.ringIndex,
+          featureIndex: issue.featureIndex,
           geometryType: 'Polygon',
           polygonCount: 1,
           ringCount: 1,
           polygonErrorCount: 1,
           ringErrorCount: 1,
-          message: `[vt-diagnostic] originStage=${issue.originStage} tile=${z}/${x}/${y} layer=${issue.layerName} ring=${issue.ringIndex} minAngleDeg=${issue.minAngleDeg.toFixed(3)} boundaryVertices=${issue.boundaryVertexCount}/3 maxSpan=${issue.maxSpan.toFixed(1)}`,
+          message: `${messagePrefix} originStage=${issue.originStage} tile=${z}/${x}/${y} layer=${issue.layerName} ring=${issue.ringIndex} vertex=${issue.suspectVertexIndex} score=${issue.score.toFixed(2)} minAngleDeg=${issue.minAngleDeg.toFixed(3)} edgeToBaseRatio=${issue.edgeToBaseRatio.toFixed(3)} areaToBBoxRatio=${issue.areaToBBoxRatio.toFixed(3)} boundaryVertices=${issue.boundaryVertexCount}/3 maxSpan=${issue.maxSpan.toFixed(1)}`,
           createdAt: Date.now(),
           lineFeatures: { type: 'FeatureCollection', features: [] },
         });
@@ -2121,23 +2434,56 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
           for (let y = yStart; y <= yEnd; y++) {
             assertNotAborted(abortSignal);
             const tileId = packTileId(x, y, z);
-            const layers = aggregatedLayersByTileId
+            const baseLayers = aggregatedLayersByTileId
               ? (aggregatedLayersByTileId.get(tileId) ?? null)
               : (indexes ? collectLayersForTileFromIndexes(indexes, z, x, y) : null);
             processedTiles += 1;
-            if (!layers) {
+            if (!baseLayers) {
               await reportTileProgress(false);
               continue;
             }
-            const triangleIssues = collectTileTriangleIssues({
-              layers,
-              z,
-              x,
-              y,
-              extent: context.vtConfig.extent,
-            });
-            if (triangleIssues.length > 0) {
-              triangleIssues.forEach((issue) => appendVtTriangleIssueRecord(issue, z, x, y));
+            let layers = baseLayers;
+            const qualityGuardActive = isOutputQualityGuardEnabledAtZoom(z);
+            if (qualityGuardActive) {
+              const initialIssues = collectTileTriangleIssues({
+                layers,
+                z,
+                x,
+                y,
+                extent: context.vtConfig.extent,
+                thresholds: outputQualityThresholds,
+              });
+              if (initialIssues.length > 0) {
+                const guardAction = outputQualityGuard?.actionOnAnomaly ?? 'mark_warning';
+                if (guardAction === 'fallback_less_simplified') {
+                  const repairResult = repairTileLayersForTriangleIssues({
+                    layers,
+                    issues: initialIssues,
+                  });
+                  layers = repairResult.layers;
+                  const remainingIssues = collectTileTriangleIssues({
+                    layers,
+                    z,
+                    x,
+                    y,
+                    extent: context.vtConfig.extent,
+                    thresholds: outputQualityThresholds,
+                  });
+                  const remainingIssueKeys = new Set(remainingIssues.map((issue) => issue.key));
+                  initialIssues.forEach((issue) => {
+                    if (!repairResult.repairedIssueKeys.has(issue.key)) return;
+                    if (remainingIssueKeys.has(issue.key)) return;
+                    appendVtTriangleIssueRecord(issue, z, x, y, 'repaired');
+                  });
+                  remainingIssues.forEach((issue) => appendVtTriangleIssueRecord(issue, z, x, y, 'suspect'));
+                } else {
+                  initialIssues.forEach((issue) => appendVtTriangleIssueRecord(issue, z, x, y, 'suspect'));
+                  if (guardAction === 'drop_tile') {
+                    await reportTileProgress(false, `tiles ${processedTiles}/${totalTiles} | dropped tile z=${z} x=${x} y=${y} due to anomalies=${initialIssues.length}`);
+                    continue;
+                  }
+                }
+              }
             }
             const tileBBox = tileToBBox(z, x, y);
             const inputStats = computeInputTileStats(
@@ -2266,7 +2612,7 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
         generatedTiles,
         outputTotals: totalOutputStats,
       }));
-      if (triangleIssueTotalCount > 0) {
+      if (triangleIssueTotalCount > 0 || triangleRepairedTotalCount > 0) {
         if (vtTriangleIssueRecords.length > 0) {
           try {
             await context.ephemeralDB.transformErrors.bulkPut(vtTriangleIssueRecords);
@@ -2274,6 +2620,7 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
             console.warn('[vt][diagnostic] failed to persist triangle issue records', JSON.stringify({
               ...taskContext,
               triangleIssueCount: triangleIssueTotalCount,
+              triangleRepairedCount: triangleRepairedTotalCount,
               persistedCount: vtTriangleIssueRecords.length,
               error: error instanceof Error ? error.message : String(error),
             }));
@@ -2282,10 +2629,11 @@ export const createVtHandler = (context: VTStageContext): StageHandler<VtTaskInp
         console.warn('[vt][diagnostic] triangle issue summary', JSON.stringify({
           ...taskContext,
           triangleIssueCount: triangleIssueTotalCount,
+          triangleRepairedCount: triangleRepairedTotalCount,
           vtOriginIssueCount,
           preVtOriginIssueCount,
           persistedCount: vtTriangleIssueRecords.length,
-          droppedCount: Math.max(0, triangleIssueTotalCount - vtTriangleIssueRecords.length),
+          droppedCount: Math.max(0, triangleIssueTotalCount + triangleRepairedTotalCount - vtTriangleIssueRecords.length),
         }));
       }
       console.info('[vt] task completed', JSON.stringify({

--- a/plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts
@@ -125,6 +125,12 @@ describe('mergeBuildConfig', () => {
           maxZoom: 8,
           actionOnAnomaly: 'mark_warning',
           enablePreviewOverlay: true,
+          scoreThreshold: 2.8,
+          minTriangleAngleDeg: 15,
+          minEdgeToBaseRatio: 3.1,
+          maxAreaToBBoxRatio: 0.12,
+          minSpanRatio: 0.04,
+          minBoundaryVertexCount: 2,
         },
       },
     });
@@ -136,5 +142,11 @@ describe('mergeBuildConfig', () => {
     expect(merged.transformConfig.anomalyDetection?.topojson?.minSharedArcRatioPercent).toBe(14);
     expect(merged.transformConfig.anomalyRetry?.fallbackMode).toBe('switch_algorithm');
     expect(merged.vtConfig.outputQualityGuard?.enablePreviewOverlay).toBe(true);
+    expect(merged.vtConfig.outputQualityGuard?.scoreThreshold).toBe(2.8);
+    expect(merged.vtConfig.outputQualityGuard?.minTriangleAngleDeg).toBe(15);
+    expect(merged.vtConfig.outputQualityGuard?.minEdgeToBaseRatio).toBe(3.1);
+    expect(merged.vtConfig.outputQualityGuard?.maxAreaToBBoxRatio).toBe(0.12);
+    expect(merged.vtConfig.outputQualityGuard?.minSpanRatio).toBe(0.04);
+    expect(merged.vtConfig.outputQualityGuard?.minBoundaryVertexCount).toBe(2);
   });
 });

--- a/plugins/shape-plugin/src/ui/components/build-config/VtOutputQualityGuardCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/VtOutputQualityGuardCard.tsx
@@ -7,6 +7,7 @@ import {
   Slider,
   Stack,
   Switch,
+  TextField,
   Typography,
 } from '@mui/material';
 import {
@@ -35,6 +36,12 @@ export const VtOutputQualityGuardCard: React.FC<Props> = ({ config, onChange, di
     maxZoom: guard?.maxZoom ?? 22,
     actionOnAnomaly: guard?.actionOnAnomaly ?? 'mark_warning',
     enablePreviewOverlay: guard?.enablePreviewOverlay ?? false,
+    scoreThreshold: guard?.scoreThreshold ?? 2.5,
+    minTriangleAngleDeg: guard?.minTriangleAngleDeg ?? 12,
+    minEdgeToBaseRatio: guard?.minEdgeToBaseRatio ?? 2.8,
+    maxAreaToBBoxRatio: guard?.maxAreaToBBoxRatio ?? 0.18,
+    minSpanRatio: guard?.minSpanRatio ?? 0.03,
+    minBoundaryVertexCount: guard?.minBoundaryVertexCount ?? 1,
   } as const;
 
   const updateGuard = (partial: Partial<typeof resolvedGuard>) => {
@@ -139,6 +146,87 @@ export const VtOutputQualityGuardCard: React.FC<Props> = ({ config, onChange, di
             </MenuItem>
           </Select>
         </FormControl>
+        <Stack spacing={1}>
+          <Typography variant="body2" color="text.secondary" fontWeight={600}>
+            {t('processing.vt.outputQualityGuard.thresholds.title', 'Anomaly thresholds')}
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.vt.outputQualityGuard.thresholds.scoreThreshold', 'Score threshold')}
+              value={resolvedGuard.scoreThreshold}
+              disabled={disabled || !resolvedGuard.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateGuard({ scoreThreshold: Math.max(0.1, value) });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.vt.outputQualityGuard.thresholds.minTriangleAngleDeg', 'Max acute angle (deg)')}
+              value={resolvedGuard.minTriangleAngleDeg}
+              disabled={disabled || !resolvedGuard.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateGuard({ minTriangleAngleDeg: Math.max(0.1, Math.min(89, value)) });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.vt.outputQualityGuard.thresholds.minBoundaryVertexCount', 'Min boundary vertices')}
+              value={resolvedGuard.minBoundaryVertexCount}
+              disabled={disabled || !resolvedGuard.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateGuard({ minBoundaryVertexCount: Math.max(0, Math.min(3, Math.floor(value))) });
+              }}
+            />
+          </Stack>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.vt.outputQualityGuard.thresholds.minEdgeToBaseRatio', 'Min edge/base ratio')}
+              value={resolvedGuard.minEdgeToBaseRatio}
+              disabled={disabled || !resolvedGuard.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateGuard({ minEdgeToBaseRatio: Math.max(1, value) });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.vt.outputQualityGuard.thresholds.maxAreaToBBoxRatio', 'Max area/BBox ratio')}
+              value={resolvedGuard.maxAreaToBBoxRatio}
+              disabled={disabled || !resolvedGuard.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateGuard({ maxAreaToBBoxRatio: Math.max(0.0001, Math.min(1, value)) });
+              }}
+            />
+            <TextField
+              size="small"
+              type="number"
+              label={t('processing.vt.outputQualityGuard.thresholds.minSpanRatio', 'Min span ratio')}
+              value={resolvedGuard.minSpanRatio}
+              disabled={disabled || !resolvedGuard.enabled}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                if (!Number.isFinite(value)) return;
+                updateGuard({ minSpanRatio: Math.max(0.0001, Math.min(1, value)) });
+              }}
+            />
+          </Stack>
+        </Stack>
         <FormControlLabel
           control={(
             <Switch

--- a/plugins/shape-plugin/src/ui/locales/en.json
+++ b/plugins/shape-plugin/src/ui/locales/en.json
@@ -165,7 +165,16 @@
           "fallback": "Fallback to less simplified",
           "dropTile": "Drop tile"
         },
-        "enablePreviewOverlay": "Show warning overlay in preview"
+        "enablePreviewOverlay": "Show warning overlay in preview",
+        "thresholds": {
+          "title": "Anomaly thresholds",
+          "scoreThreshold": "Score threshold",
+          "minTriangleAngleDeg": "Max acute angle (deg)",
+          "minEdgeToBaseRatio": "Min edge/base ratio",
+          "maxAreaToBBoxRatio": "Max area/BBox ratio",
+          "minSpanRatio": "Min span ratio",
+          "minBoundaryVertexCount": "Min boundary vertices"
+        }
       }
     },
     "download": {

--- a/plugins/shape-plugin/src/ui/locales/ja.json
+++ b/plugins/shape-plugin/src/ui/locales/ja.json
@@ -165,7 +165,16 @@
           "fallback": "簡略化を弱めて再試行",
           "dropTile": "タイルを破棄"
         },
-        "enablePreviewOverlay": "プレビューで警告オーバーレイを表示"
+        "enablePreviewOverlay": "プレビューで警告オーバーレイを表示",
+        "thresholds": {
+          "title": "異常判定の閾値",
+          "scoreThreshold": "スコア閾値",
+          "minTriangleAngleDeg": "鋭角上限 (度)",
+          "minEdgeToBaseRatio": "辺/底辺 比の下限",
+          "maxAreaToBBoxRatio": "面積/BBox比の上限",
+          "minSpanRatio": "最小スパン比",
+          "minBoundaryVertexCount": "境界頂点数の下限"
+        }
       }
     },
     "download": {


### PR DESCRIPTION
## Summary\n- add configurable VT output quality guard thresholds to shape build config\n- apply threshold settings in vt-stage spike detection/repair flow\n- expose Step4 UI controls and i18n labels for new threshold fields\n- update unit tests for vt anomaly detection and config merge\n\n## Verification\n- pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/gis-sdk --filter @hierarchidb/ui-map\n- pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/shape-api --filter @hierarchidb/gis-sdk --filter @hierarchidb/ui-map\n- pnpm exec vitest run packages/vt-orchestrator/src/vt/__tests__/vtStage.unit.test.ts plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts\n\nRefs #325