### PR TITLE
docs(shape): clarify build start/pause state transitions

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #337 / `codex/docs/shape/build-start-pause-transitions-337` / start: 2026-02-17 07:33 JST
 - #335 / `codex/fix/shape/move-transform-prepare-counts-to-fetch` / start: 2026-02-16 19:54 JST
 - #332 / `codex/feat/shape/fetch-invalid-geometry-filters` / start: 2026-02-16 16:12 JST
 - #330 / `codex/feat/ui/maximized-window-resize` / start: 2026-02-16 15:19 JST
@@ -110,6 +111,9 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- start: 2026-02-17 07:33 JST #337 を起票し（https://github.com/kubohiroya/hierarchidb/issues/337）、Project `hierarchidb` の Status を `In Progress` に設定。ブランチ `codex/docs/shape/build-start-pause-transitions-337` を作成して着手。
+- update: 2026-02-17 07:41 JST #337 `plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md` を現行実装ベースで全面更新。開始受付/実開始、停止受付/停止完了の分離、`awaiting-first-task` 監視（10s/20s/45s）、pause 後の drain 待ちと表示不整合の発生条件を整理。
+- blocked: 2026-02-17 07:43 JST #337 検証 `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は差分外既知ブロッカー `@hierarchidb/batch-runtime-services` の `@types/react` 重複読込（TS2300: `ElementType` / `LibraryManagedAttributes`）で exit 2。
 - start: 2026-02-16 16:12 JST #332 を起票し（https://github.com/kubohiroya/hierarchidb/issues/332）、Project `hierarchidb` の Status を `In Progress` に設定。ブランチ `codex/feat/shape/fetch-invalid-geometry-filters` を作成して着手。
 - update: 2026-02-16 15:23 JST #330 `packages/ui/dialog/src/headless/usePluginDialogFrame.ts` で `allowResizeHandles` 判定を `displayMode !== 'full-screen'` に変更し、`maximize` 中でも端ドラッグによるリサイズ開始を可能化。`packages/ui/floating-window/src/components/useFloatingWindowController.ts` で `exitFullscreenForInteraction` を追加し、`isFullscreen` 状態でタイトルバー/リサイズハンドル操作を開始した際に通常モードへ戻して、そのままドラッグ/リサイズ継続できるよう修正。
 - blocked: 2026-02-16 15:23 JST #330 `pnpm -w turbo run test --filter @hierarchidb/ui-dialog` は差分外既知失敗（`node_modules/@hierarchidb/tree-api/node_modules/comlink/tests/*.test.js` が `/base/dist/esm/comlink.mjs` を解決できず `vite:import-analysis` で失敗）により exit 1。

--- a/plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md
+++ b/plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md
@@ -1,463 +1,197 @@
-# Shape Plugin ダイアログフローと状態遷移仕様
+# Shape Plugin ダイアログフローと状態遷移（現行実装整理）
 
-## 概要
+## 目的
 
-Shape Pluginでは、バッチ処理の開始、進捗監視、完了/中断処理を通じて、複数のダイアログとUIコンポーネントが連携して動作します。本文書では、これらの画面遷移とダイアログの開閉制御について仕様を定義します。
+本書は、Shape Build の **開始リクエスト** / **一時停止リクエスト** と、以下の状態遷移の実装実態を整理する。
 
-## ダイアログの種類と役割
+- アイドル状態
+- ビルド開始受付
+- 実際のビルド開始（task 実行開始）
+- ビルド一時停止受付
 
-### 1. ShapeEditDialog（メインダイアログ）
-- **役割**: Shape entityの作成・編集、バッチ処理の設定
-- **開く条件**: 
-  - 新規作成: TreeConsoleから「Add Shape」アクション
-  - 編集: ShapePanelから「Edit」ボタン
-- **閉じる条件**:
-  - Cancelボタン押下
-  - Saveボタン押下後、保存成功時
+対象コード（2026-02-17 時点）:
 
-### 2. Build Progress（進捗ビュー）
-- **役割**: バッチ処理の進捗表示と制御
-- **表示条件**:
-  - ShapeEditDialog の Build Progress に到達
-  - ShapePanel からの再開導線で Build Progress を開く
-- **終了条件**:
-  - 処理完了後にユーザーがダイアログを閉じる
-  - エラー発生時にユーザーが確認/再試行する
-  - ユーザーによるキャンセル操作
+- `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts`
+- `packages/components/src/executePauseBuildFlow.ts`
+- `plugins/shape-plugin/src/worker/api.ts`
+- `plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState.ts`
 
