### PR TITLE
fix(plugin-ui-host): resolve step icons by step.id and map build icon

### DIFF
--- a/packages/plugin-ui-host/src/headless/__tests__/PluginDialogHeader.test.tsx
+++ b/packages/plugin-ui-host/src/headless/__tests__/PluginDialogHeader.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { PluginDialogProvider } from '@hierarchidb/ui-dialog';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { afterEach, vi } from 'vitest';
 import { PluginDialogHeader } from '../components/PluginDialogHeader.js';
@@ -212,5 +212,46 @@ describe('PluginDialogHeader', () => {
 
     const disabledStep = screen.getByRole('button', { name: /Step Two/i });
     expect(disabledStep).toBeDisabled();
+  });
+
+  it('resolves mapped icons by step id regardless of localized labels, including build icon', () => {
+    const contextValue = {
+      open: true,
+      stepComponents: [
+        { id: 'data-source', label: 'データソース', component: () => null },
+        { id: 'country-selection', label: '国選択', component: () => null },
+        { id: 'build', label: 'ビルド', component: () => null },
+        { id: 'preview', label: 'プレビュー', component: () => null },
+        { id: 'unmapped-step', label: '未定義', component: () => null },
+      ],
+      stepData: {},
+      onStepDataChange: vi.fn(),
+      activeStepIndex: 0,
+      enabledStepIndices: [0, 1, 2, 3, 4],
+      validatedStepIndices: [],
+      committableStepIndices: [],
+      invalidMessageMap: {},
+      isDirty: false,
+      onStepNavigate: vi.fn(),
+      onRequestClose: vi.fn(),
+      onRequestCommit: vi.fn(),
+      displayMode: 'normal' as const,
+      onDisplayModeChange: vi.fn(),
+      onDragHandlePointerDown: vi.fn(),
+    } satisfies Parameters<typeof PluginDialogProvider>[0]['value'];
+
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <PluginDialogProvider value={contextValue}>
+          <PluginDialogHeader title="Edit Item" />
+        </PluginDialogProvider>
+      </ThemeProvider>
+    );
+
+    expect(within(screen.getByTestId('plugin-dialog-step-icon-1')).getByTestId('CloudDownloadIcon')).toBeInTheDocument();
+    expect(within(screen.getByTestId('plugin-dialog-step-icon-2')).getByTestId('PublicIcon')).toBeInTheDocument();
+    expect(within(screen.getByTestId('plugin-dialog-step-icon-3')).getByTestId('ConstructionIcon')).toBeInTheDocument();
+    expect(within(screen.getByTestId('plugin-dialog-step-icon-4')).getByTestId('VisibilityIcon')).toBeInTheDocument();
+    expect(screen.getByTestId('plugin-dialog-step-icon-5')).toHaveTextContent('5');
   });
 });

