### PR TITLE
fix: set population template node versions by node type

### DIFF
--- a/app/public/templates/population-2023/population-by-countries-2023.json
+++ b/app/public/templates/population-2023/population-by-countries-2023.json
@@ -29,6 +29,7 @@
               },
               "transformConfig": {
                 "zoomBandBoundaries": [
+                  1,
                   2,
                   3,
                   6


### PR DESCRIPTION
## 概要

Total Population by Country テンプレート由来ノードのデフォルトバージョンを反映。

- folder: version=1
- shape: version=0
- styler: version=0

## 変更内容
- `app/public/templates/population-2023/population-by-countries-2023.json`
  - `Total Population by Country` ルートの `folder` に `"version": 1` を明示
  - `shape` / `styler` に `"version": 0` を明示