### PR TITLE
feat(dialog): add numbered step labels and map step icons

### DIFF
--- a/app/src/hooks/treeconsole/resolveOpenSteps.ts
+++ b/app/src/hooks/treeconsole/resolveOpenSteps.ts
@@ -48,19 +48,20 @@ const resolveDraftPayload = (node?: TreeNode | null): Record<string, unknown> =>
 
 const resolveBasicInfoLabel = (): string => {
   try {
-    const lang = String(i18n.resolvedLanguage ?? i18n.language ?? '').toLowerCase();
-    if (lang.startsWith('ja')) {
-      return '基本情報';
-    }
     const label = i18n.t('basicInfo.title', {
       ns: 'common',
-      defaultValue: 'Basic Information',
+      defaultValue: 'Info',
     });
-    return typeof label === 'string' ? label : 'Basic Information';
+    return typeof label === 'string' ? label : 'Info';
   } catch {
-    return 'Basic Information';
+    return 'Info';
   }
 };
+
+const stripStepNumberPrefix = (label: string): string => label.replace(/^\s*\d+\.\s*/, '').trim();
+
+const formatIndexedStepLabel = (label: string, index: number): string =>
+  `${index + 1}. ${stripStepNumberPrefix(label)}`;
 
 const resolveActiveStepIndex = (node?: TreeNode | null): number => {
   const persisted = node?.dialogUIState?.dialogProgress?.activeStepIndex;
@@ -144,7 +145,7 @@ export async function resolveOpenStepsForNode(params: {
   );
 
   if (steps.length === 0) {
-    return [{ step: 1, label: 'Step 1', disabled: false }];
+    return [{ step: 1, label: formatIndexedStepLabel('Step 1', 0), disabled: false }];
   }
 
   const filled = await Promise.all(
@@ -181,7 +182,7 @@ export async function resolveOpenStepsForNode(params: {
 
   return steps.map((step, index) => ({
     step: index + 1,
-    label: step.label,
+    label: formatIndexedStepLabel(step.label ?? step.id, index),
     disabled: !enabledFlags[index],
   }));
 }

--- a/packages/plugin-ui-host/src/headless/__tests__/PluginDialogHeader.test.tsx
+++ b/packages/plugin-ui-host/src/headless/__tests__/PluginDialogHeader.test.tsx
@@ -165,9 +165,9 @@ describe('PluginDialogHeader', () => {
 
     expect(screen.queryByText('Current step')).toBeNull();
 
-    const activeLabel = screen.getByText('Step Two');
+    const activeLabel = screen.getByText('2. Step Two');
     expect(activeLabel.getAttribute('data-active-label')).toBe('true');
-    const inactiveLabel = screen.getByText('Step One');
+    const inactiveLabel = screen.getByText('1. Step One');
     expect(inactiveLabel.getAttribute('data-active-label')).toBe('false');
 
     const activeStepButton = screen.getByRole('button', { name: /Step Two/i });

--- a/packages/plugin-ui-host/src/headless/components/PluginDialogStepper.tsx
+++ b/packages/plugin-ui-host/src/headless/components/PluginDialogStepper.tsx
@@ -31,6 +31,11 @@ export interface PluginDialogStepperProps {
   theme: Theme;
 }
 
+const stripStepNumberPrefix = (label: string): string => label.replace(/^\s*\d+\.\s*/, '').trim();
+
+const formatIndexedStepLabel = (label: string, stepIndex: number): string =>
+  `${stepIndex + 1}. ${stripStepNumberPrefix(label)}`;
+
 export const PluginDialogStepper: React.FC<PluginDialogStepperProps> = ({
   steps,
   activeStepIndex,
@@ -50,7 +55,8 @@ export const PluginDialogStepper: React.FC<PluginDialogStepperProps> = ({
         const fallbackCanNavigate = enabledStepIndices.includes(index) || index === activeStepIndex;
         const canNavigate = workerStep?.enabled ?? fallbackCanNavigate;
         const completed = workerStep?.completed ?? validatedStepIndices.includes(index);
-        const label = workerStep?.id ?? step.label ?? step.id;
+        const baseLabel = step.label ?? step.id;
+        const label = formatIndexedStepLabel(baseLabel, index);
         const isActive = index === activeStepIndex;
         const previousWorkerStep =
           index > 0
@@ -82,6 +88,7 @@ export const PluginDialogStepper: React.FC<PluginDialogStepperProps> = ({
                         {...props}
                         theme={theme}
                         stepIndex={iconIndex}
+                        stepLabel={baseLabel}
                         canNavigate={canNavigate}
                         variant={isValidatedButDisabled ? 'validated-disabled' : undefined}
                         inProgress={showBuildProgress}

--- a/packages/plugin-ui-host/src/headless/components/StepStatusIcon.tsx
+++ b/packages/plugin-ui-host/src/headless/components/StepStatusIcon.tsx
@@ -1,12 +1,48 @@
+import ApprovalIcon from '@mui/icons-material/Approval';
+import BookmarksIcon from '@mui/icons-material/Bookmarks';
 import CheckIcon from '@mui/icons-material/Check';
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
+import FilterAltIcon from '@mui/icons-material/FilterAlt';
+import InfoIcon from '@mui/icons-material/Info';
+import PaletteIcon from '@mui/icons-material/Palette';
+import PublicIcon from '@mui/icons-material/Public';
+import SettingsIcon from '@mui/icons-material/Settings';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import type { SvgIconComponent } from '@mui/icons-material';
 import { Box, CircularProgress, type Theme } from '@mui/material';
 import type { StepIconProps } from '@mui/material/StepIcon';
 import { alpha } from '@mui/material/styles';
+
+const stripStepNumberPrefix = (label: string): string => label.replace(/^\s*\d+\.\s*/, '').trim();
+
+const normalizeStepLabel = (label: string): string =>
+  stripStepNumberPrefix(label).toLowerCase().replace(/\s+/g, ' ');
+
+const STEP_ICON_BY_LABEL: Record<string, SvgIconComponent> = {
+  info: InfoIcon,
+  'data source': CloudDownloadIcon,
+  preview: VisibilityIcon,
+  'country selection': PublicIcon,
+  'location selection': PublicIcon,
+  'route selection': PublicIcon,
+  config: SettingsIcon,
+  filtering: FilterAltIcon,
+  'mapping keys': BookmarksIcon,
+  'apply target': ApprovalIcon,
+  palette: PaletteIcon,
+};
+
+const resolveStepIcon = (stepLabel?: string): SvgIconComponent | null => {
+  if (!stepLabel) return null;
+  const normalized = normalizeStepLabel(stepLabel);
+  return STEP_ICON_BY_LABEL[normalized] ?? null;
+};
 
 export const StepStatusIcon = (
   props: StepIconProps & {
     variant?: 'validated-disabled';
     stepIndex?: number;
+    stepLabel?: string;
     canNavigate?: boolean;
     inProgress?: boolean;
     theme: Theme;
@@ -19,9 +55,11 @@ export const StepStatusIcon = (
     icon: iconProp,
     variant,
     stepIndex,
+    stepLabel,
     canNavigate = true,
     inProgress = false,
   } = props;
+  const MappedStepIcon = resolveStepIcon(stepLabel);
   const isValidatedDisabled = variant === 'validated-disabled';
   const isDisabled = !canNavigate;
   const disabledBg =
@@ -74,6 +112,8 @@ export const StepStatusIcon = (
     >
       {inProgress ? (
         <CircularProgress size={16} thickness={5} color="inherit" />
+      ) : MappedStepIcon ? (
+        <MappedStepIcon sx={{ fontSize: 16 }} />
       ) : typeof stepIndex === 'number' ? (
         stepIndex + 1
       ) : (

--- a/packages/plugin-ui-host/src/headless/usePluginDialogController.ts
+++ b/packages/plugin-ui-host/src/headless/usePluginDialogController.ts
@@ -537,7 +537,7 @@ export function usePluginDialogController(
     setDraftData: (next) => setLocalDraftData('stepAdapter', next),
     handleBasicInfoBridge,
     dialogRef,
-    basicInfoLabel: t('common.basicInfo.title', 'Basic Information'),
+    basicInfoLabel: t('common.basicInfo.title', 'Info'),
     onTagClick: handleTagNavigate,
   });
 

--- a/packages/ui/i18n/public/locales/en/common.json
+++ b/packages/ui/i18n/public/locales/en/common.json
@@ -77,7 +77,7 @@
     "warning": "Warning",
     "themeChangeRequested": "Theme change requested: {{theme}}",
     "basicInfo": {
-      "title": "Basic Information",
+      "title": "Info",
       "subtitle": "Enter a name and optional description.",
       "name": {
         "label": "Name",

--- a/packages/ui/i18n/public/locales/en/styler-plugin.json
+++ b/packages/ui/i18n/public/locales/en/styler-plugin.json
@@ -82,14 +82,30 @@
     }
   },
   "steps": {
-    "dataSource": { "label": "Data Source" },
-    "filtering": { "label": "Filtering" },
-    "mappingKeys": { "label": "Mapping Keys" },
-    "targetBehavior": { "label": "Apply Target" },
-    "styleSettings": { "label": "Style Mapping" },
-    "target": { "label": "Apply Target" },
-    "styleAlgorithm": { "label": "Algorithm" },
-    "preview": { "label": "Preview" }
+    "dataSource": {
+      "label": "Data Source"
+    },
+    "filtering": {
+      "label": "Filtering"
+    },
+    "mappingKeys": {
+      "label": "Mapping Keys"
+    },
+    "targetBehavior": {
+      "label": "Apply Target"
+    },
+    "styleSettings": {
+      "label": "Style Mapping"
+    },
+    "target": {
+      "label": "Apply Target"
+    },
+    "styleAlgorithm": {
+      "label": "Palette"
+    },
+    "preview": {
+      "label": "Preview"
+    }
   },
   "step5": {
     "target": {
@@ -119,6 +135,11 @@
       "validation": {
         "required": "Select a target to continue."
       }
+    },
+    "title": "Style Algorithm",
+    "errors": {
+      "range": "Maximum value must be greater than minimum value",
+      "configure": "Configure styling targets before continuing."
     }
   },
   "step6": {
@@ -133,7 +154,20 @@
     "numericRange": {
       "min": "Minimum",
       "max": "Maximum"
-    }
+    },
+    "title": "Preview with Style Mapping",
+    "required": {
+      "title": "Configuration Required",
+      "body": "Please complete Step 5 configuration before viewing the preview.",
+      "property": "Select a MapLibre style property",
+      "valueColumn": "Select a value column for mapping"
+    },
+    "noData": {
+      "title": "No Data Available",
+      "body": "No tabular data is available for preview. Please ensure data has been loaded in previous steps."
+    },
+    "truncate": "Showing preview of first 1,000 rows. Full dataset contains",
+    "rows": "rows."
   },
   "step3": {
     "description": "Choose the table columns and tile feature ID to link styling values.",
@@ -184,28 +218,6 @@
       "styleType": "Select a style type",
       "mappingMode": "Select a mapping mode"
     }
-  },
-  "step5": {
-    "title": "Style Algorithm",
-    "errors": {
-      "range": "Maximum value must be greater than minimum value",
-      "configure": "Configure styling targets before continuing."
-    }
-  },
-  "step6": {
-    "title": "Preview with Style Mapping",
-    "required": {
-      "title": "Configuration Required",
-      "body": "Please complete Step 5 configuration before viewing the preview.",
-      "property": "Select a MapLibre style property",
-      "valueColumn": "Select a value column for mapping"
-    },
-    "noData": {
-      "title": "No Data Available",
-      "body": "No tabular data is available for preview. Please ensure data has been loaded in previous steps."
-    },
-    "truncate": "Showing preview of first 1,000 rows. Full dataset contains",
-    "rows": "rows."
   },
   "extension": {
     "description": "Configure Styler visualization settings for this folder",

--- a/packages/ui/i18n/public/locales/ja/common.json
+++ b/packages/ui/i18n/public/locales/ja/common.json
@@ -77,7 +77,7 @@
     "warning": "警告",
     "themeChangeRequested": "テーマ変更がリクエストされました: {{theme}}",
     "basicInfo": {
-      "title": "基本情報",
+      "title": "Info",
       "subtitle": "名前と説明（任意）を入力してください。",
       "name": {
         "label": "名前",

--- a/packages/ui/i18n/public/locales/ja/styler-plugin.json
+++ b/packages/ui/i18n/public/locales/ja/styler-plugin.json
@@ -82,14 +82,30 @@
     }
   },
   "steps": {
-    "dataSource": { "label": "データソース" },
-    "filtering": { "label": "フィルタリング" },
-    "mappingKeys": { "label": "キーのマッピング" },
-    "targetBehavior": { "label": "適用対象" },
-    "styleSettings": { "label": "スタイル設定" },
-    "target": { "label": "適用対象" },
-    "styleAlgorithm": { "label": "アルゴリズム" },
-    "preview": { "label": "プレビュー" }
+    "dataSource": {
+      "label": "データソース"
+    },
+    "filtering": {
+      "label": "フィルタリング"
+    },
+    "mappingKeys": {
+      "label": "キーのマッピング"
+    },
+    "targetBehavior": {
+      "label": "適用対象"
+    },
+    "styleSettings": {
+      "label": "スタイル設定"
+    },
+    "target": {
+      "label": "適用対象"
+    },
+    "styleAlgorithm": {
+      "label": "Palette"
+    },
+    "preview": {
+      "label": "プレビュー"
+    }
   },
   "step5": {
     "target": {
@@ -119,6 +135,11 @@
       "validation": {
         "required": "対象を選択してください。"
       }
+    },
+    "title": "スタイルアルゴリズム",
+    "errors": {
+      "range": "最大値は最小値より大きくする必要があります",
+      "configure": "スタイルターゲットを設定してから次へ進んでください。"
     }
   },
   "step6": {
@@ -133,7 +154,20 @@
     "numericRange": {
       "min": "最小値",
       "max": "最大値"
-    }
+    },
+    "title": "スタイル適用プレビュー",
+    "required": {
+      "title": "設定が必要です",
+      "body": "プレビューの前にステップ5の設定を完了してください。",
+      "property": "MapLibreのスタイルプロパティを選択してください",
+      "valueColumn": "マッピングに使用する値の列を選択してください"
+    },
+    "noData": {
+      "title": "データがありません",
+      "body": "プレビュー用の表データがありません。前のステップでデータが読み込まれているか確認してください。"
+    },
+    "truncate": "先頭1,000行のみプレビュー表示しています。全データ件数:",
+    "rows": "行"
   },
   "step3": {
     "description": "表の列とタイル側の feature ID を指定して、スタイル値を紐づけます。",
@@ -184,28 +218,6 @@
       "styleType": "スタイル種別を選択してください",
       "mappingMode": "マッピング方式を選択してください"
     }
-  },
-  "step5": {
-    "title": "スタイルアルゴリズム",
-    "errors": {
-      "range": "最大値は最小値より大きくする必要があります",
-      "configure": "スタイルターゲットを設定してから次へ進んでください。"
-    }
-  },
-  "step6": {
-    "title": "スタイル適用プレビュー",
-    "required": {
-      "title": "設定が必要です",
-      "body": "プレビューの前にステップ5の設定を完了してください。",
-      "property": "MapLibreのスタイルプロパティを選択してください",
-      "valueColumn": "マッピングに使用する値の列を選択してください"
-    },
-    "noData": {
-      "title": "データがありません",
-      "body": "プレビュー用の表データがありません。前のステップでデータが読み込まれているか確認してください。"
-    },
-    "truncate": "先頭1,000行のみプレビュー表示しています。全データ件数:",
-    "rows": "行"
   },
   "extension": {
     "description": "このフォルダ用の Styler 可視化設定を行います。",

--- a/plugins/route-plugin/src/ui/components/steps-provider.tsx
+++ b/plugins/route-plugin/src/ui/components/steps-provider.tsx
@@ -151,7 +151,7 @@ registry.registerConfigProvider<RouteStepData>({
       },
       {
         id: 'processing',
-        label: t('steps.processing.label', 'Settings'),
+        label: t('steps.processing.label', 'Config'),
         componentFactory: (p: StepProps) => {
           const draft = { ...(p.data ?? {}) };
           const handleUpdate = createDraftUpdater(draft, p.onChange);

--- a/plugins/route-plugin/src/ui/locales/en.json
+++ b/plugins/route-plugin/src/ui/locales/en.json
@@ -1,12 +1,26 @@
 {
   "steps": {
-    "dataSource": { "label": "Data Source" },
-    "routeConfig": { "label": "Route Selection" },
-    "processing": { "label": "Settings" },
-    "tileSettings": { "label": "Vector Tile Settings" },
-    "build": { "label": "Build" },
-    "stage": { "label": "Build" },
-    "preview": { "label": "Preview" }
+    "dataSource": {
+      "label": "Data Source"
+    },
+    "routeConfig": {
+      "label": "Route Selection"
+    },
+    "processing": {
+      "label": "Config"
+    },
+    "tileSettings": {
+      "label": "Vector Tile Settings"
+    },
+    "build": {
+      "label": "Build"
+    },
+    "stage": {
+      "label": "Build"
+    },
+    "preview": {
+      "label": "Preview"
+    }
   },
   "auth": {
     "loading": "Checking authentication..."
@@ -78,8 +92,7 @@
     "locationEmpty": "No sibling locations are available yet.",
     "startLocationLabel": "Start location",
     "endLocationLabel": "End location",
-    "locationPlaceholder": "Select a location"
-    ,
+    "locationPlaceholder": "Select a location",
     "style": {
       "title": "Route style",
       "description": "Configure colors and line styles per transport mode.",

--- a/plugins/route-plugin/src/ui/locales/ja.json
+++ b/plugins/route-plugin/src/ui/locales/ja.json
@@ -1,12 +1,26 @@
 {
   "steps": {
-    "dataSource": { "label": "データソース" },
-    "routeConfig": { "label": "交通経路の種類" },
-    "processing": { "label": "処理設定" },
-    "tileSettings": { "label": "ベクタタイル設定" },
-    "build": { "label": "ビルド" },
-    "stage": { "label": "ビルド" },
-    "preview": { "label": "プレビュー" }
+    "dataSource": {
+      "label": "データソース"
+    },
+    "routeConfig": {
+      "label": "交通経路の種類"
+    },
+    "processing": {
+      "label": "Config"
+    },
+    "tileSettings": {
+      "label": "ベクタタイル設定"
+    },
+    "build": {
+      "label": "ビルド"
+    },
+    "stage": {
+      "label": "ビルド"
+    },
+    "preview": {
+      "label": "プレビュー"
+    }
   },
   "auth": {
     "loading": "認証状態を確認中..."

--- a/plugins/shape-plugin/src/ui/components/steps-provider.tsx
+++ b/plugins/shape-plugin/src/ui/components/steps-provider.tsx
@@ -117,7 +117,7 @@ registry.registerConfigProvider<Partial<ShapeEntity>>({
       },
       {
         id: 'processing-configuration',
-        label: t('steps.processing.label', 'Processing Configuration'),
+        label: t('steps.processing.label', 'Config'),
         componentFactory: (props: ShapeStepProps) => <ShapeProcessing {...props} />,
         validate: (data?: Partial<ShapeEntity>) =>
           validateBatchConfig(

--- a/plugins/shape-plugin/src/ui/locales/en.json
+++ b/plugins/shape-plugin/src/ui/locales/en.json
@@ -13,7 +13,7 @@
       "label": "License Agreement"
     },
     "processing": {
-      "label": "Build Configuration"
+      "label": "Config"
     },
     "countrySelection": {
       "label": "Country Selection"
@@ -120,26 +120,26 @@
         "verbose": "verbose"
       },
       "anomaly": {
-      "title": "Anomaly detection",
-      "enabled": "Enable anomaly detection",
-      "scoreThreshold": "Anomaly score threshold",
-      "maxEdgeLengthRatio": "Max edge length ratio",
-      "maxAreaDriftPercent": "Max area drift (%)",
-      "maxSelfIntersectionCount": "Max self intersections",
-      "maxLineLengthDriftPercent": "Max line length drift (%)",
-      "maxVertexDriftPercent": "Max vertex drift (%)",
-      "geojson": {
-        "caption": "GeoJSON path checks triangle-shape drift using edge length against polygon BBox span.",
-        "maxTriangleShareDriftPercent": "Max triangle share drift (%)",
-        "maxTriangleEdgeToBBoxRatio": "Max triangle edge/BBox ratio"
-      },
-      "topojson": {
-        "caption": "TopoJSON path uses shared-arc continuity diagnostics from topology references.",
-        "minSharedArcRatioPercent": "Min shared arc ratio (%)"
-      },
-      "retry": {
-        "enabled": "Enable automatic retry",
-        "maxRetries": "Max retries",
+        "title": "Anomaly detection",
+        "enabled": "Enable anomaly detection",
+        "scoreThreshold": "Anomaly score threshold",
+        "maxEdgeLengthRatio": "Max edge length ratio",
+        "maxAreaDriftPercent": "Max area drift (%)",
+        "maxSelfIntersectionCount": "Max self intersections",
+        "maxLineLengthDriftPercent": "Max line length drift (%)",
+        "maxVertexDriftPercent": "Max vertex drift (%)",
+        "geojson": {
+          "caption": "GeoJSON path checks triangle-shape drift using edge length against polygon BBox span.",
+          "maxTriangleShareDriftPercent": "Max triangle share drift (%)",
+          "maxTriangleEdgeToBBoxRatio": "Max triangle edge/BBox ratio"
+        },
+        "topojson": {
+          "caption": "TopoJSON path uses shared-arc continuity diagnostics from topology references.",
+          "minSharedArcRatioPercent": "Min shared arc ratio (%)"
+        },
+        "retry": {
+          "enabled": "Enable automatic retry",
+          "maxRetries": "Max retries",
           "toleranceScale": "Retry tolerance scale",
           "fallbackMode": "Fallback mode",
           "fallback": {

--- a/plugins/shape-plugin/src/ui/locales/ja.json
+++ b/plugins/shape-plugin/src/ui/locales/ja.json
@@ -13,7 +13,7 @@
       "label": "ライセンス同意"
     },
     "processing": {
-      "label": "ビルド設定"
+      "label": "Config"
     },
     "countrySelection": {
       "label": "国選択"
@@ -120,26 +120,26 @@
         "verbose": "verbose"
       },
       "anomaly": {
-      "title": "異常検出",
-      "enabled": "異常検出を有効化",
-      "scoreThreshold": "異常スコア閾値",
-      "maxEdgeLengthRatio": "最大辺長比",
-      "maxAreaDriftPercent": "最大面積差分 (%)",
-      "maxSelfIntersectionCount": "自己交差の許容数",
-      "maxLineLengthDriftPercent": "最大線長差分 (%)",
-      "maxVertexDriftPercent": "最大頂点数差分 (%)",
-      "geojson": {
-        "caption": "GeoJSON 経路では、ポリゴンBBoxに対する三角形辺長の変動を監視します。",
-        "maxTriangleShareDriftPercent": "最大三角形シェア差分 (%)",
-        "maxTriangleEdgeToBBoxRatio": "最大三角形辺長/BBox比"
-      },
-      "topojson": {
-        "caption": "TopoJSON 経路では、トポロジー参照の共有弧連続性を診断します。",
-        "minSharedArcRatioPercent": "最小共有弧比率 (%)"
-      },
-      "retry": {
-        "enabled": "自動リトライを有効化",
-        "maxRetries": "最大リトライ回数",
+        "title": "異常検出",
+        "enabled": "異常検出を有効化",
+        "scoreThreshold": "異常スコア閾値",
+        "maxEdgeLengthRatio": "最大辺長比",
+        "maxAreaDriftPercent": "最大面積差分 (%)",
+        "maxSelfIntersectionCount": "自己交差の許容数",
+        "maxLineLengthDriftPercent": "最大線長差分 (%)",
+        "maxVertexDriftPercent": "最大頂点数差分 (%)",
+        "geojson": {
+          "caption": "GeoJSON 経路では、ポリゴンBBoxに対する三角形辺長の変動を監視します。",
+          "maxTriangleShareDriftPercent": "最大三角形シェア差分 (%)",
+          "maxTriangleEdgeToBBoxRatio": "最大三角形辺長/BBox比"
+        },
+        "topojson": {
+          "caption": "TopoJSON 経路では、トポロジー参照の共有弧連続性を診断します。",
+          "minSharedArcRatioPercent": "最小共有弧比率 (%)"
+        },
+        "retry": {
+          "enabled": "自動リトライを有効化",
+          "maxRetries": "最大リトライ回数",
           "toleranceScale": "リトライ時の tolerance 係数",
           "fallbackMode": "フォールバックモード",
           "fallback": {

--- a/plugins/styler-plugin/src/ui/components/steps-provider.tsx
+++ b/plugins/styler-plugin/src/ui/components/steps-provider.tsx
@@ -128,7 +128,7 @@ registry.registerConfigProvider<StylerStepData>({
       },
       {
         id: 'style-scaling',
-        label: t('steps.styleAlgorithm.label', 'Algorithm'),
+        label: t('steps.styleAlgorithm.label', 'Palette'),
         componentFactory: (p: PluginStepProps<StylerStepData>) => <StylerAlgorithmStep2 {...p} />,
         validate: (dialogData?: StylerStepData) => hasTargetBehavior(dialogData),
         capabilities: {


### PR DESCRIPTION
Summary
- Add numbered step labels (n. label) in dialog stepper and open-step options.
- Map specific labels to MUI icons; unspecified labels keep default numeric step icon.
- Rename labels to Info / Config / Palette.

Verification
- pnpm -w turbo run build --filter @hierarchidb/styler-plugin^... --output-logs errors-only
- pnpm -w turbo run typecheck --filter @hierarchidb/styler-plugin --only --output-logs errors-only
- pnpm -w turbo run typecheck --filter @hierarchidb/app --filter @hierarchidb/plugin-ui-host --filter @hierarchidb/route-plugin --filter @hierarchidb/shape-plugin --filter @hierarchidb/styler-plugin --filter @hierarchidb/ui-i18n --only --output-logs errors-only
- pnpm -w turbo run test --filter @hierarchidb/plugin-ui-host -- --run src/headless/__tests__/PluginDialogHeader.test.tsx
- pnpm -w turbo run test --filter @hierarchidb/app -- --run src/router/__tests__/unit/plugin-dialog-step.unit.test.tsx

Closes #341