--- a/packages/plugin-ui-host/src/headless/components/PluginDialogStepper.tsx
+++ b/packages/plugin-ui-host/src/headless/components/PluginDialogStepper.tsx
@@ -88,7 +88,7 @@ export const PluginDialogStepper: React.FC<PluginDialogStepperProps> = ({
                         {...props}
                         theme={theme}
                         stepIndex={iconIndex}
-                        stepLabel={baseLabel}
+                        stepId={step.id}
                         canNavigate={canNavigate}
                         variant={isValidatedButDisabled ? 'validated-disabled' : undefined}
                         inProgress={showBuildProgress}

--- a/packages/plugin-ui-host/src/headless/components/StepStatusIcon.tsx
+++ b/packages/plugin-ui-host/src/headless/components/StepStatusIcon.tsx
@@ -2,6 +2,7 @@ import ApprovalIcon from '@mui/icons-material/Approval';
 import BookmarksIcon from '@mui/icons-material/Bookmarks';
 import CheckIcon from '@mui/icons-material/Check';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
+import ConstructionIcon from '@mui/icons-material/Construction';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import InfoIcon from '@mui/icons-material/Info';
 import PaletteIcon from '@mui/icons-material/Palette';
@@ -13,36 +14,39 @@ import { Box, CircularProgress, type Theme } from '@mui/material';
 import type { StepIconProps } from '@mui/material/StepIcon';
 import { alpha } from '@mui/material/styles';
 
-const stripStepNumberPrefix = (label: string): string => label.replace(/^\s*\d+\.\s*/, '').trim();
+const normalizeStepId = (stepId: string): string => stepId.trim().toLowerCase();
 
-const normalizeStepLabel = (label: string): string =>
-  stripStepNumberPrefix(label).toLowerCase().replace(/\s+/g, ' ');
-
-const STEP_ICON_BY_LABEL: Record<string, SvgIconComponent> = {
+const STEP_ICON_BY_ID: Record<string, SvgIconComponent> = {
+  'basic-info': InfoIcon,
   info: InfoIcon,
-  'data source': CloudDownloadIcon,
+  'data-source': CloudDownloadIcon,
   preview: VisibilityIcon,
-  'country selection': PublicIcon,
-  'location selection': PublicIcon,
-  'route selection': PublicIcon,
-  config: SettingsIcon,
-  filtering: FilterAltIcon,
-  'mapping keys': BookmarksIcon,
-  'apply target': ApprovalIcon,
-  palette: PaletteIcon,
+  'style-preview': VisibilityIcon,
+  'map-preview': VisibilityIcon,
+  'country-selection': PublicIcon,
+  selection: PublicIcon,
+  'route-config': PublicIcon,
+  processing: SettingsIcon,
+  'processing-configuration': SettingsIcon,
+  'style-filter': FilterAltIcon,
+  'mapping-keys': BookmarksIcon,
+  'target-behavior': ApprovalIcon,
+  'style-scaling': PaletteIcon,
+  build: ConstructionIcon,
+  stage: ConstructionIcon,
 };
 
-const resolveStepIcon = (stepLabel?: string): SvgIconComponent | null => {
-  if (!stepLabel) return null;
-  const normalized = normalizeStepLabel(stepLabel);
-  return STEP_ICON_BY_LABEL[normalized] ?? null;
+const resolveStepIcon = (stepId?: string): SvgIconComponent | null => {
+  if (!stepId) return null;
+  const normalized = normalizeStepId(stepId);
+  return STEP_ICON_BY_ID[normalized] ?? null;
 };
 
 export const StepStatusIcon = (
   props: StepIconProps & {
     variant?: 'validated-disabled';
     stepIndex?: number;
-    stepLabel?: string;
+    stepId?: string;
     canNavigate?: boolean;
     inProgress?: boolean;
     theme: Theme;
@@ -55,11 +59,11 @@ export const StepStatusIcon = (
     icon: iconProp,
     variant,
     stepIndex,
-    stepLabel,
+    stepId,
     canNavigate = true,
     inProgress = false,
   } = props;
-  const MappedStepIcon = resolveStepIcon(stepLabel);
+  const MappedStepIcon = resolveStepIcon(stepId);
   const isValidatedDisabled = variant === 'validated-disabled';
   const isDisabled = !canNavigate;
   const disabledBg =


### PR DESCRIPTION
## Summary
- switch step icon resolution from localized label text to `step.id`
- add `Construction` icon mapping for build step ids (`build`, `stage`)
- keep numeric fallback for unmapped step ids
- add regression test for locale-independent icon mapping

## Verification
- `pnpm -w turbo run build --filter @hierarchidb/plugin-ui-host^... --output-logs errors-only`
- `pnpm -w turbo run typecheck --filter @hierarchidb/plugin-ui-host --only --output-logs errors-only`
- `pnpm -w turbo run test --filter @hierarchidb/plugin-ui-host -- --run src/headless/__tests__/PluginDialogHeader.test.tsx`

Closes #346