-### 3. ConfirmationDialog（確認ダイアログ）
-- **役割**: 処理の中断・キャンセルの確認
-- **開く条件**:
-  - Build Progress で Cancel 操作を実行した時
-  - エラー発生時の再試行確認
-- **閉じる条件**:
-  - Yes/Noボタン押下
+---
 
-## 状態遷移フロー（現行実装準拠）
+## 状態の整理（UIで見えるもの）
 
-凡例:
-- `✅`: 自動テストで遷移を検証済み
-- `❌`: 自動テストが存在し、現在失敗
-- `❓`: まだ自動テスト未整備
+### 1) ビルド実行状態（`buildStatus` / `runtimeStatus`）
 
-```mermaid
-stateDiagram-v2
-    [*] --> Idle: 初期状態
-    Idle --> Starting: Start / Resume ✅
+- `idle`: 実行していない
+- `running` / `processing`: 実行中
+- `paused`: 一時停止中（または停止受付直後）
+- `completed`: 完了
+- `failed`: 失敗
 
-    state Starting {
-        [*] --> AcquiringLock
-        AcquiringLock --> WaitingLock: lock unavailable ❓
-        AcquiringLock --> SavingDraft: lock acquired ❓
-        WaitingLock --> SavingDraft: lock acquired ❓
-        SavingDraft --> InitializingWorker: draft saved ❓
-        InitializingWorker --> BuildingPayloads: new start ❓
-        InitializingWorker --> StartingSession: resume ❓
-        BuildingPayloads --> StartingSession: payload ready ❓
-        StartingSession --> AwaitingFirstTask: request accepted ✅
-    }
+### 2) 開始トランジション状態（`buildSessionTransition.phase`）
 
-    Starting --> Processing: startup success ✅
-    Starting --> Failed: startup error / timeout ❌
-    Processing --> Paused: Pause ❓
-    Paused --> Starting: Resume ❓
-    Processing --> Completed: Success ❓
-    Processing --> Failed: Error ❓
-    Completed --> Idle: Close Dialog ❓
-    Failed --> Idle: Abort / Close ❓
-```
+開始〜再開時に UI 内部で進むフェーズ。
 
-### AwaitingFirstTask 以降の詳細分岐（実装準拠）
+- `acquiring-lock`
+- `waiting-lock`
+- `saving-draft`
+- `initializing-worker`
+- `building-payloads`（新規開始のみ）
+- `starting-session`
+- `awaiting-first-task`
 
-```mermaid
-flowchart TD
-    A["AwaitingFirstTask"] --> B{"hasFirstTaskSignal?"}
-    A --> T["timeout (45s)"]:::ng
+### 3) 停止リクエスト状態
 
-    B -->|"yes + started task"| S1["startup success: task-execution-started"]:::ok
-    B -->|"yes + queued/progress only"| S2["startup success: task-queue-observed"]:::ok
-    B -->|"no"| C{"buildStatus"}
+- `isPausePending=true`: UI で停止要求中
+- Worker 側は `setPaused(nodeId, true)` で pause フラグを先に立てる
+- 実タスク停止は `waitIfPaused` チェックポイント到達後
 
-    C -->|"running"| W1["continue waiting"]:::ok
-    C -->|"failed"| E1["startup error: failed-before-task-start"]:::ok
-    C -->|"paused"| P{"isPausePending?"}
-    C -->|"completed"| D{"isTaskStreamReady?"}
+---
 
-    P -->|"true"| W2["continue waiting"]:::ok
-    P -->|"false"| X1["startup cancelled: paused-before-task-start"]:::ok
-
-    D -->|"false"| W3["continue waiting"]:::ok
-    D -->|"true"| E{"taskCount is number?"}
-    E -->|"no (undefined)"| W4["continue waiting"]:::ok
-    E -->|"yes"| F{"taskCount === 0?"}
-
-    F -->|"no"| S3["startup success: completed-before-first-task-update"]:::ok
-    F -->|"yes"| G{"expectTaskGeneration?"}
-    G -->|"true"| W5["continue waiting"]:::ok
-    G -->|"false"| S4["startup success: completed-without-generating-tasks"]:::ok
-
-    classDef ok fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
-    classDef ng fill:#ffebee,stroke:#c62828,color:#b71c1c
-```
+## 全体状態遷移（要約）
 
 ```mermaid
 stateDiagram-v2
-    [*] --> fetch
-    fetch --> transform
-    transform --> vt
-    vt --> [*]
+    [*] --> Idle
+    Idle --> StartAccepted: Start/Resume click
+    StartAccepted --> BuildRunning: first task signal observed
+    StartAccepted --> Completed: start response is completed
+    StartAccepted --> Failed: start response is failed
+    StartAccepted --> Failed: awaiting-first-task timeout (45s)
+    BuildRunning --> PauseAccepted: Pause click
+    PauseAccepted --> Paused: running tasks drained / checkpoint reached
+    PauseAccepted --> BuildRunning: drain pending (見かけ上継続)
+    Paused --> StartAccepted: Resume click
+    BuildRunning --> Completed
+    BuildRunning --> Failed
+    Completed --> Idle
+    Failed --> Idle
 ```
 
