### PR TITLE
fix(shape-plugin): align pause flow with paused status

### DIFF
--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions.ts
@@ -51,6 +51,8 @@ export const useShapeBuildStepControlActions = ({
     saveDraftBeforeBuild,
     refreshTasks,
     updateSessionRecord,
+    setIsStopRequested,
+    setIsStopAccepted,
   });
 
   const handleCancelQueued = useShapeBuildCancelQueued({
@@ -74,7 +76,6 @@ export const useShapeBuildStepControlActions = ({
     isStopRequestedInFlight,
     bridgeRef,
     clearStartPendingRef,
-    updateSessionRecord,
     setIsStopRequested,
     setIsStopAccepted,
     handleCancelQueued,

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/types.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/types.ts
@@ -112,6 +112,8 @@ export type StartOrResumeControlActionsArgs = Pick<
   | 'saveDraftBeforeBuild'
   | 'refreshTasks'
   | 'updateSessionRecord'
+  | 'setIsStopRequested'
+  | 'setIsStopAccepted'
 >;
 
 export type StartOrResumeExecutionArgs = StartOrResumeControlActionsArgs & {
@@ -134,7 +136,6 @@ export type PauseControlActionsArgs = Pick<
   | 'isStopRequestedInFlight'
   | 'bridgeRef'
   | 'clearStartPendingRef'
-  | 'updateSessionRecord'
   | 'setIsStopRequested'
   | 'setIsStopAccepted'
 >;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildCancelQueued.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildCancelQueued.ts
@@ -32,6 +32,7 @@ export const useShapeBuildCancelQueued = ({
         `Cancel queued build timed out after ${PAUSE_COMMAND_TIMEOUT_MS}ms.`,
       );
       setIsStopAccepted(true);
+      setIsStopRequested(false);
       releaseBuildLock();
       if (buildSessionTransitionActive) {
         finishBuildSessionTransition({

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildPause.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildPause.ts
@@ -15,7 +15,6 @@ export const useShapeBuildPause = ({
   isStopRequestedInFlight,
   bridgeRef,
   clearStartPendingRef,
-  updateSessionRecord,
   setIsStopRequested,
   setIsStopAccepted,
   handleCancelQueued,
@@ -66,12 +65,6 @@ export const useShapeBuildPause = ({
         PAUSE_COMMAND_TIMEOUT_MS,
         `Pause command timed out after ${PAUSE_COMMAND_TIMEOUT_MS}ms while worker is busy.`,
       );
-
-      await updateSessionRecord({
-        status: 'idle',
-        stopReason: reason,
-        canResume: true,
-      });
       setIsStopAccepted(true);
       logPauseTrace('request-finished');
     } catch (error) {
@@ -94,7 +87,6 @@ export const useShapeBuildPause = ({
     handleCancelQueued,
     setIsStopRequested,
     setIsStopAccepted,
-    updateSessionRecord,
   ]);
 
   return handlePause;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildStartOrResume.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildStartOrResume.ts
@@ -23,9 +23,13 @@ export const useShapeBuildStartOrResume = ({
   saveDraftBeforeBuild,
   refreshTasks,
   updateSessionRecord,
+  setIsStopRequested,
+  setIsStopAccepted,
 }: StartOrResumeControlActionsArgs) => {
   const handleStartOrResume = useCallback(async (options?: StartOrResumeOptions): Promise<boolean> => {
     const requestStartedAt = Date.now();
+    setIsStopRequested(false);
+    setIsStopAccepted(false);
     cancelStartRequestRef.current = false;
 
     const startupSource = options?.autoResume ? 'auto' : 'manual';
@@ -78,6 +82,8 @@ export const useShapeBuildStartOrResume = ({
       saveDraftBeforeBuild,
       updateSessionRecord,
       refreshTasks,
+      setIsStopRequested,
+      setIsStopAccepted,
       options,
       startupSource,
       shouldResumeSession,
@@ -139,6 +145,8 @@ export const useShapeBuildStartOrResume = ({
     saveDraftBeforeBuild,
     refreshTasks,
     updateSessionRecord,
+    setIsStopRequested,
+    setIsStopAccepted,
   ]);
 
   return handleStartOrResume;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
@@ -1219,7 +1219,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
 
   useEffect(() => {
     if (!isStopRequestedInFlight) return;
-    if (sessionRecord?.status === 'idle') {
+    if (sessionRecord?.status === 'idle' || sessionRecord?.status === 'paused') {
       setIsStopRequested(false);
       setIsStopAccepted(false);
     }

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.ts
@@ -1219,7 +1219,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
 
   useEffect(() => {
     if (!isStopRequestedInFlight) return;
-    if (sessionRecord?.status === 'idle') {
+    if (sessionRecord?.status === 'idle' || sessionRecord?.status === 'paused') {
       setIsStopRequested(false);
       setIsStopAccepted(false);
     }


### PR DESCRIPTION
## DoD
- Pause: set StopRequested -> StopAccepted only
- Do not force local status idle on pause
- Clear stop flags only when worker reports paused/idle
- Keep start path clearing stop flags on entry

### Changes
- useShapeBuildPause: remove local updateSessionRecord idle write after pause
- useShapeBuildStepLogic: treat sessionRecord.status===paused as stop-complete edge in UI
- start/resume flow: clear stop flags via explicit clear at request start
- control action types updated accordingly

### Verification
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin,