### PR TITLE
fix(ui-search-input): remove native browser clear icon

### DIFF
--- a/packages/ui/search-input/src/SearchInput.tsx
+++ b/packages/ui/search-input/src/SearchInput.tsx
@@ -17,7 +17,7 @@ const SEARCH_INPUT_DEFAULT_AUTOCOMPLETE_PROPS = {
   'data-form-type': 'other',
   inputMode: 'search',
   spellCheck: false,
-  type: 'search',
+  type: 'text',
 } as const satisfies Record<string, string | boolean>;
 
 type SearchFieldCommitMode = 'change' | 'blur' | 'enter' | 'blur-and-enter';
@@ -120,6 +120,12 @@ export const TreeTableSearchInput = memo(function TreeTableSearchInput({
       width: resolvedFullWidth ? '100%' : `${SEARCH_FIELD_WIDTH_PX}px`,
       '& .MuiInputBase-root': {
         borderRadius: '30px',
+      },
+      '& input::-webkit-search-cancel-button': {
+        display: 'none',
+      },
+      '& input::-webkit-search-decoration': {
+        display: 'none',
       },
     },
     sx,


### PR DESCRIPTION
## 変更内容
- `@hierarchidb/ui-search-input` の入力欄で発生していた右端のネイティブ検索クリアUIを除去
- `type="search"` を `type="text"` に変更し、`::-webkit-search-cancel-button` / `::-webkit-search-decoration` を非表示化
- 既存の `Close` クリアボタン（primary色ではない方）だけが残る状態に統一

## 受け入れ条件
- [x] 入力欄右端に表示されるアイコンが1つだけになっていること