-- 実行ステージは `fetch -> transform -> vt`。
-- 起動フェーズ `awaiting-first-task` は待機監視対象で、10s で wait 通知、20s で long-wait 警告、45s で timeout エラー終了。
-- `awaiting-first-task` の task-signal 判定:
-  - `running/completed/failed/...` タスク受信
-  - `queued` タスク受信
-  - progress メタデータ（`progressTaskId` または `total > 0`）受信
-- task stream の初回同期完了前は `taskCount` を `undefined` として扱う。
-- ただし Worker session の `progress.total > 0` が確認できた場合は、task stream 未同期でも `completed-with-session-progress-evidence` で成功遷移する。
-- `buildStatus=failed` で失敗遷移する場合は Worker `stageId` をエラーメッセージへ埋め込み、失敗位置を UI ログから直接追跡できるようにする。
+---
 
-### AwaitingFirstTask 遷移マトリクス（矢印とテスト証跡）
+## 開始リクエストの詳細
 
-| ID | 遷移 | 条件（要約） | 状態 | 主な証跡 |
-| --- | --- | --- | --- | --- |
-| AFT-01 | `AwaitingFirstTask -> success(task-execution-started)` | `hasFirstTaskSignal && hasStartedTasks` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-02 | `AwaitingFirstTask -> success(task-queue-observed)` | `hasFirstTaskSignal && !hasStartedTasks` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` / integration: `buildSessionStartup.integration.test.tsx` |
-| AFT-03 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=running && no signal` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-04 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=completed && !isTaskStreamReady && sessionProgressTotal<=0` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-05 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=completed && taskCount=undefined && sessionProgressTotal<=0` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-06 | `AwaitingFirstTask -> success(completed-before-first-task-update)` | `buildStatus=completed && taskCount>0` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-07 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=completed && taskCount=0 && expectTaskGeneration=true` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-08 | `AwaitingFirstTask -> success(completed-without-generating-tasks)` | `buildStatus=completed && taskCount=0 && expectTaskGeneration=false` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` / e2e: `shape-build-startup-first-task.spec.ts` |
-| AFT-09 | `AwaitingFirstTask -> success(completed-with-session-progress-evidence)` | `buildStatus=completed && sessionProgressTotal>0 && (task stream未同期 or taskCount未確定 or taskCount=0)` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` / e2e: `shape-build-startup-first-task.spec.ts` |
-| AFT-10 | `AwaitingFirstTask -> error(failed-before-task-start)` | `buildStatus=failed`（`sessionStageId` があればメッセージへ付与） | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-11 | `AwaitingFirstTask -> cancelled(paused-before-task-start)` | `buildStatus=paused && !isPausePending` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-12 | `AwaitingFirstTask -> continue(wait)` | `buildStatus=paused && isPausePending` | ✅ | unit: `resolveAwaitingFirstTaskDecision.unit.test.ts` |
-| AFT-13 | `AwaitingFirstTask -> error(timeout)` | `awaiting-first-task elapsed >= 45s` | ✅ | unit: `resolveStartupTransitionWatchdogEvent.unit.test.ts` |
+### 開始受付（UI）
 
-### 検証ソース一覧
+`handleStartOrResume` で以下を実行する。
 
-- Unit:
-  - `plugins/shape-plugin/src/ui/__tests__/hooks/unit/awaitingFirstTaskSignal.unit.test.ts`
-  - `plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts`
-  - `plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveStartupTransitionWatchdogEvent.unit.test.ts`
-- Integration:
-  - `plugins/shape-plugin/src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx`
-- E2E:
-  - `e2e/shape/shape-build-startup-first-task.spec.ts`
+1. lock acquire / wait
+2. draft save
+3. worker initialize
+4. session start request
+5. `awaiting-first-task` へ遷移（通常ケース）
 
-## 2026-02-15 検証結果（Worker実装/テスト照合）
+### 実際のビルド開始判定
 
-### 最新性の判定
-結論: 本文書は一部 outdated。
+`awaiting-first-task` 中に `resolveAwaitingFirstTaskDecision` で判定する。
 
-### 不一致点（要点）
-- 「リアルタイム進捗購読（ポーリングのみ）」は不正確。実装は `subscribeBatchProgress` / `subscribeBuildTasks` の購読に加え、UI 側で 1s 間隔のリコンシル (`getBuildTasks`) を併用している。
-  - 参照: `packages/ui/batch/src/hooks/useBatchProgressState.ts`, `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks.ts`, `plugins/shape-plugin/src/worker/api.ts`
-- 実行ステージは `fetch -> transform -> vt` だけではなく、`metadata-stage` と `cleanup-stage` を含む。
-  - 参照: `plugins/shape-plugin/src/services/vt/shapePipeline.ts`
-- Worker 側は購読者がいない場合に `emitProgressSnapshot` をスキップする。ログ上 `progress snapshot skipped (no subscriber)` が出力されるため、UI 購読が遅れると初期 progress が欠落し得る。
-  - 参照: `plugins/shape-plugin/src/worker/api.ts`
-- ダイアログ間状態共有は `DialogContextProvider` ではなく、Jotai atoms + `useShapeBuildStep` が中心。
-  - 参照: `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts`
-- 自動クローズ/エラーリカバリー/セッション復旧の仕様は本文書にのみ存在し、実装側の呼び出し箇所が確認できない。
-  - 参照: `plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md` 以外に該当コードなし
+- 成功（実行開始）:
+  - `hasFirstTaskSignal && hasStartedTasks`
+  - または queued/progress シグナルを確認
+- 失敗:
+  - `buildStatus=failed`
+  - `awaiting-first-task` 45s timeout
+- キャンセル扱い:
+  - `buildStatus=paused && !isPausePending`
 
-### Worker 内部状態遷移（詳細・実装準拠）
+監視ウォッチドッグ:
 
-```mermaid
-flowchart TD
-  A["Start / Resume"] --> B["lock-acquire"]
-  B -->|lock acquired| C["draft-save"]
-  B -->|lock unavailable| B1["waiting-lock"]
-  B1 --> C
-  C --> D["worker-initialize"]
-  D --> E["payload-build"]
-  E --> F["session-start-request"]
-  F --> G["awaiting-first-task"]
-  G -->|task signal| P["pipeline-dispatch"]
-  G -->|timeout / failed / cancelled| X["startup error/cancel"]
-  P --> S1["prepare-pipeline-run"]
-  S1 --> S2["fetch-stage"]
-  S2 --> S3["transform-stage"]
-  S3 --> S4["vt-stage"]
-  S4 --> S5["metadata-stage"]
-  S5 --> S6["cleanup-stage"]
-  S6 --> Z["completed"]
-```
+- 10s: wait 通知
+- 20s: long-wait 通知
+- 45s: timeout（開始失敗扱い）
 
-### AwaitingFirstTask のガード条件（補足）
-- `hasFirstTaskSignal` は `queued` / `running` / `completed` / `progressTaskId` / `progress.total` のいずれかで成立。
-- `buildStatus=completed` かつ `sessionProgressTotal>0` の場合は、task stream 未同期でも成功遷移となる。
-- 45s 超過で `timeout` エラー遷移となる。
-  - 参照: `plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts`, `resolveStartupTransitionWatchdogEvent.unit.test.ts`
+### 「開始受付したのに開始せず終了」に見える代表経路
 
-### Worker↔UI シーケンス（通知の欠落候補）
+1. `session-start-request` の戻りが `completed`
+- UI は `Build completed immediately after start.` で終了遷移する。
 
-- 通信は **progress subscribe** が起点（`subscribeBatchProgress/subscribeBuildTasks`）。
-- **初回は progress snapshot** → **task item snapshot** の順で UI に届く。
-- 以降は **task item updates** をバッファリングし、rAF で最新シーケンスのみ UI 反映。
+2. `awaiting-first-task` でシグナルが来ない
+- 45s timeout で失敗遷移する。
 
-```mermaid
-sequenceDiagram
-  participant User
-  participant UI as "ShapeBuildStep (UI)"
-  participant Bridge as "WorkerBridge"
-  participant Worker as "shapeBatchAPI / ShapePipeline"
-  participant Queue as "VtTaskQueueDb"
-  participant Cache as "EphemeralShapeDB (fetch/transform/vt caches)"
+3. 開始直後に `buildStatus=failed`
+- task 実行前失敗として終了遷移する。
 
