### PR TITLE
chore(build): emit tsdown output to dist

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "Bundler",
     "outDir": "dist",
     "lib": [
       "ES2022",
@@ -21,11 +21,11 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "allowImportingTsExtensions": true,
-    "module": "NodeNext",
+    "module": "ESNext",
     "noEmit": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "baseUrl": ".",
+    "baseUrl": ".."
   },
   "include": [
     "src/**/*.ts",

--- a/app/vite-plugins/vite-plugin-hierarchidb-plugin-alias/package.json
+++ b/app/vite-plugins/vite-plugin-hierarchidb-plugin-alias/package.json
@@ -11,7 +11,7 @@
     "src"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --config ../../tsdown.config.ts --target es2020",
+    "build": "tsdown src/index.ts --config ../../tsdown.config.ts --target es2020 --outDir dist",
     "clean": "rm -rf dist",
     "lint": "eslint 'src/**/*.ts'",
     "typecheck": "tsc --noEmit --project tsconfig.json"

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -401,10 +401,13 @@ function pluginTildeRootAliasPlugin(): Plugin {
       if (typeof importer !== 'string' || importer.length === 0) return null;
       const importerUrl: string = importer;
       const questionIndex = importerUrl.indexOf('?');
-      const sanitizedImporter = (
+      const normalizedImporter = (
         questionIndex >= 0 ? importerUrl.slice(0, questionIndex) : importerUrl
       ).replace(/\\/g, '/');
-      const importerDir = path.dirname(sanitizedImporter);
+      const importerWithoutFsPrefix = normalizedImporter.startsWith('/@fs/')
+        ? normalizedImporter.slice(5)
+        : normalizedImporter;
+      const importerDir = path.dirname(importerWithoutFsPrefix);
       let pluginRoot: string | null = null;
       let pluginSrcRoot: string | null = null;
       let cursor = importerDir;
@@ -415,14 +418,14 @@ function pluginTildeRootAliasPlugin(): Plugin {
           try {
             const raw = fs.readFileSync(packageJsonPath, 'utf8');
             const packageJson = JSON.parse(raw);
-            const hasPluginName =
-              typeof packageJson?.name === 'string' &&
-              /plugin/i.test(packageJson.name);
+            const packageName = typeof packageJson?.name === 'string' ? packageJson.name : '';
+            const hasPluginName = /plugin/i.test(packageName);
+            const isAppPackage = packageName === '@hierarchidb/app';
             const isPluginPackage =
               packageJson &&
               typeof packageJson === 'object' &&
               !!((packageJson as { hierarchidb?: { plugin?: unknown } }).hierarchidb?.plugin || packageJson?.nodeType);
-            if (isPluginPackage || hasPluginName) {
+            if (isPluginPackage || isAppPackage || hasPluginName) {
               pluginRoot = cursor;
               const candidateSrcRoot = path.join(cursor, 'src');
               pluginSrcRoot = fs.existsSync(candidateSrcRoot) ? candidateSrcRoot : cursor;
@@ -440,6 +443,21 @@ function pluginTildeRootAliasPlugin(): Plugin {
         const parent = path.dirname(cursor);
         if (parent === cursor) break;
         cursor = parent;
+      }
+
+      if (!pluginRoot) {
+        const appRoot = path.resolve(__dirname);
+        const withinAppPath =
+          importerWithoutFsPrefix.includes(`${path.sep}app${path.sep}`)
+          || importerWithoutFsPrefix.endsWith(`${path.sep}app`)
+          || importerWithoutFsPrefix.includes('/app/');
+        if (withinAppPath && fs.existsSync(appRoot)) {
+          const appSrcRoot = path.join(appRoot, 'src');
+          if (fs.existsSync(appSrcRoot)) {
+            pluginRoot = appRoot;
+            pluginSrcRoot = appSrcRoot;
+          }
+        }
       }
 
       if (!pluginRoot) return null;

--- a/packages/batch-session-ports/package.json
+++ b/packages/batch-session-ports/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --config ../../tsdown.config.ts",
+    "build": "tsdown src/index.ts --config ../../tsdown.config.ts --outDir dist",
     "build:types": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "test": "vitest"

--- a/packages/ui/datasource/tsconfig.json
+++ b/packages/ui/datasource/tsconfig.json
@@ -1,13 +1,5 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "paths": {
-      "@hierarchidb/ui-file": [
-        "../packages/ui/file/dist/index.d.ts"
-      ],
-      "@hierarchidb/ui-file/*": [
-        "../packages/ui/file/dist/*"
-      ]
-    }
   }
 }

--- a/packages/vectortile-orchestrator/package.json
+++ b/packages/vectortile-orchestrator/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --config ../../tsdown.config.ts",
+    "build": "tsdown src/index.ts --config ../../tsdown.config.ts --outDir dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/plugins/basemap-plugin/package.json
+++ b/plugins/basemap-plugin/package.json
@@ -45,7 +45,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,scss}\"",
     "dev:tsc": "tsc --watch",
     "typecheck": "tsc --noEmit --project tsconfig.json",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts",
+    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/plugins/folder-plugin/package.json
+++ b/plugins/folder-plugin/package.json
@@ -51,7 +51,7 @@
     "coverage": "vitest run --coverage",
     "dev:tsc": "tsc --watch",
     "typecheck": "tsc --noEmit --project tsconfig.json",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --splitting false",
+    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --splitting false --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/plugins/linker-plugin/package.json
+++ b/plugins/linker-plugin/package.json
@@ -48,7 +48,7 @@
     "test:run": "vitest run",
     "coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit --project tsconfig.json",
-    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/icon/index.ts --config ../../tsdown.config.ts",
+    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/plugins/location-plugin/package.json
+++ b/plugins/location-plugin/package.json
@@ -47,7 +47,7 @@
     "test:watch": "vitest",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
-    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/worker/locationEntitiesDB.ts src/worker/locationGroupStore.dexie.ts src/worker/locationRelationStore.dexie.ts src/locationEntitiesDB.ts src/icon/index.ts --config ../../tsdown.config.ts",
+    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/worker/locationEntitiesDB.ts src/worker/locationGroupStore.dexie.ts src/worker/locationRelationStore.dexie.ts src/locationEntitiesDB.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/plugins/resolver-plugin/package.json
+++ b/plugins/resolver-plugin/package.json
@@ -43,7 +43,7 @@
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "typecheck": "tsc --noEmit --project tsconfig.json",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts",
+    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/plugins/resolver-plugin/tsconfig.json
+++ b/plugins/resolver-plugin/tsconfig.json
@@ -1,6 +1,20 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "~/*": [
+        "*",
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx",
+        "*.mjs",
+        "*.cjs",
+        "*.mts",
+        "*.cts"
+      ]
+    },
     "experimentalDecorators": true,
     "allowImportingTsExtensions": true,
     "allowArbitraryExtensions": true,

--- a/plugins/route-plugin/package.json
+++ b/plugins/route-plugin/package.json
@@ -48,7 +48,7 @@
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "typecheck": "tsc --noEmit --project tsconfig.json",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/icon/index.ts --config ../../tsdown.config.ts",
+    "build:js": "tsdown src/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/plugins/shape-plugin/package.json
+++ b/plugins/shape-plugin/package.json
@@ -52,7 +52,7 @@
     "coverage": "SHAPE_VITEST_POOL=forks vitest run --coverage",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
-    "build:js": "tsdown src/common/shared/index.ts src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/public.ts src/worker/shapeEntitiesDB.ts src/worker/shapeGroupStore.dexie.ts src/worker/shapeRelationStore.dexie.ts src/icon/index.ts --config ../../tsdown.config.ts --splitting false",
+    "build:js": "tsdown src/common/shared/index.ts src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/public.ts src/worker/shapeEntitiesDB.ts src/worker/shapeGroupStore.dexie.ts src/worker/shapeRelationStore.dexie.ts src/icon/index.ts --config ../../tsdown.config.ts --splitting false --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/plugins/spreadsheet-plugin/package.json
+++ b/plugins/spreadsheet-plugin/package.json
@@ -52,7 +52,7 @@
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "build:dts": "rollup -c rollup.dts.config.mjs",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/worker/index.ts src/icon/index.ts --config ../../tsdown.config.ts"
+    "build:js": "tsdown src/index.ts src/ui/index.ts src/worker/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist"
   },
   "peerDependencies": {
     "@emotion/react": "^11.14.0",

--- a/plugins/styler-plugin/package.json
+++ b/plugins/styler-plugin/package.json
@@ -45,7 +45,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,scss}\"",
     "dev:tsc": "tsc --watch",
     "typecheck": "tsc --noEmit --project tsconfig.json",
-    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts",
+    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/plugins/timeline-plugin/package.json
+++ b/plugins/timeline-plugin/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "typecheck": "tsc --noEmit --project tsconfig.json",
-    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts",
+    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "build:dts": "rollup -c rollup.dts.config.mjs"
   },
   "dependencies": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,634 +11,640 @@
     "moduleResolution": "NodeNext",
     "paths": {
       "@hierarchidb/auth": [
-        "../packages/auth/dist/index.d.ts"
+        "./packages/auth/dist/index.d.ts"
       ],
       "@hierarchidb/auth/*": [
-        "../packages/auth/dist/*"
+        "./packages/auth/dist/*"
       ],
       "@hierarchidb/auth-api": [
-        "../packages/auth-api/dist/index.d.ts"
+        "./packages/auth-api/dist/index.d.ts"
       ],
       "@hierarchidb/auth-api/*": [
-        "../packages/auth-api/dist/*"
+        "./packages/auth-api/dist/*"
       ],
       "@hierarchidb/basemap-plugin": [
-        "../plugins/basemap-plugin/dist/index.d.ts"
+        "./plugins/basemap-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/basemap-plugin/worker": [
-        "../plugins/basemap-plugin/dist/worker/index.d.ts"
+        "./plugins/basemap-plugin/dist/worker/index.d.ts"
       ],
       "@hierarchidb/basemap-plugin/*": [
-        "../plugins/basemap-plugin/dist/*"
+        "./plugins/basemap-plugin/dist/*"
       ],
       "@hierarchidb/batch": [
-        "../packages/batch/dist/index.d.ts"
+        "./packages/batch/dist/index.d.ts"
       ],
       "@hierarchidb/batch/*": [
-        "../packages/batch/dist/*"
+        "./packages/batch/dist/*"
       ],
       "@hierarchidb/batch-runtime-services": [
-        "../packages/batch-runtime-services/dist/index.d.ts"
+        "./packages/batch-runtime-services/dist/index.d.ts"
       ],
       "@hierarchidb/batch-runtime-services/*": [
-        "../packages/batch-runtime-services/dist/*"
+        "./packages/batch-runtime-services/dist/*"
       ],
       "@hierarchidb/bff": [
-        "../packages/backend/bff/dist/index.d.ts"
+        "./packages/backend/bff/dist/index.d.ts"
       ],
       "@hierarchidb/bff/*": [
-        "../packages/backend/bff/dist/*"
+        "./packages/backend/bff/dist/*"
       ],
       "@hierarchidb/components": [
-        "../packages/components/dist/index.d.ts"
+        "./packages/components/dist/index.d.ts"
       ],
       "@hierarchidb/components/*": [
-        "../packages/components/dist/*"
+        "./packages/components/dist/*"
       ],
       "@hierarchidb/core-types": [
-        "../packages/core-types/dist/index.d.ts"
+        "./packages/core-types/dist/index.d.ts"
       ],
       "@hierarchidb/core-types/*": [
-        "../packages/core-types/dist/*"
+        "./packages/core-types/dist/*"
       ],
       "@hierarchidb/cors-proxy": [
-        "../packages/backend/cors-proxy/dist/index.d.ts"
+        "./packages/backend/cors-proxy/dist/index.d.ts"
       ],
       "@hierarchidb/cors-proxy/*": [
-        "../packages/backend/cors-proxy/dist/*"
+        "./packages/backend/cors-proxy/dist/*"
       ],
       "@hierarchidb/download": [
-        "../packages/download/dist/index.d.ts"
+        "./packages/download/dist/index.d.ts"
       ],
       "@hierarchidb/download/*": [
-        "../packages/download/dist/*"
+        "./packages/download/dist/*"
       ],
       "@hierarchidb/chunk-store": [
-        "../packages/chunk-store/dist/index.d.ts"
+        "./packages/chunk-store/dist/index.d.ts"
       ],
       "@hierarchidb/chunk-store/*": [
-        "../packages/chunk-store/dist/*"
+        "./packages/chunk-store/dist/*"
       ],
       "@hierarchidb/location-store": [
-        "../packages/location-store/dist/index.d.ts"
+        "./packages/location-store/dist/index.d.ts"
       ],
       "@hierarchidb/location-store/*": [
-        "../packages/location-store/dist/*"
+        "./packages/location-store/dist/*"
       ],
       "@hierarchidb/location-api": [
-        "../packages/location-api/dist/index.d.ts"
+        "./packages/location-api/dist/index.d.ts"
       ],
       "@hierarchidb/location-api/*": [
-        "../packages/location-api/dist/*"
+        "./packages/location-api/dist/*"
       ],
       "@hierarchidb/tree-api": [
-        "../packages/tree-api/dist/index.d.ts"
+        "./packages/tree-api/dist/index.d.ts"
       ],
       "@hierarchidb/tree-api/*": [
-        "../packages/tree-api/dist/*"
+        "./packages/tree-api/dist/*"
       ],
       "@hierarchidb/tag-api": [
-        "../packages/tag-api/dist/index.d.ts"
+        "./packages/tag-api/dist/index.d.ts"
       ],
       "@hierarchidb/tag-api/*": [
-        "../packages/tag-api/dist/*"
+        "./packages/tag-api/dist/*"
       ],
       "@hierarchidb/batch-api": [
-        "../packages/batch-api/dist/index.d.ts"
+        "./packages/batch-api/dist/index.d.ts"
       ],
       "@hierarchidb/batch-api/*": [
-        "../packages/batch-api/dist/*"
+        "./packages/batch-api/dist/*"
       ],
       "@hierarchidb/import-export-api": [
-        "../packages/import-export-api/dist/index.d.ts"
+        "./packages/import-export-api/dist/index.d.ts"
       ],
       "@hierarchidb/import-export-api/*": [
-        "../packages/import-export-api/dist/*"
+        "./packages/import-export-api/dist/*"
       ],
       "@hierarchidb/shape-api": [
-        "../packages/shape-api/dist/index.d.ts"
+        "./packages/shape-api/dist/index.d.ts"
       ],
       "@hierarchidb/shape-api/*": [
-        "../packages/shape-api/dist/*"
+        "./packages/shape-api/dist/*"
       ],
       "@hierarchidb/style-api": [
-        "../packages/style-api/dist/index.d.ts"
+        "./packages/style-api/dist/index.d.ts"
       ],
       "@hierarchidb/style-api/*": [
-        "../packages/style-api/dist/*"
+        "./packages/style-api/dist/*"
       ],
       "@hierarchidb/shape-store": [
-        "../packages/shape-store/dist/index.d.ts"
+        "./packages/shape-store/dist/index.d.ts"
       ],
       "@hierarchidb/shape-store/*": [
-        "../packages/shape-store/dist/*"
+        "./packages/shape-store/dist/*"
       ],
       "@hierarchidb/worker-api": [
-        "../packages/worker-api/dist/index.d.ts"
+        "./packages/worker-api/dist/index.d.ts"
       ],
       "@hierarchidb/worker-api/*": [
-        "../packages/worker-api/dist/*"
+        "./packages/worker-api/dist/*"
       ],
       "@hierarchidb/styler-store": [
-        "../packages/styler-store/dist/index.d.ts"
+        "./packages/styler-store/dist/index.d.ts"
       ],
       "@hierarchidb/styler-store/*": [
-        "../packages/styler-store/dist/*"
+        "./packages/styler-store/dist/*"
       ],
       "@hierarchidb/spreadsheet-store": [
-        "../packages/spreadsheet-store/dist/index.d.ts"
+        "./packages/spreadsheet-store/dist/index.d.ts"
       ],
       "@hierarchidb/spreadsheet-store/*": [
-        "../packages/spreadsheet-store/dist/*"
+        "./packages/spreadsheet-store/dist/*"
       ],
       "@hierarchidb/memory": [
-        "../packages/memory/dist/index.d.ts"
+        "./packages/memory/dist/index.d.ts"
       ],
       "@hierarchidb/memory/*": [
-        "../packages/memory/dist/*"
+        "./packages/memory/dist/*"
       ],
       "@hierarchidb/gis-sdk": [
-        "../packages/gis-sdk/dist/index.d.ts"
+        "./packages/gis-sdk/dist/index.d.ts"
       ],
       "@hierarchidb/gis-sdk/*": [
-        "../packages/gis-sdk/dist/*"
+        "./packages/gis-sdk/dist/*"
       ],
       "@hierarchidb/folder-plugin": [
-        "../plugins/folder-plugin/dist/index.d.ts"
+        "./plugins/folder-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/folder-plugin/*": [
-        "../plugins/folder-plugin/dist/*"
+        "./plugins/folder-plugin/dist/*"
       ],
       "@hierarchidb/import-export": [
-        "../packages/import-export/dist/index.d.ts"
+        "./packages/import-export/dist/index.d.ts"
       ],
       "@hierarchidb/import-export/*": [
-        "../packages/import-export/dist/*"
+        "./packages/import-export/dist/*"
       ],
       "@hierarchidb/linker-plugin": [
-        "../plugins/linker-plugin/dist/index.d.ts"
+        "./plugins/linker-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/linker-plugin/*": [
-        "../plugins/linker-plugin/dist/*"
+        "./plugins/linker-plugin/dist/*"
       ],
       "@hierarchidb/location-plugin": [
-        "../plugins/location-plugin/dist/index.d.ts"
+        "./plugins/location-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/location-plugin/*": [
-        "../plugins/location-plugin/dist/*"
+        "./plugins/location-plugin/dist/*"
       ],
       "@hierarchidb/map-adapter": [
-        "../packages/map-adapter/dist/index.d.ts"
+        "./packages/map-adapter/dist/index.d.ts"
       ],
       "@hierarchidb/map-adapter/*": [
-        "../packages/map-adapter/dist/*"
+        "./packages/map-adapter/dist/*"
       ],
       "@hierarchidb/map-source": [
-        "../packages/map-source/dist/index.d.ts"
+        "./packages/map-source/dist/index.d.ts"
       ],
       "@hierarchidb/map-source/*": [
-        "../packages/map-source/dist/*"
+        "./packages/map-source/dist/*"
       ],
       "@hierarchidb/memory-usage": [
-        "../packages/ui/memory-usage/dist/index.d.ts"
+        "./packages/ui/memory-usage/dist/index.d.ts"
       ],
       "@hierarchidb/memory-usage/*": [
-        "../packages/ui/memory-usage/dist/*"
+        "./packages/ui/memory-usage/dist/*"
       ],
       "@hierarchidb/plugin-registry": [
-        "../packages/plugin-registry/dist/registry.d.ts"
+        "./packages/plugin-registry/dist/registry.d.ts"
       ],
       "@hierarchidb/plugin-registry/derivations": [
-        "../packages/plugin-registry/dist/derivations.d.ts"
+        "./packages/plugin-registry/dist/derivations.d.ts"
       ],
       "@hierarchidb/plugin-registry/types": [
-        "../packages/plugin-registry/dist/types.d.ts"
+        "./packages/plugin-registry/dist/types.d.ts"
       ],
       "@hierarchidb/plugin-registry/*": [
-        "../packages/plugin-registry/dist/*"
+        "./packages/plugin-registry/dist/*"
       ],
       "@hierarchidb/plugin-presentation": [
-        "../packages/plugin-presentation/dist/index.d.ts"
+        "./packages/plugin-presentation/dist/index.d.ts"
       ],
       "@hierarchidb/plugin-presentation/*": [
-        "../packages/plugin-presentation/dist/*"
+        "./packages/plugin-presentation/dist/*"
       ],
       "@hierarchidb/plugin-service-api": [
-        "../packages/plugin-service-api/dist/index.d.ts"
+        "./packages/plugin-service-api/dist/index.d.ts"
       ],
       "@hierarchidb/plugin-service-api/*": [
-        "../packages/plugin-service-api/dist/*"
+        "./packages/plugin-service-api/dist/*"
       ],
       "@hierarchidb/plugin-ui-sdk": [
-        "../packages/plugin-ui-sdk/dist/index.d.ts"
+        "./packages/plugin-ui-sdk/dist/index.d.ts"
       ],
       "@hierarchidb/plugin-ui-sdk/*": [
-        "../packages/plugin-ui-sdk/dist/*"
+        "./packages/plugin-ui-sdk/dist/*"
       ],
       "@hierarchidb/resolver-plugin": [
-        "../plugins/resolver-plugin/dist/index.d.ts"
+        "./plugins/resolver-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/resolver-plugin/*": [
-        "../plugins/resolver-plugin/dist/*"
+        "./plugins/resolver-plugin/dist/*"
       ],
       "@hierarchidb/resolver-plugin/database": [
-        "../plugins/resolver-plugin/dist/worker/database/index.d.ts"
+        "./plugins/resolver-plugin/dist/worker/database/index.d.ts"
       ],
       "@hierarchidb/route-plugin": [
-        "../plugins/route-plugin/dist/index.d.ts"
+        "./plugins/route-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/route-plugin/*": [
-        "../plugins/route-plugin/dist/*"
+        "./plugins/route-plugin/dist/*"
       ],
       "@hierarchidb/route-resolver": [
-        "../packages/route-resolver/dist/index.d.ts"
+        "./packages/route-resolver/dist/index.d.ts"
       ],
       "@hierarchidb/route-resolver/*": [
-        "../packages/route-resolver/dist/*"
+        "./packages/route-resolver/dist/*"
       ],
       "@hierarchidb/route-engine": [
-        "../packages/route-engine/dist/index.d.ts"
+        "./packages/route-engine/dist/index.d.ts"
       ],
       "@hierarchidb/route-engine/*": [
-        "../packages/route-engine/dist/*"
+        "./packages/route-engine/dist/*"
       ],
       "@hierarchidb/route-searoute": [
-        "../packages/route-searoute/dist/index.d.ts"
+        "./packages/route-searoute/dist/index.d.ts"
       ],
       "@hierarchidb/route-searoute/*": [
-        "../packages/route-searoute/dist/*"
+        "./packages/route-searoute/dist/*"
       ],
       "@hierarchidb/route-store": [
-        "../packages/route-store/dist/index.d.ts"
+        "./packages/route-store/dist/index.d.ts"
       ],
       "@hierarchidb/route-store/*": [
-        "../packages/route-store/dist/*"
+        "./packages/route-store/dist/*"
       ],
       "@hierarchidb/route-api": [
-        "../packages/route-api/dist/index.d.ts"
+        "./packages/route-api/dist/index.d.ts"
       ],
       "@hierarchidb/route-api/*": [
-        "../packages/route-api/dist/*"
+        "./packages/route-api/dist/*"
       ],
       "@hierarchidb/vectortile-store": [
-        "../packages/vectortile-store/dist/index.d.ts"
+        "./packages/vectortile-store/dist/index.d.ts"
       ],
       "@hierarchidb/vectortile-store/*": [
-        "../packages/vectortile-store/dist/*"
+        "./packages/vectortile-store/dist/*"
       ],
       "@hierarchidb/vt-orchestrator": [
-        "../packages/vt-orchestrator/dist/index.d.ts"
+        "./packages/vt-orchestrator/dist/index.d.ts"
       ],
       "@hierarchidb/vt-orchestrator/*": [
-        "../packages/vt-orchestrator/dist/*"
+        "./packages/vt-orchestrator/dist/*"
       ],
       "@hierarchidb/ui-worker-client": [
-        "../packages/ui/worker-client/dist/index.d.ts"
+        "./packages/ui/worker-client/dist/index.d.ts"
       ],
       "@hierarchidb/ui-worker-client/*": [
-        "../packages/ui/worker-client/dist/*"
+        "./packages/ui/worker-client/dist/*"
       ],
       "@hierarchidb/ui-worker-provider": [
-        "../packages/ui/worker-provider/dist/index.d.ts"
+        "./packages/ui/worker-provider/dist/index.d.ts"
       ],
       "@hierarchidb/ui-worker-provider/*": [
-        "../packages/ui/worker-provider/dist/*"
+        "./packages/ui/worker-provider/dist/*"
       ],
       "react-transition-group/Transition": [
         "types/react-transition-group/Transition.d.ts"
       ],
       "@hierarchidb/runtime-worker": [
-        "../packages/runtime-worker/dist/index.d.ts"
+        "./packages/runtime-worker/dist/index.d.ts"
       ],
       "@hierarchidb/runtime-worker/stage-worker": [
-        "../packages/runtime-worker/dist/stageWorker.entry.d.ts"
+        "./packages/runtime-worker/dist/stageWorker.entry.d.ts"
       ],
       "@hierarchidb/runtime-worker/*": [
-        "../packages/runtime-worker/dist/*"
+        "./packages/runtime-worker/dist/*"
       ],
       "@hierarchidb/session-coordinator": [
-        "../packages/session-coordinator/dist/index.d.ts"
+        "./packages/session-coordinator/dist/index.d.ts"
       ],
       "@hierarchidb/session-coordinator/*": [
-        "../packages/session-coordinator/dist/*"
+        "./packages/session-coordinator/dist/*"
       ],
       "@hierarchidb/shape-plugin": [
-        "../plugins/shape-plugin/dist/index.d.ts"
+        "./plugins/shape-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/shape-plugin/shape-stage-worker": [
-        "../plugins/shape-plugin/dist/services/batch/workers/shapeStageWorker.entry.d.ts"
+        "./plugins/shape-plugin/dist/services/batch/workers/shapeStageWorker.entry.d.ts"
       ],
       "@hierarchidb/shape-plugin/*": [
-        "../plugins/shape-plugin/dist/*"
+        "./plugins/shape-plugin/dist/*"
       ],
       "@hierarchidb/spreadsheet-plugin": [
-        "../plugins/spreadsheet-plugin/dist/index.d.ts"
+        "./plugins/spreadsheet-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/spreadsheet-plugin/*": [
-        "../plugins/spreadsheet-plugin/dist/*"
+        "./plugins/spreadsheet-plugin/dist/*"
       ],
       "@hierarchidb/styler-plugin": [
-        "../plugins/styler-plugin/dist/index.d.ts"
+        "./plugins/styler-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/styler-plugin/*": [
-        "../plugins/styler-plugin/dist/*"
+        "./plugins/styler-plugin/dist/*"
       ],
       "@hierarchidb/tabular-source": [
-        "../packages/tabular-source/dist/index.d.ts"
+        "./packages/tabular-source/dist/index.d.ts"
       ],
       "@hierarchidb/tabular-store": [
-        "../packages/tabular-store/dist/index.d.ts"
+        "./packages/tabular-store/dist/index.d.ts"
       ],
       "@hierarchidb/tabular-store/*": [
-        "../packages/tabular-store/dist/*"
+        "./packages/tabular-store/dist/*"
       ],
       "@hierarchidb/tabular-source-xlsx": [
-        "../packages/tabular-source-xlsx/dist/index.d.ts"
+        "./packages/tabular-source-xlsx/dist/index.d.ts"
       ],
       "@hierarchidb/tabular-source-xlsx/*": [
-        "../packages/tabular-source-xlsx/dist/*"
+        "./packages/tabular-source-xlsx/dist/*"
       ],
       "@hierarchidb/tabular-source/*": [
-        "../packages/tabular-source/dist/*"
+        "./packages/tabular-source/dist/*"
       ],
       "@hierarchidb/tag": [
-        "../packages/tag/dist/index.d.ts"
+        "./packages/tag/dist/index.d.ts"
       ],
       "@hierarchidb/tag/*": [
-        "../packages/tag/dist/*"
+        "./packages/tag/dist/*"
       ],
       "@hierarchidb/timeline-plugin": [
-        "../plugins/timeline-plugin/dist/index.d.ts"
+        "./plugins/timeline-plugin/dist/index.d.ts"
       ],
       "@hierarchidb/timeline-plugin/*": [
-        "../plugins/timeline-plugin/dist/*"
+        "./plugins/timeline-plugin/dist/*"
       ],
       "@hierarchidb/ui-accordion-config": [
-        "../packages/ui/accordion-config/dist/index.d.ts"
+        "./packages/ui/accordion-config/dist/index.d.ts"
       ],
       "@hierarchidb/ui-accordion-config/*": [
-        "../packages/ui/accordion-config/dist/*"
+        "./packages/ui/accordion-config/dist/*"
       ],
       "@hierarchidb/ui-auth": [
-        "../packages/ui/auth/dist/index.d.ts"
+        "./packages/ui/auth/dist/index.d.ts"
       ],
       "@hierarchidb/ui-auth/*": [
-        "../packages/ui/auth/dist/*"
+        "./packages/ui/auth/dist/*"
       ],
       "@hierarchidb/ui-country-select": [
-        "../packages/ui/country-select/dist/index.d.ts"
+        "./packages/ui/country-select/dist/index.d.ts"
       ],
       "@hierarchidb/ui-country-select/*": [
-        "../packages/ui/country-select/dist/*"
+        "./packages/ui/country-select/dist/*"
       ],
       "@hierarchidb/ui-csv-extract": [
-        "../packages/ui/tabular-extract/dist/index.d.ts"
+        "./packages/ui/tabular-extract/dist/index.d.ts"
       ],
       "@hierarchidb/ui-csv-extract/*": [
-        "../packages/ui/tabular-extract/dist/*"
+        "./packages/ui/tabular-extract/dist/*"
       ],
       "@hierarchidb/ui-grid": [
-        "../packages/ui/data-grid/dist/index.d.ts"
+        "./packages/ui/data-grid/dist/index.d.ts"
       ],
       "@hierarchidb/ui-grid/*": [
-        "../packages/ui/data-grid/dist/*"
+        "./packages/ui/data-grid/dist/*"
       ],
       "@hierarchidb/ui-datasource": [
-        "../packages/ui/datasource/dist/index.d.ts"
+        "./packages/ui/datasource/dist/index.d.ts"
       ],
       "@hierarchidb/ui-datasource/*": [
-        "../packages/ui/datasource/dist/*"
+        "./packages/ui/datasource/dist/*"
       ],
       "@hierarchidb/ui-batch-progress": [
-        "../packages/ui/batch/dist/index.d.ts"
+        "./packages/ui/batch/dist/index.d.ts"
       ],
       "@hierarchidb/ui-batch-progress/*": [
-        "../packages/ui/batch/dist/*"
+        "./packages/ui/batch/dist/*"
       ],
       "@hierarchidb/ui-dialog": [
-        "../packages/ui/dialog/dist/index.d.ts"
+        "./packages/ui/dialog/dist/index.d.ts"
       ],
       "@hierarchidb/ui-dialog/*": [
-        "../packages/ui/dialog/dist/*"
+        "./packages/ui/dialog/dist/*"
       ],
       "@hierarchidb/ui-file": [
-        "../packages/ui/file/dist/index.d.ts"
+        "./packages/ui/file/dist/index.d.ts"
       ],
       "@hierarchidb/ui-file/*": [
-        "../packages/ui/file/dist/*"
+        "./packages/ui/file/dist/*"
       ],
       "@hierarchidb/ui-floating-window": [
-        "../packages/ui/floating-window/dist/index.d.ts"
+        "./packages/ui/floating-window/dist/index.d.ts"
       ],
       "@hierarchidb/ui-floating-window/*": [
-        "../packages/ui/floating-window/dist/*"
+        "./packages/ui/floating-window/dist/*"
       ],
       "@hierarchidb/ui-i18n": [
-        "../packages/ui/i18n/dist/index.d.ts"
+        "./packages/ui/i18n/dist/index.d.ts"
       ],
       "@hierarchidb/ui-i18n/*": [
-        "../packages/ui/i18n/dist/*"
+        "./packages/ui/i18n/dist/*"
       ],
       "@hierarchidb/ui-json-treeview": [
-        "../packages/ui/json-treeview/dist/index.d.ts"
+        "./packages/ui/json-treeview/dist/index.d.ts"
       ],
       "@hierarchidb/ui-json-treeview/*": [
-        "../packages/ui/json-treeview/dist/*"
+        "./packages/ui/json-treeview/dist/*"
       ],
       "@hierarchidb/ui-icon": [
-        "../packages/ui/icon/dist/index.d.ts"
+        "./packages/ui/icon/dist/index.d.ts"
       ],
       "@hierarchidb/ui-icon/*": [
-        "../packages/ui/icon/dist/*"
+        "./packages/ui/icon/dist/*"
       ],
       "@hierarchidb/ui-layout": [
-        "../packages/ui/layout/dist/index.d.ts"
+        "./packages/ui/layout/dist/index.d.ts"
       ],
       "@hierarchidb/ui-layout/*": [
-        "../packages/ui/layout/dist/*"
+        "./packages/ui/layout/dist/*"
       ],
       "@hierarchidb/ui-license": [
-        "../packages/ui/license/dist/index.d.ts"
+        "./packages/ui/license/dist/index.d.ts"
       ],
       "@hierarchidb/ui-license/*": [
-        "../packages/ui/license/dist/*"
+        "./packages/ui/license/dist/*"
       ],
       "@hierarchidb/gen-iso3166-2": [
-        "../packages/tools/gen-iso3166-2/dist/index.d.ts"
+        "./packages/tools/gen-iso3166-2/dist/index.d.ts"
       ],
       "@hierarchidb/gen-iso3166-2/browser": [
-        "../packages/tools/gen-iso3166-2/dist/browser.d.ts"
+        "./packages/tools/gen-iso3166-2/dist/browser.d.ts"
       ],
       "@hierarchidb/gen-iso3166-2/node": [
-        "../packages/tools/gen-iso3166-2/dist/node.d.ts"
+        "./packages/tools/gen-iso3166-2/dist/node.d.ts"
       ],
       "@hierarchidb/gen-iso3166-2/*": [
-        "../packages/tools/gen-iso3166-2/dist/*"
+        "./packages/tools/gen-iso3166-2/dist/*"
       ],
       "@hierarchidb/ui-lru-splitview": [
-        "../packages/ui/lru-splitview/dist/index.d.ts"
+        "./packages/ui/lru-splitview/dist/index.d.ts"
       ],
       "@hierarchidb/ui-lru-splitview/*": [
-        "../packages/ui/lru-splitview/dist/*"
+        "./packages/ui/lru-splitview/dist/*"
       ],
       "@hierarchidb/ui-map": [
-        "../packages/ui/map/dist/index.d.ts"
+        "./packages/ui/map/dist/index.d.ts"
       ],
       "@hierarchidb/ui-map/*": [
-        "../packages/ui/map/dist/*"
+        "./packages/ui/map/dist/*"
       ],
       "@hierarchidb/ui-memory": [
-        "../packages/ui/memory/dist/index.d.ts"
+        "./packages/ui/memory/dist/index.d.ts"
       ],
       "@hierarchidb/ui-memory/*": [
-        "../packages/ui/memory/dist/*"
+        "./packages/ui/memory/dist/*"
       ],
       "@hierarchidb/ui-monitoring": [
-        "../packages/ui/monitoring/dist/index.d.ts"
+        "./packages/ui/monitoring/dist/index.d.ts"
       ],
       "@hierarchidb/ui-monitoring/*": [
-        "../packages/ui/monitoring/dist/*"
+        "./packages/ui/monitoring/dist/*"
       ],
       "@hierarchidb/ui-navigation": [
-        "../packages/ui/navigation/dist/index.d.ts"
+        "./packages/ui/navigation/dist/index.d.ts"
       ],
       "@hierarchidb/ui-navigation/*": [
-        "../packages/ui/navigation/dist/*"
+        "./packages/ui/navigation/dist/*"
       ],
       "@hierarchidb/ui-plugin-basic-info": [
-        "../packages/ui/plugin-basic-info/dist/index.d.ts"
+        "./packages/ui/plugin-basic-info/dist/index.d.ts"
       ],
       "@hierarchidb/ui-plugin-basic-info/*": [
-        "../packages/ui/plugin-basic-info/dist/*"
+        "./packages/ui/plugin-basic-info/dist/*"
       ],
       "@hierarchidb/plugin-ui-host": [
-        "../packages/plugin-ui-host/dist/index.d.ts"
+        "./packages/plugin-ui-host/dist/index.d.ts"
       ],
       "@hierarchidb/plugin-ui-host/*": [
-        "../packages/plugin-ui-host/dist/*"
+        "./packages/plugin-ui-host/dist/*"
       ],
       "@hierarchidb/plugin-base": [
-        "../packages/plugin-base/dist/index.d.ts"
+        "./packages/plugin-base/dist/index.d.ts"
       ],
       "@hierarchidb/plugin-base/*": [
-        "../packages/plugin-base/dist/*"
+        "./packages/plugin-base/dist/*"
       ],
       "@hierarchidb/ui-routing": [
-        "../packages/ui/routing/dist/index.d.ts"
+        "./packages/ui/routing/dist/index.d.ts"
       ],
       "@hierarchidb/ui-routing/*": [
-        "../packages/ui/routing/dist/*"
+        "./packages/ui/routing/dist/*"
       ],
       "@hierarchidb/ui-plugin-shell": [
-        "../packages/ui/plugin-shell/dist/index.d.ts"
+        "./packages/ui/plugin-shell/dist/index.d.ts"
       ],
       "@hierarchidb/ui-plugin-shell/*": [
-        "../packages/ui/plugin-shell/dist/*"
+        "./packages/ui/plugin-shell/dist/*"
       ],
       "@hierarchidb/ui-search-result-window": [
-        "../packages/ui/search-result-window/dist/index.d.ts"
+        "./packages/ui/search-result-window/dist/index.d.ts"
       ],
       "@hierarchidb/ui-search-result-window/*": [
-        "../packages/ui/search-result-window/dist/*"
+        "./packages/ui/search-result-window/dist/*"
       ],
       "@hierarchidb/ui-session-coordinator": [
-        "../packages/ui/session-coordinator/dist/index.d.ts"
+        "./packages/ui/session-coordinator/dist/index.d.ts"
       ],
       "@hierarchidb/ui-session-coordinator/*": [
-        "../packages/ui/session-coordinator/dist/*"
+        "./packages/ui/session-coordinator/dist/*"
       ],
       "@hierarchidb/ui-tabular": [
-        "../packages/ui/tabular-extract/dist/index.d.ts"
+        "./packages/ui/tabular-extract/dist/index.d.ts"
       ],
       "@hierarchidb/ui-tabular/*": [
-        "../packages/ui/tabular-extract/dist/*"
+        "./packages/ui/tabular-extract/dist/*"
       ],
       "@hierarchidb/ui-modal-select": [
-        "../packages/ui/modal-select/dist/index.d.ts"
+        "./packages/ui/modal-select/dist/index.d.ts"
       ],
       "@hierarchidb/ui-modal-select/*": [
-        "../packages/ui/modal-select/dist/*"
+        "./packages/ui/modal-select/dist/*"
       ],
       "@hierarchidb/ui-theme": [
-        "../packages/ui/theme/dist/index.d.ts"
+        "./packages/ui/theme/dist/index.d.ts"
       ],
       "@hierarchidb/ui-theme/*": [
-        "../packages/ui/theme/dist/*"
+        "./packages/ui/theme/dist/*"
       ],
       "@hierarchidb/ui-tour": [
-        "../packages/ui/tour/dist/index.d.ts"
+        "./packages/ui/tour/dist/index.d.ts"
       ],
       "@hierarchidb/ui-tour/*": [
-        "../packages/ui/tour/dist/*"
+        "./packages/ui/tour/dist/*"
       ],
       "@hierarchidb/ui-treeconsole-base": [
-        "../packages/ui/treeconsole/base/dist/index.d.ts"
+        "./packages/ui/treeconsole/base/dist/index.d.ts"
       ],
       "@hierarchidb/ui-treeconsole-base/*": [
-        "../packages/ui/treeconsole/base/dist/*"
+        "./packages/ui/treeconsole/base/dist/*"
       ],
       "@hierarchidb/ui-treeconsole-breadcrumb": [
-        "../packages/ui/treeconsole/breadcrumb/dist/index.d.ts"
+        "./packages/ui/treeconsole/breadcrumb/dist/index.d.ts"
       ],
       "@hierarchidb/ui-treeconsole-breadcrumb/*": [
-        "../packages/ui/treeconsole/breadcrumb/dist/*"
+        "./packages/ui/treeconsole/breadcrumb/dist/*"
       ],
       "@hierarchidb/ui-treeconsole-footer": [
-        "../packages/ui/treeconsole/footer/dist/index.d.ts"
+        "./packages/ui/treeconsole/footer/dist/index.d.ts"
       ],
       "@hierarchidb/ui-treeconsole-footer/*": [
-        "../packages/ui/treeconsole/footer/dist/*"
+        "./packages/ui/treeconsole/footer/dist/*"
       ],
       "@hierarchidb/ui-treeconsole-speeddial": [
-        "../packages/ui/treeconsole/speeddial/dist/index.d.ts"
+        "./packages/ui/treeconsole/speeddial/dist/index.d.ts"
       ],
       "@hierarchidb/ui-treeconsole-speeddial/*": [
-        "../packages/ui/treeconsole/speeddial/dist/*"
+        "./packages/ui/treeconsole/speeddial/dist/*"
       ],
       "@hierarchidb/ui-treeconsole-toolbar": [
-        "../packages/ui/treeconsole/toolbar/dist/index.d.ts"
+        "./packages/ui/treeconsole/toolbar/dist/index.d.ts"
       ],
       "@hierarchidb/ui-treeconsole-toolbar/*": [
-        "../packages/ui/treeconsole/toolbar/dist/*"
+        "./packages/ui/treeconsole/toolbar/dist/*"
       ],
       "@hierarchidb/ui-search-field": [
-        "../packages/ui/search-field/dist/index.d.ts"
+        "./packages/ui/search-field/dist/index.d.ts"
       ],
       "@hierarchidb/ui-search-field/*": [
-        "../packages/ui/search-field/dist/*"
+        "./packages/ui/search-field/dist/*"
       ],
       "@hierarchidb/ui-search-input": [
-        "../packages/ui/search-input/dist/index.d.ts"
+        "./packages/ui/search-input/dist/index.d.ts"
       ],
       "@hierarchidb/ui-search-input/*": [
-        "../packages/ui/search-input/dist/*"
+        "./packages/ui/search-input/dist/*"
       ],
       "@hierarchidb/ui-speeddial-submenu": [
-        "../packages/ui/speeddial-submenu/dist/index.d.ts"
+        "./packages/ui/speeddial-submenu/dist/index.d.ts"
       ],
       "@hierarchidb/ui-speeddial-submenu/*": [
-        "../packages/ui/speeddial-submenu/dist/*"
+        "./packages/ui/speeddial-submenu/dist/*"
       ],
       "@hierarchidb/ui-treeconsole-treetable": [
-        "../packages/ui/treeconsole/treetable/dist/index.d.ts"
+        "./packages/ui/treeconsole/treetable/dist/index.d.ts"
       ],
       "@hierarchidb/ui-treeconsole-treetable/*": [
-        "../packages/ui/treeconsole/treetable/dist/*"
+        "./packages/ui/treeconsole/treetable/dist/*"
       ],
       "~~/*": [
-        "src/*"
+        "app/src/*"
+      ],
+      "~": [
+        "app/src"
+      ],
+      "~/*": [
+        "app/src/*"
       ],
       "@hierarchidb/ui-usermenu": [
-        "../packages/ui/usermenu/dist/index.d.ts"
+        "./packages/ui/usermenu/dist/index.d.ts"
       ],
       "@hierarchidb/ui-usermenu/*": [
-        "../packages/ui/usermenu/dist/*"
+        "./packages/ui/usermenu/dist/*"
       ],
       "@hierarchidb/util": [
-        "../packages/util/dist/index.d.ts"
+        "./packages/util/dist/index.d.ts"
       ],
       "@hierarchidb/util/*": [
-        "../packages/util/dist/*"
+        "./packages/util/dist/*"
       ]
     },
     "noUnusedLocals": true,


### PR DESCRIPTION
## 概要
- packages内の tsdown build コマンドの outDir を明示し、./src 直下へ JS/JS.map を生成しないよう統一
- これにより未追跡のビルド汚染( *.js / *.js.map ) を抑止

## 変更ファイル
- app/vite.config.ts
- app/tsconfig.json
- tsconfig.base.json
- packages: batch-session-ports, vectortile-orchestrator, ui/datasource
- plugins: basemap-plugin, folder-plugin, linker-plugin, location-plugin, resolver-plugin, route-plugin, shape-plugin, spreadsheet-plugin, styler-plugin, timeline-plugin

## 検証
- app/内外の src 配下で未追跡の *.js, *.js.map が残らないことを確認