### PR TITLE
feat(rel2abs): support app/src scope in absolute rewrite

### DIFF
--- a/packages/tools/rel2abs/README.md
+++ b/packages/tools/rel2abs/README.md
@@ -13,7 +13,9 @@ Input:
 
 Output:
 
-- `../` imports are rewritten to `~/<path from package root>`
+- `../` imports are rewritten to `~/<path from scope root>`
+  - In `packages/*`, `plugins/*`, scope root is the package root.
+  - In `app`, scope root is `app/src`.
 - `./` imports are kept as-is (local relative path exception)
 - File extensions such as `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` are stripped
 - Only imports that resolve inside the target package are rewritten
@@ -62,7 +64,9 @@ The tool rewrites module specifiers in:
   - `@scope/pkg`
 - Converts URL-constructor relative paths with `import.meta.url` base:
   - `new URL('../worker.ts', import.meta.url)`
-- `~/*` aliases are resolved from the nearest package root
+- `~/*` aliases are resolved from the nearest scope root:
+  - package scopes (`packages/*`, `plugins/*`) resolve from package root
+  - `app` resolves from `app/src`
 - You can also import package-root files directly, e.g. `~/package.json`
 - absolute path imports
 - Rewrites only files under the provided root directory

--- a/packages/tools/rel2abs/src/rel2abs.ts
+++ b/packages/tools/rel2abs/src/rel2abs.ts
@@ -129,11 +129,37 @@ function getPackageScopePrefixCached(sourceFilePath: string, rootDir: string): s
   return prefix
 }
 
+function getAppScopeRoot(sourceFilePath: string): string | null {
+  let current = path.dirname(sourceFilePath)
+
+  while (true) {
+    const basename = path.basename(current)
+    if (basename === "src" && path.basename(path.dirname(current)) === "app") {
+      return current
+    }
+
+    const parent = path.dirname(current)
+    if (current === parent) {
+      return null
+    }
+    current = parent
+  }
+}
+
 function toLegacyAbsoluteAlias(
   moduleSpecifier: string,
   sourceFilePath: string,
   rootDir: string,
 ): string | null {
+  const appScopeRoot = getAppScopeRoot(sourceFilePath)
+  if (appScopeRoot !== null) {
+    const appPrefix = "~/"
+    if (!moduleSpecifier.startsWith(appPrefix)) {
+      return null
+    }
+    return `~/${stripKnownExtension(moduleSpecifier.slice(appPrefix.length))}`
+  }
+
   const prefix = getPackageScopePrefixCached(sourceFilePath, rootDir)
   if (prefix === null || prefix.length === 0) {
     return null
@@ -207,16 +233,19 @@ function toAbsoluteAlias(
 ): string | null {
   const sourceDir = path.dirname(sourceFilePath)
   const targetPath = path.resolve(sourceDir, moduleSpecifier)
+  const appScopeRoot = getAppScopeRoot(sourceFilePath)
   const packageRoot = getPackageRoot(sourceFilePath, rootDir)
-  if (packageRoot === null) {
+
+  const scopeRoot = appScopeRoot ?? packageRoot
+  if (scopeRoot === null) {
     return null
   }
 
-  if (!isWithinRoot(targetPath, packageRoot)) {
+  if (!isWithinRoot(targetPath, scopeRoot)) {
     return null
   }
 
-  const rel = path.relative(packageRoot, targetPath)
+  const rel = path.relative(scopeRoot, targetPath)
   const alias = `~/${stripKnownExtension(toPosix(rel))}`
 
   return alias


### PR DESCRIPTION
## Summary
- Extend rel2abs scope detection to support app/src as its own root for absolute rewrite.
- Keep package/plugins behavior unchanged while app imports now resolve to ~ based on app/src root.
- Update README with scope root specification.

## Verification
- Verified with dry-run on app/src: replacements were reported and no file writes performed.

## Notes
- Scope mapping implemented: plugin/package directories use package-root behavior; app uses app/src.