-  UI->>Bridge: "subscribeBatchProgress/subscribeBuildTasks (progress subscribe)"
-  User->>UI: "Start"
-  UI->>Bridge: "startOrResumeBuildSession(nodeId)"
-  Bridge->>Worker: "startOrResumeBuildSession"
-  Worker->>Worker: "startBatchProcess (load-draft...pipeline-dispatch)"
-  Worker->>Queue: "deleteTasksByNode (clear fetch/transform/vt tasks)"
-  Worker->>Cache: "read/write cache (fetchCache/transformCache/transformErrors/tileIdToBufferRelations)"
-  Worker->>Queue: "enqueue tasks"
-  Worker-->>UI: "progress snapshot (initial, if subscribed)"
-  Note over Worker,UI: "購読が遅い場合は progress snapshot skipped (no subscriber)"
-  Worker->>Worker: "runShapePipeline (fetch/transform/vt)"
-  Worker->>Queue: "updateTask status (queued/running/completed)"
-  Queue-->>Worker: "onTaskQueueUpdate"
-  Worker-->>UI: "task item snapshot (initial)"
-  Worker-->>UI: "task item updates (incremental)"
-  Worker-->>UI: "progress events (payload from current tasks)"
-  UI->>UI: "buffer task item updates (keep latest sequence per task)"
-  UI->>UI: "requestAnimationFrame -> apply latest sequence, ignore older than committed"
-  UI->>Bridge: "getBuildTasks (reconcile when empty/in-flight)"
-  UI->>UI: "タスク一覧・サマリー更新"
-```
+---
 
-### 通知/呼び出しの欠落ポイント（現状の候補）
-- `emit-planned-progress` 時点で UI 側購読が未接続だと progress 初期通知が欠落する。
-- `subscribeBuildTasks` が `nodeId` 不一致でフィルタされると、タスク更新が UI に届かない。
-  - 参照: `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks.ts`（`node_id_mismatch` で drop）
+## 一時停止リクエストの詳細
 
-## ダイアログ制御の詳細仕様
+### 停止受付（UI→Worker）
 
-### 1. ShapeEditDialog 内の Build Progress への遷移
+`handlePause` は `executePauseBuildFlow` を通し、次を順に実行する。
 
-```typescript
-interface DialogTransition {
-  trigger: 'START_PROCESSING';
-  source: 'ShapeEditDialog';
-  target: 'ShapeBuildStep';
-  conditions: {
-    validationPassed: boolean;
-    draftSaved: boolean;
-    batchConfigReady: boolean;
-  };
-  actions: {
-    beforeTransition: [
-      'saveDraft',
-      'createBatchSession',
-      'registerProgressCallback'
-    ];
-    onTransition: [
-      'advanceToBuildProgress',
-      'startProgressMonitoring'
-    ];
-  };
-}
-```
+1. Worker 初期化
+2. `pauseBuildSession(...)` 実行（60s timeout 付き）
+3. UI 側 `updateSessionRecord(status='paused')`
 
-### 2. バッチ処理完了時の自動クローズ
+Worker 側 `session/pause` では、先に `setPaused(nodeId, true)` を実行し、`status='paused'` を保存する。
 
-```typescript
-interface CompletionBehavior {
-  onSuccess: {
-    autoClose: true;
-    delay: 2000; // 2秒後に自動クローズ
-    showNotification: true;
-    notificationDuration: 5000;
-    actions: [
-      'commitDraft',
-      'cleanupBatchSession',
-      'refreshParentView'
-    ];
-  };
-  onError: {
-    autoClose: false; // エラー時は自動クローズしない
-    showErrorDetails: true;
-    allowRetry: true;
-    actions: [
-      'logError',
-      'preserveDraft',
-      'showRetryOption'
-    ];
-  };
-  onCancel: {
-    autoClose: true;
-    delay: 0; // 即座にクローズ
-    confirmBeforeClose: true;
-    actions: [
-      'pauseBatchSession',
-      'preserveDraft',
-      'cleanupPartialData'
-    ];
-  };
-}
-```
+### 実際の停止完了
 
-### 3. 進捗イベントによる画面更新
+Worker は非同期で `waitForRunningTasksToDrain` を行う。
 
-```typescript
-interface ProgressEventHandler {
-  eventType: 'PROGRESS_UPDATE' | 'STAGE_CHANGE' | 'TASK_COMPLETE' | 'ERROR';
-  
-  handlers: {
-    PROGRESS_UPDATE: (event: ProgressEvent) => {
-      // プログレスバーの更新
-      updateProgressBar(event.percentage);
-      updateTaskCount(event.completed, event.total);
-    };
-    
-    STAGE_CHANGE: (event: StageChangeEvent) => {
-      // ステージインジケーターの更新
-      highlightCurrentStage(event.newStage);
-      updateStageDescription(event.stageInfo);
-    };
-    
-    TASK_COMPLETE: (event: TaskCompleteEvent) => {
-      // タスクリストの更新
-      markTaskComplete(event.taskId);
-      if (event.isLastTask) {
-        triggerCompletionSequence();
-      }
-    };
-    
-    ERROR: (event: ErrorEvent) => {
-      // エラー表示とリトライオプション
-      showErrorDialog(event.error);
-      enableRetryButton();
-      pauseProcessing();
-    };
-  };
-}
-```
+- timeout: 15s
+- `drained=false` の場合、`running task(s) to reach a pause point` メッセージを出す
 
-## 実装要件
+つまり、**停止受付** と **処理停止完了** は同時ではない。
 
-### 1. ダイアログ間の状態共有
+### 「停止ボタンを押しても終わらない」に見える代表経路
 
-```typescript
-// DialogContextProvider で状態を管理
-interface DialogState {
-  shapeEditDialog: {
-    isOpen: boolean;
-    mode: 'create' | 'edit';
-    draftId?: EntityId;
-  };
-  
-  batchProcessingDialog: {
-    isOpen: boolean;
-    sessionId?: string;
-    currentStage?: BatchStage;
-    progress?: ProgressInfo;
-  };
-  
-  confirmationDialog: {
-    isOpen: boolean;
-    type?: 'cancel' | 'retry' | 'delete';
-    onConfirm?: () => void;
-  };
-}
-```
+- pause フラグは立っているが、実行中タスクがチェックポイント未到達
+- drain timeout まで running が残る
+- この間、UI 上は停止受付済みでも処理継続に見える
 
-### 2. リアルタイム通知の購読管理
+---
 
-```typescript
-interface ProgressSubscription {
-  // 購読開始
-  subscribe(sessionId: string): () => void;
-  
-  // イベントハンドラー登録
-  on(event: 'progress', handler: (data: ProgressInfo) => void): void;
-  on(event: 'complete', handler: (data: CompletionInfo) => void): void;
-  on(event: 'error', handler: (error: Error) => void): void;
-  
-  // クリーンアップ
-  unsubscribe(): void;
-}
-```
+## 表示不整合が起きる条件（今回事象に直結）
 
-### 3. エラーリカバリー
+UI は複数ソースを合成して表示しているため、更新タイミング差で不整合が出る。
 
-```typescript
-interface ErrorRecovery {
-  strategies: {
-    NETWORK_ERROR: {
-      maxRetries: 3;
-      retryDelay: [1000, 2000, 5000]; // Exponential backoff
-      fallback: 'PAUSE_AND_NOTIFY';
-    };
-    
-    VALIDATION_ERROR: {
-      maxRetries: 0; // 検証エラーはリトライしない
-      userAction: 'FIX_AND_RESTART';
-    };
-    
-    QUOTA_EXCEEDED: {
-      maxRetries: 1;
-      cleanupBeforeRetry: true;
-      userAction: 'CONFIRM_CLEANUP';
-    };
-  };
-}
-```
+- Task queue 更新（running/queued/completed）
+- Progress snapshot / progress event
+- Session stage heartbeat（`stageId`）
 
-## UI/UX ガイドライン
+既知の観測:
 
-### 1. プログレス表示
-- 全体進捗: メインプログレスバー（0-100%）
-- ステージ進捗: セカンダリプログレスバー
-- タスクカウンター: "120/500 completed (24%)"
-- 推定残り時間: "約15分" （過去の処理速度から計算）
+- `progress snapshot skipped (no subscriber)`
+  - 購読タイミング次第で初期 progress が欠落
+- `[ShapeRunningResidue] UI_MISMATCH ... reason=running_stage_not_active`
+  - stage の running 判定と active stage 判定が一時的にズレる
 
-### 2. 中断と再開
-- 中断時: 現在の状態を保存し、いつでも再開可能
-- 再開時: 前回の続きから処理を継続
-- タイムアウト: 24時間経過したセッションは自動削除
+このため、同一時刻でも以下が同時に起き得る。
 
-### 3. 通知
-- 成功時: トースト通知（緑色、5秒表示）
-- エラー時: モーダルダイアログ（詳細表示付き）
-- 警告時: インラインアラート（黄色、dismissable）
+- Spinner（並列スロット）は停止表示
+- SVG 進捗まとめは「処理中」表示
+- タスクカード更新がしばらく止まって見える
 
-## テスト要件
+---
 
-### 1. ダイアログ遷移テスト
-- [ ] ShapeEditDialog 内で Build Progress を開く導線
-- [ ] 処理完了時の自動クローズ
-- [ ] エラー時のダイアログ残留
-- [ ] キャンセル確認ダイアログの表示
+## ログ確認ポイント
 
-### 2. 進捗更新テスト
-- [ ] リアルタイム進捗更新の反映
-- [ ] ステージ切り替えの表示
-- [ ] エラー発生時の状態保持
+開始系:
 
-### 3. エッジケース
-- [ ] ネットワーク切断時の挙動
-- [ ] ブラウザリロード時の復旧
-- [ ] 複数ダイアログ同時表示の防止
+- `[ShapeBuildStartResumeTrace]`
+- `[ShapeBuildProgressStep]`
+- `[ShapeAwaitingFirstTaskDecisionTrace]`
 
-## 現在の実装状況と改善点
+停止系:
 
-### 実装済み ✅
-- ShapeEditDialogの基本機能
-- Build Progress 進捗ビューの骨組み
-- 進捗情報の表示コンポーネント
+- `[ShapeBuildPauseTrace]`
+- `[shapeBatchAPI][PauseTrace]`
 
-### 未実装 ❌
-- リアルタイム進捗購読（ポーリングのみ）
-- 自動クローズ機能
-- エラーリカバリー機能
-- セッション復旧機能
+表示不整合:
 
-### 要改善 ⚠️
-- ダイアログ間の状態管理が分散している
-- Worker APIとの接続が不完全
-- 進捗コールバックが機能していない
+- `[ShapeRunningResidue] UI_MISMATCH`
+- `progress snapshot skipped (no subscriber)`
+
+---
+
+## 現状まとめ
+
+- 開始受付と実行開始は分離されている（`awaiting-first-task` 監視あり）。
+- 停止受付と停止完了も分離されている（running task drain 待ちあり）。
+- したがって、
+  - 「開始受付後に勝手に終了」
+  - 「停止押下後も終わらない」
+  は、現行実装の遷移条件上、発生し得る。
+- UX 改善では「受付中」「実処理中」「停止待ち」の表示を明示的に分離する必要がある。


### PR DESCRIPTION
## Summary
- `plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md` を現行実装ベースで更新し、以下の遷移を明確化しました。
  - 開始受付 (`StartAccepted`) と実タスク開始 (`BuildRunning`) の分離
  - 停止受付 (`PauseAccepted`) と停止完了 (`Paused`) の分離
- 「開始受付後に開始せず終了」「停止押下後に終了しない」経路を、実装条件付きで記述しました。
- 表示不整合が出る条件（task queue / progress snapshot / session stage heartbeat の非同期）を追記しました。

## Files
- `plugins/shape-plugin/docs/DIALOG_FLOW_AND_STATE_TRANSITIONS.md`
- `TASKS.md`（運用ログ更新）

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin`
- 結果: exit 2（差分外既知ブロッカー）
  - `@hierarchidb/batch-runtime-services` で `@types/react` 重複読込起因の TS2300
  - `ElementType` / `LibraryManagedAttributes`

## Issue
- Refs #337
