### PR TITLE
fix(shape-plugin): fix country availability worker entry path

### DIFF
--- a/plugins/shape-plugin/src/ui/components/country-selection/internal/availabilityWorker.ts
+++ b/plugins/shape-plugin/src/ui/components/country-selection/internal/availabilityWorker.ts
@@ -3,7 +3,7 @@ import type { CountryAvailabilityWorkerAPI } from '../../../workers/countryAvail
 
 // availability is loaded in a dedicated worker thread
 const createAvailabilityWorker = () => new Worker(
-  new URL('../../workers/countryAvailability.worker.ts', import.meta.url),
+  new URL('../../../workers/countryAvailability.worker.ts', import.meta.url),
   { type: 'module' },
 );
 


### PR DESCRIPTION
## 概要
- Shape plugin の country availability worker の URL を build/entry 解決可能なパスに修正

## 変更内容
- `plugins/shape-plugin/src/ui/components/country-selection/internal/availabilityWorker.ts`
  - `new URL('../../workers/countryAvailability.worker.ts', import.meta.url)` を
    `new URL('../../../workers/countryAvailability.worker.ts', import.meta.url)` に修正

## 検証
- `pnpm --filter @hierarchidb/app build` を実行し、`UNRESOLVED_ENTRY` が解消されることを確認
