### PR TITLE
fix(shape-plugin): correct controller base JS shim import

### DIFF
--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerBase.js
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerBase.js
@@ -1,5 +1,4 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useShapeBuildProgressPanelControllerBase = void 0;
-var useShapeBuildProgressPanelControllerBaseState_ts_1 = require("../base/useShapeBuildProgressPanelControllerBaseState.ts");
-Object.defineProperty(exports, "useShapeBuildProgressPanelControllerBase", { enumerable: true, get: function () { return useShapeBuildProgressPanelControllerBaseState_ts_1.useShapeBuildProgressPanelControllerBase; } });
+Object.defineProperty(exports, "useShapeBuildProgressPanelControllerBase", { enumerable: true, get: function () { return useShapeBuildProgressPanelControllerBase_impl_js_1.useShapeBuildProgressPanelControllerBase; } });
+var useShapeBuildProgressPanelControllerBase_impl_js_1 = require("./useShapeBuildProgressPanelControllerBase.impl.js");


### PR DESCRIPTION
### What
- Fix broken CJS shim import in ShapeBuildProgressPanel controller base module.
- The previous output required a .ts path that is not resolvable at build time.

### Validation
- pnpm --filter @hierarchidb/shape-plugin typecheck
- pnpm --filter @hierarchidb/shape-plugin build