### PR TITLE
Fix shape build-progress re-export surface for import failures

### DIFF
--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/stage.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/stage.ts
@@ -54,6 +54,15 @@ const resolveMostAdvancedRunningStage = (
   stages: Array<{ id: string }>,
 ): string | null => {
   const stageOrder = stages.map((stage) => stage.id);
+  const preferredStageOrder = ['fetch', 'transform', 'vt'];
+  for (let index = preferredStageOrder.length - 1; index >= 0; index -= 1) {
+    const stage = preferredStageOrder[index];
+    if (typeof stage !== 'string') {
+      continue;
+    }
+    if (!stageIds.has(stage)) continue;
+    return stage;
+  }
   for (let index = stageOrder.length - 1; index >= 0; index -= 1) {
     const stage = stageOrder[index];
     if (typeof stage !== 'string') {

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
@@ -61,6 +61,14 @@ import {
 import { useShapeBuildStepControlActions } from './useShapeBuildStepControlActions.js';
 import { useShapeBuildProgressSummaryComputation } from '../shapeBuildProgressSummaryComputation.js';
 
+export {
+  shouldResetElapsedState,
+  resolveDisplayBuildStatus,
+  shouldRefreshTasksSnapshot,
+  resolveMostAdvancedRunningStageId,
+  resolveMostAdvancedInFlightStageId,
+};
+
 type ShapeProgressStepTracePayload = {
   nodeId: string | null;
   phase: BuildStatus;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.ts
@@ -1,1 +1,8 @@
 export { useShapeBuildStep } from './useShapeBuildStepLogic.impl.js';
+export {
+  shouldResetElapsedState,
+  resolveDisplayBuildStatus,
+  shouldRefreshTasksSnapshot,
+  resolveMostAdvancedRunningStageId,
+  resolveMostAdvancedInFlightStageId,
+} from './useShapeBuildStepLogic.impl.js';


### PR DESCRIPTION
## Summary
- Fix re-exports for shape build-progress internal step logic to expose required helper APIs used by current import patterns.
- Keep export surface aligned with import usage to avoid module resolution/import failures.

## Verification
- pnpm --filter @hierarchidb/shape-plugin build
- pnpm --filter @hierarchidb/shape-plugin typecheck
- pnpm --filter @hierarchidb/app build