### PR TITLE
feat(shape): add searchable task filtering in build progress

### DIFF
--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel.tsx
@@ -26,6 +26,7 @@ import { type NodeId, toNodeType } from '@hierarchidb/core-types';
 import { BuildSessionProgressPanel, useBuildStageFilter } from '@hierarchidb/components';
 import { BuildSessionLauncherPanel } from '@hierarchidb/ui-batch-progress';
 import { DownloadRetryControls, type DownloadRetryConfig, WorkerNumberConfigCard } from '@hierarchidb/ui-accordion-config';
+import { TreeTableSearchInput } from '@hierarchidb/ui-search-input';
 import { useAtomValue, useSetAtom } from 'jotai';
 import type { TaskItemWithMetadata } from './TaskItemCardListCard.tsx';
 import { TaskItemCardListCard, sortTransformTasks, sortVectorTileTasks } from './TaskItemCardListCard.tsx';
@@ -425,6 +426,7 @@ const BuildProgressStageContent = ({
   resolveStatusColor,
   resolveTaskTitle,
   t,
+  matchesSearchQuery,
 }: {
   showHeader?: boolean;
   stage: BuildStage;
@@ -437,6 +439,7 @@ const BuildProgressStageContent = ({
   resolveStatusColor: (statusValue?: string, skipped?: boolean) => 'default' | 'success' | 'error' | 'warning' | 'info';
   resolveTaskTitle: (task: TaskItemWithMetadata) => string;
   t: (key: string, fallback: string) => string;
+  matchesSearchQuery: (task: TaskItemWithMetadata) => boolean;
 }) => {
   const filter = useBuildStageFilter();
   const stageTasks = tasksByStage[stage.id] ?? [];
@@ -450,6 +453,7 @@ const BuildProgressStageContent = ({
   const disableVirtualization = typeof window !== 'undefined'
     && new URLSearchParams(window.location.search).has('noTaskVirtual');
   const filteredTasks = stageTasks.filter((task) => {
+    if (!matchesSearchQuery(task)) return false;
     if (isTaskSkipped(task.display, task.message)) return filter.skippedMode;
     if (task.status === 'failed') return filter.failedMode;
     if (task.status === 'completed' || task.status === 'recycled') return filter.completedMode;
@@ -759,6 +763,7 @@ export const ShapeBuildProgressPanel = ({
 
   const [isResetSessionPending, setIsResetSessionPending] = useState(false);
   const [startPendingHold, setStartPendingHold] = useState(false);
+  const [taskSearchText, setTaskSearchText] = useState('');
   const isResetSessionLoading = isResetSessionPending || deleteLoading.resetSession;
   const [concurrencyEditorAnchor, setConcurrencyEditorAnchor] = useState<HTMLElement | null>(null);
   const [concurrencyEditorStageId, setConcurrencyEditorStageId] = useState<'fetch' | 'transform' | 'vt' | null>(null);
@@ -852,6 +857,13 @@ export const ShapeBuildProgressPanel = ({
   const pauseButtonLabel = pauseActsAsCancel
     ? t('stage.controls.cancelBuild', 'Cancel Build')
     : t('stage.controls.pause', 'Pause');
+  const taskSearchQuery = taskSearchText.trim().toLowerCase();
+  const matchesSearchQuery = useCallback((task: TaskItemWithMetadata) => {
+    if (taskSearchQuery.length === 0) return true;
+    const title = typeof task.title === 'string' ? task.title.toLowerCase() : '';
+    const message = typeof task.message === 'string' ? task.message.toLowerCase() : '';
+    return title.includes(taskSearchQuery) || message.includes(taskSearchQuery);
+  }, [taskSearchQuery]);
 
   const processingConfigForEdit = useMemo<ShapeProcessingConfig>(() => {
     const draftConfig = data?.processingConfig ?? DEFAULT_PROCESSING_CONFIG;
@@ -1266,6 +1278,7 @@ export const ShapeBuildProgressPanel = ({
           resolveStatusColor={resolveStatusColor}
           resolveTaskTitle={resolveTaskTitle}
           t={t}
+          matchesSearchQuery={matchesSearchQuery}
           showHeader={false}
         />
       );
@@ -1277,6 +1290,7 @@ export const ShapeBuildProgressPanel = ({
     paneProgressForDisplay,
     resolveStatusColor,
     resolveStatusLabel,
+    matchesSearchQuery,
     resolveTaskTitle,
     stageProgressForDisplay,
     stages,
@@ -1330,7 +1344,21 @@ export const ShapeBuildProgressPanel = ({
       statusLabel={controls.statusLabel}
       controlDetails={controlDetails}
       controlRightContent={(
-        <BuildSessionLauncherPanel nodeType={toNodeType('shape')} excludeNodeId={nodeId} />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, justifyContent: 'flex-end', flexWrap: 'nowrap' }}>
+          <BuildSessionLauncherPanel nodeType={toNodeType('shape')} excludeNodeId={nodeId} />
+          <TreeTableSearchInput
+            fullWidth
+            value={taskSearchText}
+            onChange={setTaskSearchText}
+            onClear={() => setTaskSearchText('')}
+            placeholder={t('stage.tasks.search', 'Search tasks')}
+            sx={{
+              flex: '1 1 auto',
+              minWidth: 0,
+              maxWidth: 250,
+            }}
+          />
+        </Box>
       )}
       suspendDialog={{
         open: suspendSuspectOpen,


### PR DESCRIPTION
## Summary
- Add a searchable input to Shape Build Controls card using @hierarchidb/ui-search-input.
- Filter build tasks by partial match on task title and message.
- Prevent overflow in narrow dialogs by making the search field flexible and capped in width.\n\n## Testing\n- Not run here (per request).