### PR TITLE
fix(preview): align error summary and retry diagnostics

### DIFF
--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler.ts
@@ -1358,8 +1358,11 @@ const resolveFeatureIdentifier = (
   featureIndex: number,
   sourceKey?: string,
 ): string => {
-  const rawFeatureId = feature?.id
-    ?? (feature?.properties && 'id' in feature.properties ? String(feature.properties.id) : undefined);
+  const properties = (feature?.properties ?? null) as Record<string, unknown> | null;
+  const metadataFeatureId = properties?.__hdbFeatureId;
+  const rawFeatureId = (typeof metadataFeatureId === 'string' && metadataFeatureId.trim().length > 0)
+    ? metadataFeatureId
+    : (feature?.id ?? (properties && 'id' in properties ? String(properties.id) : undefined));
   if (rawFeatureId != null) {
     return String(rawFeatureId);
   }
@@ -3314,6 +3317,8 @@ export const createTransformByBandHandler = (
       const retryVertexLimit = 6553;
       const maxRetrySteps = 8;
       const resolveRetryToleranceStep = (): number => configuredRetryToleranceStep;
+      const retryToleranceStep = resolveRetryToleranceStep();
+      const formatTolerance = (value: number): string => Number.isFinite(value) ? value.toFixed(6) : '-';
       const countVertexLimitOverages = (collection: FeatureCollection) => {
         let maxVertexCount = 0;
         let overLimitFeatureCount = 0;
@@ -3352,32 +3357,48 @@ export const createTransformByBandHandler = (
         feature: Feature;
         vertexCount: number;
         overLimit: boolean;
+        retryAttempts: number;
+        finalTolerance: number;
       }> => {
-        if (!feature.geometry) return { feature, vertexCount: 0, overLimit: false };
+        if (!feature.geometry) {
+          return { feature, vertexCount: 0, overLimit: false, retryAttempts: 0, finalTolerance: tolerance };
+        }
         const baseVertexCount = countVerticesFromGeometry(feature.geometry);
         if (baseVertexCount < retryVertexLimit) {
-          return { feature, vertexCount: baseVertexCount, overLimit: false };
+          return {
+            feature,
+            vertexCount: baseVertexCount,
+            overLimit: false,
+            retryAttempts: 0,
+            finalTolerance: tolerance,
+          };
         }
 
         let lastFailTolerance = tolerance;
         let successTolerance: number | null = null;
         let successIndex: number | null = null;
         let bestFeature: Feature | null = null;
+        let bestTolerance = tolerance;
         let bestVertexCount = baseVertexCount;
         let lastAttemptFeature: Feature = feature;
         let lastAttemptVertexCount = baseVertexCount;
+        let lastAttemptTolerance = tolerance;
+        let retryAttempts = 0;
 
-        const retryStep = resolveRetryToleranceStep();
-        if (retryStep <= 0) {
+        if (retryToleranceStep <= 0) {
           return {
             feature,
             vertexCount: baseVertexCount,
             overLimit: true,
+            retryAttempts: 0,
+            finalTolerance: tolerance,
           };
         }
         for (let i = 0; i < maxRetrySteps; i += 1) {
-          const nextToleranceValue = tolerance + retryStep * (i + 1);
+          const nextToleranceValue = tolerance + retryToleranceStep * (i + 1);
           const retryFeature = await runRetrySimplifyFeature(feature, nextToleranceValue);
+          retryAttempts += 1;
+          lastAttemptTolerance = nextToleranceValue;
           if (!retryFeature?.geometry) break;
           const retryVertexCount = countVerticesFromGeometry(retryFeature.geometry);
           lastAttemptFeature = retryFeature;
@@ -3386,6 +3407,7 @@ export const createTransformByBandHandler = (
             successTolerance = nextToleranceValue;
             successIndex = i;
             bestFeature = retryFeature;
+            bestTolerance = nextToleranceValue;
             bestVertexCount = retryVertexCount;
             break;
           }
@@ -3399,18 +3421,27 @@ export const createTransformByBandHandler = (
           for (let stepIndex = 0; stepIndex < bisectionSteps; stepIndex += 1) {
             const mid = (low + high) / 2;
             const midFeature = await runRetrySimplifyFeature(feature, mid);
+            retryAttempts += 1;
+            lastAttemptTolerance = mid;
             if (!midFeature?.geometry) break;
             const midVertexCount = countVerticesFromGeometry(midFeature.geometry);
             if (midVertexCount < retryVertexLimit) {
               high = mid;
               bestFeature = midFeature;
+              bestTolerance = mid;
               bestVertexCount = midVertexCount;
             } else {
               low = mid;
             }
           }
           if (bestFeature) {
-            return { feature: bestFeature, vertexCount: bestVertexCount, overLimit: false };
+            return {
+              feature: bestFeature,
+              vertexCount: bestVertexCount,
+              overLimit: false,
+              retryAttempts,
+              finalTolerance: bestTolerance,
+            };
           }
         }
 
@@ -3418,25 +3449,46 @@ export const createTransformByBandHandler = (
           feature: lastAttemptFeature,
           vertexCount: lastAttemptVertexCount,
           overLimit: lastAttemptVertexCount >= retryVertexLimit,
+          retryAttempts,
+          finalTolerance: lastAttemptTolerance,
         };
       };
 
       let adjustedSimplified = simplified;
       let vertexLimitStats = countVertexLimitOverages(adjustedSimplified);
+      const retryDiagnosticsByFeatureIndex = new Map<number, { retryAttempts: number; finalTolerance: number }>();
+      let retryAttemptsTotal = 0;
+      let retryAttemptedFeatureCount = 0;
+      let maxRetryAttemptsPerFeature = 0;
+      let minFinalTolerance = Number.POSITIVE_INFINITY;
+      let maxFinalTolerance = Number.NEGATIVE_INFINITY;
       if (vertexLimitStats.overLimitFeatureCount > 0) {
         const nextFeatures: Feature[] = [];
         let maxVertexCount = 0;
         let overLimitFeatureCount = 0;
-        for (const feature of adjustedSimplified.features) {
+        for (const [featureIndex, feature] of adjustedSimplified.features.entries()) {
           if (!feature?.geometry) {
             nextFeatures.push(feature);
             continue;
           }
           const result = await retrySimplifyFeatureIfNeeded(feature);
+          retryDiagnosticsByFeatureIndex.set(featureIndex, {
+            retryAttempts: result.retryAttempts,
+            finalTolerance: result.finalTolerance,
+          });
           nextFeatures.push(result.feature);
           maxVertexCount = Math.max(maxVertexCount, result.vertexCount);
           if (result.overLimit) {
             overLimitFeatureCount += 1;
+          }
+          retryAttemptsTotal += result.retryAttempts;
+          if (result.retryAttempts > 0) {
+            retryAttemptedFeatureCount += 1;
+          }
+          maxRetryAttemptsPerFeature = Math.max(maxRetryAttemptsPerFeature, result.retryAttempts);
+          if (Number.isFinite(result.finalTolerance)) {
+            minFinalTolerance = Math.min(minFinalTolerance, result.finalTolerance);
+            maxFinalTolerance = Math.max(maxFinalTolerance, result.finalTolerance);
           }
         }
         adjustedSimplified = {
@@ -3505,9 +3557,10 @@ export const createTransformByBandHandler = (
         overLimitFeatureCount += 1;
         maxVertexCount = Math.max(maxVertexCount, vertexCount);
         if (vertexLimitRecords.length >= vertexRecordLimit) continue;
-        const rawFeatureId = feature.id
-          ?? (feature.properties && 'id' in feature.properties ? String(feature.properties.id) : undefined);
-        const featureId = rawFeatureId ? String(rawFeatureId) : `${input.sourceKey}:${featureIndex}`;
+        const featureId = resolveFeatureIdentifier(feature, featureIndex, input.sourceKey);
+        const retryDiagnostics = retryDiagnosticsByFeatureIndex.get(featureIndex);
+        const retryAttempts = retryDiagnostics?.retryAttempts ?? 0;
+        const finalTolerance = retryDiagnostics?.finalTolerance ?? tolerance;
         const lineFeaturesCandidate = buildErrorLineFeatures(feature.geometry, featureId);
         const summary = analyzeGeometryIssues(feature.geometry, geometryOps);
         vertexLimitRecords.push({
@@ -3528,7 +3581,7 @@ export const createTransformByBandHandler = (
           ringCount: summary.ringCount,
           polygonErrorCount: summary.polygonCount,
           ringErrorCount: summary.ringCount,
-          message: `max vertices per feature exceeded (vertexCount=${vertexCount} limit=${retryVertexLimit})`,
+          message: `max vertices per feature exceeded (vertexCount=${vertexCount} limit=${retryVertexLimit} retryAttempts=${retryAttempts} finalTolerance=${formatTolerance(finalTolerance)})`,
           createdAt: Date.now(),
           lineFeatures: {
             type: 'FeatureCollection',
@@ -3537,6 +3590,15 @@ export const createTransformByBandHandler = (
         });
       }
       if (overLimitFeatureCount > 0) {
+        const finalToleranceMinValue = Number.isFinite(minFinalTolerance) ? minFinalTolerance : tolerance;
+        const finalToleranceMaxValue = Number.isFinite(maxFinalTolerance) ? maxFinalTolerance : tolerance;
+        const retrySummary = [
+          `retryAttemptsTotal=${retryAttemptsTotal}`,
+          `retriedFeatures=${retryAttemptedFeatureCount}/${simplifiedFeatureCount}`,
+          `maxRetriesPerFeature=${maxRetryAttemptsPerFeature}`,
+          `retryStep=${formatTolerance(retryToleranceStep)}`,
+          `finalToleranceRange=${formatTolerance(finalToleranceMinValue)}..${formatTolerance(finalToleranceMaxValue)}`,
+        ].join(', ');
         if (vertexLimitRecords.length > 0) {
           try {
             await ephemeralDB.transformErrors.bulkPut(vertexLimitRecords);
@@ -3555,7 +3617,7 @@ export const createTransformByBandHandler = (
         await reportPolygonProgress(task.taskId, 0, inputPolygonCount);
         return {
           status: 'failed',
-          errorMessage: `transform failed: max vertices per feature exceeded (limit=${retryVertexLimit}, overLimit=${overLimitFeatureCount}/${simplifiedFeatureCount}, maxVertices=${maxVertexCount})`,
+          errorMessage: `transform failed: max vertices per feature exceeded (limit=${retryVertexLimit}, overLimit=${overLimitFeatureCount}/${simplifiedFeatureCount}, maxVertices=${maxVertexCount}, ${retrySummary})`,
         };
       }
 

--- a/plugins/route-plugin/src/ui/components/steps/useRoutePreviewStep.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRoutePreviewStep.ts
@@ -6,6 +6,7 @@ import {
   type ResourceVectorLayer,
   useVectorTilePreviewSearch,
   type MapAttributionItem,
+  type MapPreviewErrorSummaryById,
   type MapLibreMapInstance,
   type MapToggleSelection,
   type MapViewState,
@@ -502,12 +503,14 @@ export const useRoutePreviewStep = ({
     setMatchedIds,
   );
   const matchedIdSet = useMemo(() => new Set(matchedIds), [matchedIds]);
-  const staleSummaryById = useMemo(() => {
-    const map = new Map<string, { count: number; messages: string[] }>();
+  const staleSummaryById = useMemo<MapPreviewErrorSummaryById>(() => {
+    const map: MapPreviewErrorSummaryById = new Map();
     if (!metadataSyncSummary) return map;
     metadataSyncSummary.rows.forEach((row) => {
       if (row.status !== 'stale') return;
       map.set(row.lineId, {
+        errorCount: 1,
+        repairCount: 0,
         count: 1,
         messages: row.reason ? [row.reason] : ['metadata mismatch'],
       });

--- a/plugins/shape-plugin/src/ui/components/preview/useShapePreviewStep.ts
+++ b/plugins/shape-plugin/src/ui/components/preview/useShapePreviewStep.ts
@@ -1012,6 +1012,20 @@ export const useShapePreviewStep = (data: Partial<ShapeEntity>, nodeId?: string)
       count: number;
       messages: string[];
     }>();
+    featureListRows.forEach((row) => {
+      const id = row.featureId ?? row.id;
+      if (!id) return;
+      const key = String(id);
+      const metadataErrorCount = typeof row.errorCount === 'number' ? Math.max(0, row.errorCount) : 0;
+      const metadataRepairCount = typeof row.repairCount === 'number' ? Math.max(0, row.repairCount) : 0;
+      if (metadataErrorCount === 0 && metadataRepairCount === 0) return;
+      summary.set(key, {
+        errorCount: metadataErrorCount,
+        repairCount: metadataRepairCount,
+        count: metadataErrorCount,
+        messages: [],
+      });
+    });
     normalizedTransformErrorRows.forEach((row) => {
       const id = row.featureId;
       if (!id) return;
@@ -1029,13 +1043,13 @@ export const useShapePreviewStep = (data: Partial<ShapeEntity>, nodeId?: string)
       }
       entry.count = entry.errorCount;
       const message = normalizeText(row.message);
-      if (message) {
+      if (message && !entry.messages.includes(message)) {
         entry.messages.push(message);
       }
       summary.set(key, entry);
     });
     return summary;
-  }, [normalizedTransformErrorRows]);
+  }, [featureListRows, normalizedTransformErrorRows]);
 
   const toggleRecyclingForSelection = useCallback(async () => {
     if (selectedFeatureIds.length === 0) return;
@@ -1084,7 +1098,11 @@ export const useShapePreviewStep = (data: Partial<ShapeEntity>, nodeId?: string)
         errorCount += summary.errorCount ?? summary.count ?? 0;
         repairCount += summary.repairCount ?? 0;
         if (summary.messages.length > 0) {
-          messages.push(...summary.messages);
+          summary.messages.forEach((message) => {
+            if (!messages.includes(message)) {
+              messages.push(message);
+            }
+          });
         }
       });
       if (errorCount > 0 || repairCount > 0) {


### PR DESCRIPTION
## Summary
- align preview error summary aggregation with MapPreviewErrorSummary schema (errorCount/repairCount)
- merge metadata-level error/repair counters into shape preview table summary and deduplicate error messages
- include simplify-retry diagnostics (retry counts and final tolerance range) in transform max-vertices failure messages
- align route preview stale summary map to the new summary schema

## Verification
- pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin --filter @hierarchidb/route-plugin
- pnpm exec vitest run packages/ui/map/src/__tests__/map-preview-floating-table.unit.test.tsx plugins/shape-plugin/src/ui/__tests__/components/build-progress/ShapeBuildProgressPanel.unit.test.tsx
