### PR TITLE
feat(tools-rel2abs): keep local relative imports

### DIFF
--- a/packages/tools/rel2abs/README.md
+++ b/packages/tools/rel2abs/README.md
@@ -1,6 +1,6 @@
 # rel2abs
 
-`@hierarchidb/tools-rel2abs` is a workspace CLI that rewrites relative imports to a `~`-prefixed absolute import style.
+`@hierarchidb/tools-rel2abs` is a workspace CLI that rewrites some relative imports to a `~`-prefixed absolute import style.
 
 ## Purpose
 
@@ -13,7 +13,8 @@ Input:
 
 Output:
 
-- `./` and `../` imports are rewritten to `~/<path from root>`
+- `../` imports are rewritten to `~/<path from root>`
+- `./` imports are kept as-is (local relative path exception)
 - File extensions such as `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` are stripped
 - Only imports that resolve inside the target root are rewritten
 - No file is modified in dry-run mode
@@ -55,8 +56,7 @@ The tool rewrites module specifiers in:
 
 ## Conversion rules
 
-- Converts only relative module specifiers:
-  - `./foo`
+- Converts only relative module specifiers that navigate outside the current directory:
   - `../bar`
 - Leaves non-relative references unchanged:
   - `@scope/pkg`

--- a/packages/tools/rel2abs/src/rel2abs.ts
+++ b/packages/tools/rel2abs/src/rel2abs.ts
@@ -64,6 +64,10 @@ function isRelativeImport(moduleSpecifier: string): boolean {
   return moduleSpecifier.startsWith("./") || moduleSpecifier.startsWith("../")
 }
 
+function isKeepAsRelativeImport(moduleSpecifier: string): boolean {
+  return moduleSpecifier.startsWith("./")
+}
+
 function isImportMetaUrl(node: ts.Node): boolean {
   return (
     ts.isPropertyAccessExpression(node) &&
@@ -191,6 +195,9 @@ function rewriteSourceFile(sourceText: string, filePath: string, rootDir: string
   const pushRewrite = (node: ts.StringLiteral): void => {
     const moduleSpecifier = node.text
     if (!isRelativeImport(moduleSpecifier)) {
+      return
+    }
+    if (isKeepAsRelativeImport(moduleSpecifier)) {
       return
     }
 


### PR DESCRIPTION
## Summary
- Keep local relative imports starting with `./` as-is in rel2abs rewrite logic.
- Continue converting parent-relative imports (`../...`) to `~` alias.
- Update README to document the exception rule.

## Testing
- Verified by running: `pnpm --filter @hierarchidb/tools-rel2abs run rel2abs /Users/hiroya/WebstormProjects/hierarchidb/plugins/shape-plugin/src --dry-run`
- Confirmed output includes only parent-relative rewrites and no `./` rewrites.
