### PR TITLE
refactor: unify orchestrator execution policy and centralize progress bridge

### DIFF
--- a/packages/batch-runtime-services/src/index.ts
+++ b/packages/batch-runtime-services/src/index.ts
@@ -12,3 +12,16 @@ export {
   type BuildSessionTimingSnapshot,
   type UseBuildSessionTimingArgs,
 } from '@hierarchidb/batch';
+
+export {
+  toBuildProgressEventFromUpdate,
+  runWithStageCheckpoint,
+  createMemorySnapshot,
+} from './progressHelpers.js';
+export type {
+  ProgressBridgeUpdate,
+  StageCheckpointPhase,
+  StageCheckpointContext,
+  StageCheckpointLogger,
+  StageHeartbeatWriter,
+} from './progressHelpers.js';

--- a/packages/batch-runtime-services/src/progressHelpers.ts
+++ b/packages/batch-runtime-services/src/progressHelpers.ts
@@ -1,0 +1,132 @@
+import type { BuildProgressEvent } from '@hierarchidb/batch-api';
+import type { NodeId } from '@hierarchidb/core-types';
+
+type NumericValue = string | number | boolean;
+
+export type ProgressBridgeUpdate = {
+  jobId: string;
+  progress: number;
+  phase: string;
+  ts?: number;
+};
+
+export type StageCheckpointPhase = 'start' | 'success' | 'error';
+
+export type StageHeartbeatWriter = (stage: string, phase: StageCheckpointPhase) => Promise<void>;
+
+export type StageCheckpointContext = {
+  nodeId: NodeId;
+  runId?: string | null;
+  stage: string;
+  startedAt: number;
+  errorMessage?: string;
+  elapsedMs?: number;
+  memory?: Record<string, NumericValue>;
+};
+
+export type StageCheckpointLogger = {
+  onStart?: (ctx: StageCheckpointContext) => void;
+  onSuccess?: (ctx: StageCheckpointContext) => void;
+  onError?: (ctx: StageCheckpointContext) => void;
+};
+
+const normalizeProgress = (progress: number): number => {
+  if (!Number.isFinite(progress)) return 0;
+  return Math.max(0, Math.min(100, Math.round(progress)));
+};
+
+export function toBuildProgressEventFromUpdate(update: ProgressBridgeUpdate): BuildProgressEvent {
+  const completed = normalizeProgress(update.progress);
+  return {
+    nodeId: update.jobId as NodeId,
+    stage: update.phase,
+    phase: completed >= 100 ? 'completed' : 'running',
+    timestamp: update.ts ?? Date.now(),
+    payload: {
+      total: 100,
+      completed,
+      failed: 0,
+    },
+  };
+};
+
+export function createMemorySnapshot(): Record<string, NumericValue> | undefined {
+  const memory = (globalThis as {
+    performance?: {
+      memory?: {
+        usedJSHeapSize?: number;
+        totalJSHeapSize?: number;
+        jsHeapSizeLimit?: number;
+        usedJSHeapSizeLimit?: number;
+      };
+    };
+  }).performance?.memory;
+
+  if (!memory) return undefined;
+  if (memory.usedJSHeapSize === undefined && memory.totalJSHeapSize === undefined) return undefined;
+
+  return {
+    usedJSHeapSize: memory.usedJSHeapSize ?? 0,
+    totalJSHeapSize: memory.totalJSHeapSize ?? 0,
+    jsHeapSizeLimit: memory.jsHeapSizeLimit ?? 0,
+    usedJSHeapSizeLimit: memory.usedJSHeapSizeLimit ?? 0,
+  };
+}
+
+export async function runWithStageCheckpoint<T>(
+  options: {
+    nodeId: NodeId;
+    stage: string;
+    action: () => Promise<T>;
+    writeHeartbeat: StageHeartbeatWriter;
+    runId?: string | null;
+    logger?: StageCheckpointLogger;
+  },
+): Promise<T> {
+  const {
+    nodeId,
+    stage,
+    action,
+    writeHeartbeat,
+    runId,
+    logger,
+  } = options;
+  const startedAt = Date.now();
+
+  logger?.onStart?.({
+    nodeId,
+    stage,
+    runId,
+    startedAt,
+    memory: createMemorySnapshot(),
+  });
+  await writeHeartbeat(stage, 'start');
+
+  try {
+    const result = await action();
+    const finishedAt = Date.now();
+    await writeHeartbeat(stage, 'success');
+    logger?.onSuccess?.({
+      nodeId,
+      stage,
+      runId,
+      startedAt,
+      elapsedMs: finishedAt - startedAt,
+      memory: createMemorySnapshot(),
+    });
+    return result;
+  } catch (error) {
+    const finishedAt = Date.now();
+    await writeHeartbeat(stage, 'error');
+    logger?.onError?.({
+      nodeId,
+      stage,
+      runId,
+      startedAt,
+      elapsedMs: finishedAt - startedAt,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      memory: createMemorySnapshot(),
+    });
+    throw error;
+  }
+}

--- a/packages/vt-orchestrator/src/compareTaskOrder.ts
+++ b/packages/vt-orchestrator/src/compareTaskOrder.ts
@@ -1,5 +1,11 @@
 import { listTasksByStage, listTasksByStageAndStatus, updateTask, VtTaskQueueDb } from './task/taskQueue.js';
-import type { FailureHandling, RunStageOptions, TaskQueueRecord } from './types/types.js';
+import type {
+  FailureHandling,
+  LaneExecutionPolicy,
+  RunStageOptions,
+  TaskQueueRecord,
+  TaskFilter,
+} from './types/types.js';
 
 const compareTaskOrder = (a: TaskQueueRecord, b: TaskQueueRecord): number => {
   const pa = a.stagePriority ?? 0;
@@ -8,10 +14,72 @@ const compareTaskOrder = (a: TaskQueueRecord, b: TaskQueueRecord): number => {
   return a.index - b.index;
 };
 
+type ConcurrencyGate = {
+  limit: number;
+  active: number;
+  queue: Array<() => void>;
+};
+
+type StageTask<TInput = unknown, TOutput = unknown> = TaskQueueRecord<TInput, TOutput>;
+
+const createGate = (limit: number): ConcurrencyGate => ({
+  limit: Math.max(1, limit),
+  active: 0,
+  queue: [],
+});
+
+const acquire = async (gate: ConcurrencyGate): Promise<void> => {
+  if (gate.active < gate.limit) {
+    gate.active += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => gate.queue.push(resolve));
+  gate.active += 1;
+};
+
+const release = (gate: ConcurrencyGate): void => {
+  gate.active = Math.max(0, gate.active - 1);
+  const next = gate.queue.shift();
+  if (next && gate.active < gate.limit) {
+    next();
+  }
+};
+
+const buildTaskFilter = <TInput = unknown, TOutput = unknown>(
+  taskFilter?: TaskFilter<TInput, TOutput>,
+) => (task: StageTask<TInput, TOutput>): boolean => taskFilter ? taskFilter(task) : true;
+
+const buildLanePolicy = <TInput = unknown, TOutput = unknown>(
+  lanePolicy?: LaneExecutionPolicy<TInput, TOutput>,
+) => {
+  const enabled = lanePolicy?.enabled === true;
+  const laneOfTask = lanePolicy?.laneOfTask;
+  const resolveLaneLimit = lanePolicy?.maxConcurrentForLane;
+  const defaultLane = lanePolicy?.defaultLane ?? 'default';
+  return {
+    enabled,
+    getLaneKey: (task: StageTask<TInput, TOutput>): string => {
+      if (!enabled || !laneOfTask) return defaultLane;
+      const lane = laneOfTask(task);
+      return lane?.trim().length ? lane : defaultLane;
+    },
+    resolveLaneLimit,
+    defaultLane,
+  };
+};
+
 export async function runStageTasks<TInput = unknown, TOutput = unknown>(
   options: RunStageOptions<TInput, TOutput>
 ): Promise<void> {
-  const { nodeId, stage, handler, waitIfPaused, maxConcurrent } = options;
+  const {
+    nodeId,
+    stage,
+    handler,
+    waitIfPaused,
+    maxConcurrent,
+    taskFilter,
+    lanePolicy,
+  } = options;
   const failureHandling: FailureHandling = options.failureHandling ?? 'continue';
   const stopOnFailure = failureHandling === 'stop';
   const skipOnFailure = failureHandling === 'skip';
@@ -19,7 +87,15 @@ export async function runStageTasks<TInput = unknown, TOutput = unknown>(
   const abortSignal = abortController?.signal;
   const db = new VtTaskQueueDb();
   const tasks = await listTasksByStage(db, nodeId, stage);
-  const pending = tasks.filter((task) => task.status === 'queued').sort(compareTaskOrder);
+  const typedTasks = tasks as Array<StageTask<TInput, TOutput>>;
+  const shouldRunTask = buildTaskFilter(taskFilter);
+  const pending: Array<StageTask<TInput, TOutput>> = typedTasks
+    .filter((task) => task.status === 'queued')
+    .filter(shouldRunTask)
+    .sort((a, b) => compareTaskOrder(a, b));
+  const trackedTaskIds = new Set(pending.map((task) => task.taskId));
+  const lane = buildLanePolicy(lanePolicy);
+  const laneGates = new Map<string, ConcurrencyGate>();
   const baseMaxConcurrent = Math.max(1, Math.floor(maxConcurrent ?? 1));
   const dynamicConfig = options.dynamicConcurrency?.enabled ? options.dynamicConcurrency : null;
   const minConcurrent = dynamicConfig
@@ -45,6 +121,26 @@ export async function runStageTasks<TInput = unknown, TOutput = unknown>(
   let loggedTaskError = 0;
   let loggedPauseWait = 0;
   const maxTaskLogs = 2;
+
+  const resolveLaneLimit = (task: StageTask<TInput, TOutput>): number => {
+    if (!lane.enabled || !lane.resolveLaneLimit) return desiredConcurrent;
+    const key = lane.getLaneKey(task);
+    const resolved = lane.resolveLaneLimit(key, task);
+    if (typeof resolved === 'number' && Number.isFinite(resolved)) {
+      return Math.max(1, Math.floor(resolved));
+    }
+    return desiredConcurrent;
+  };
+
+  const getLaneGate = (task: StageTask<TInput, TOutput>): ConcurrencyGate | undefined => {
+    if (!lane.enabled) return undefined;
+    const key = lane.getLaneKey(task);
+    let next = laneGates.get(key);
+    if (next) return next;
+    next = createGate(resolveLaneLimit(task));
+    laneGates.set(key, next);
+    return next;
+  };
 
   const extractTaskId = (error: unknown): string | null => {
     if (!error || typeof error !== 'object') return null;
@@ -136,6 +232,10 @@ export async function runStageTasks<TInput = unknown, TOutput = unknown>(
       cursor += 1;
       const task = pending[index];
       if (!task) return;
+      const laneGate = getLaneGate(task);
+      if (laneGate) {
+        await acquire(laneGate);
+      }
       if (waitIfPaused) {
         const pauseWaitStartedAt = Date.now();
         await waitIfPaused();
@@ -244,6 +344,10 @@ export async function runStageTasks<TInput = unknown, TOutput = unknown>(
           abortAll(new Error(err), task.taskId);
           return;
         }
+      } finally {
+        if (laneGate) {
+          release(laneGate);
+        }
       }
     }
   };
@@ -293,7 +397,9 @@ export async function runStageTasks<TInput = unknown, TOutput = unknown>(
       listTasksByStageAndStatus(db, nodeId, stage, 'running'),
     ]);
     await Promise.all(
-      [...queued, ...running].map((task) => (
+      [...queued, ...running]
+        .filter((task) => trackedTaskIds.has(task.taskId))
+        .map((task) => (
         markTaskFailed(task.taskId, `aborted: ${reason}`)
       ))
     );

--- a/packages/vt-orchestrator/src/types/types.ts
+++ b/packages/vt-orchestrator/src/types/types.ts
@@ -17,6 +17,17 @@ export type TaskStatus = CommonTaskStatus;
 
 export type FailureHandling = 'continue' | 'stop' | 'skip';
 
+export type TaskFilter<TInput = unknown, TOutput = unknown> = (
+  task: TaskQueueRecord<TInput, TOutput>,
+) => boolean;
+
+export type LaneExecutionPolicy<TInput = unknown, TOutput = unknown> = {
+  enabled: boolean;
+  laneOfTask: (task: TaskQueueRecord<TInput, TOutput>) => string;
+  maxConcurrentForLane?: (lane: string, task: TaskQueueRecord<TInput, TOutput>) => number;
+  defaultLane?: string;
+};
+
 export type DynamicConcurrencyConfig = {
   enabled: boolean;
   minConcurrent: number;
@@ -97,6 +108,8 @@ export interface RunStageOptions<TInput = unknown, TOutput = unknown> {
   dynamicConcurrency?: DynamicConcurrencyConfig;
   failureHandling?: FailureHandling;
   abortController?: AbortController;
+  lanePolicy?: LaneExecutionPolicy<TInput, TOutput>;
+  taskFilter?: TaskFilter<TInput, TOutput>;
 }
 
 export type PipelineRunConfig<

--- a/plugins/route-plugin/src/services/RouteBuildManager.ts
+++ b/plugins/route-plugin/src/services/RouteBuildManager.ts
@@ -7,7 +7,11 @@ import type { NodeId } from '@hierarchidb/core-types';
 
 import type { RouteGenerationConfig } from '@hierarchidb/route-store';
 import type { RouteBuildConfig } from '@hierarchidb/route-store';
-import { RouteBuildSession, type RouteBuildTask } from './RouteBuildSession.js';
+import {
+  RouteBuildSession,
+  type RouteBuildTask,
+  type RouteBuildTaskStage,
+} from './RouteBuildSession.js';
 import type { BuildProgressEvent } from '@hierarchidb/batch-api';
 import { VtTaskQueueDb, putTasks } from '@hierarchidb/vt-orchestrator';
 import type { TaskQueueRecord, TaskStage } from '@hierarchidb/batch-api';
@@ -83,8 +87,8 @@ export class RouteBuildManager {
             treeNodeId: nodeId,
             nodeId,
             taskType: 'location_resolution',
-            stage: 'download', // Reuse Shape's stage
-            status: 'pending',
+            stage: 'location-resolution',
+            status: 'queued',
             index: routeTasks.length,
             routeData: {
               startLocationId: route.startLocationId,
@@ -104,8 +108,8 @@ export class RouteBuildManager {
         treeNodeId: nodeId,
         nodeId,
         taskType: 'route_generation',
-        stage: 'extract1', // Reuse Shape's stage for processing
-        status: 'pending',
+        stage: 'route-generation',
+        status: 'queued',
         index: routeTasks.length,
         routeData: {
           startLocationId: route?.startLocationId,
@@ -128,8 +132,8 @@ export class RouteBuildManager {
         treeNodeId: nodeId,
         nodeId,
         taskType: 'validation',
-        stage: 'extract2', // Reuse Shape's stage for validation
-        status: 'pending',
+        stage: 'validation',
+        status: 'queued',
         index: routeTasks.length,
       });
     }
@@ -140,8 +144,8 @@ export class RouteBuildManager {
       treeNodeId: nodeId,
       nodeId,
       taskType: 'optimization',
-      stage: 'vectortile', // Reuse Shape's stage for final optimization
-      status: 'pending',
+      stage: 'optimization',
+      status: 'queued',
       index: routeTasks.length,
     });
 
@@ -152,7 +156,7 @@ export class RouteBuildManager {
     await putTasks(taskQueue, routeTasks.map((task) => toTaskQueueRecord(task)));
 
     // Start processing using Shape's infrastructure
-    const session = new RouteBuildSession(nodeId, config, routeTasks, { taskQueue });
+    const session = new RouteBuildSession(nodeId, config, routeTasks);
     this.activeSessions.set(nodeId, session);
     const unsubscribe = session.addBuildProgressListener((event: BuildProgressEvent) => this.emitProgressEvent(event));
     await session.initialize();
@@ -225,9 +229,9 @@ export class RouteBuildManager {
     phase: string;
     progress: number;
     completedRoutes: number;
-    totalRoutes: number;
-    errors: string[];
-  }> {
+  totalRoutes: number;
+  errors: string[];
+}> {
     const tasks = this.routeSpecificTasks.get(nodeId) || [];
     const completedTasks = tasks.filter((t) => t.status === 'completed');
     const failedTasks = tasks.filter((t) => t.status === 'failed');
@@ -241,13 +245,13 @@ export class RouteBuildManager {
 
     // Determine current phase
     let phase = 'idle';
-    if (tasks.some((t) => t.taskType === 'location_resolution' && t.status === 'processing')) {
+    if (tasks.some((t) => t.taskType === 'location_resolution' && t.status === 'running')) {
       phase = 'resolving_locations';
-    } else if (tasks.some((t) => t.taskType === 'route_generation' && t.status === 'processing')) {
+    } else if (tasks.some((t) => t.taskType === 'route_generation' && t.status === 'running')) {
       phase = 'generating_routes';
-    } else if (tasks.some((t) => t.taskType === 'validation' && t.status === 'processing')) {
+    } else if (tasks.some((t) => t.taskType === 'validation' && t.status === 'running')) {
       phase = 'validating';
-    } else if (tasks.some((t) => t.taskType === 'optimization' && t.status === 'processing')) {
+    } else if (tasks.some((t) => t.taskType === 'optimization' && t.status === 'running')) {
       phase = 'optimizing';
     }
 
@@ -265,11 +269,12 @@ export class RouteBuildManager {
     const total = coerceNumber(payload.total);
     const completed = coerceNumber(payload.completed);
     const percentage = computePercentage(total, completed, event.phase === 'completed');
+    const stage = normalizeRouteProgressStage(event.stage);
     const ts = event.timestamp ?? Date.now();
     const update: ProgressUpdate = {
       jobId: event.nodeId,
       progress: percentage,
-      phase: event.stage,
+      phase: stage,
       ts,
     };
     try {
@@ -310,18 +315,33 @@ function toTaskQueueRecord(task: RouteBuildTask): TaskQueueRecord {
   };
 }
 
-function mapRouteStageToVtStage(stage: string): TaskStage {
+function mapRouteStageToVtStage(stage: RouteBuildTaskStage): TaskStage {
   switch (stage) {
-    case 'download':
+    case 'location-resolution':
       return 'fetch';
-    case 'extract1':
+    case 'route-generation':
       return 'transform';
-    case 'extract2':
+    case 'validation':
       return 'transform';
-    case 'vectortile':
+    case 'optimization':
       return 'vt';
     default:
       throw new Error(`Unsupported route stage for vt task queue: ${stage}`);
+  }
+}
+
+function normalizeRouteProgressStage(stage: string): string {
+  switch (stage) {
+    case 'location-resolution':
+      return 'resolving_locations';
+    case 'route-generation':
+      return 'generating_routes';
+    case 'validation':
+      return 'validating';
+    case 'optimization':
+      return 'optimizing';
+    default:
+      return stage;
   }
 }
 

--- a/plugins/route-plugin/src/services/RouteBuildSession.ts
+++ b/plugins/route-plugin/src/services/RouteBuildSession.ts
@@ -1,22 +1,23 @@
 import { AbstractBuildSession } from '@hierarchidb/batch-runtime-services';
-import type { BuildProgressEvent } from '@hierarchidb/batch-api';
+import type { BuildProgressEvent, TaskStatus } from '@hierarchidb/batch-api';
 import type { NodeId } from '@hierarchidb/core-types';
 import type { RouteGenerationConfig, RouteGenerationMethod } from '@hierarchidb/route-store';
 import type { RouteBuildConfig } from '@hierarchidb/route-store';
 import { RouteGenerator } from '@hierarchidb/route-engine';
 import type { TaskQueueRecord } from '@hierarchidb/batch-api';
-import { updateTask, type VtTaskQueueDb } from '@hierarchidb/vt-orchestrator';
+import { runStageTasks } from '@hierarchidb/vt-orchestrator';
+import type { TaskStage } from '@hierarchidb/batch-api';
 
-export type RouteBuildTaskStatus = 'pending' | 'processing' | 'completed' | 'failed';
 export type RouteBuildTaskType = 'location_resolution' | 'route_generation' | 'validation' | 'optimization';
+export type RouteBuildTaskStage = 'location-resolution' | 'route-generation' | 'validation' | 'optimization';
 
 export type RouteBuildTask = {
   taskId: string;
   treeNodeId: NodeId;
   nodeId: NodeId;
   taskType: RouteBuildTaskType;
-  stage: string;
-  status: RouteBuildTaskStatus;
+  stage: RouteBuildTaskStage;
+  status: TaskStatus;
   index: number;
   routeData?: {
     startLocationId?: NodeId;
@@ -29,15 +30,13 @@ export type RouteBuildTask = {
   error?: string;
 };
 
-export type RouteBuildSessionDeps = {
-  generator?: { generate: (points: [number, number][], config: RouteGenerationConfig) => Promise<unknown> };
-  taskQueue?: VtTaskQueueDb;
+export type RouteBuildTaskQueueInput = {
+  taskType: RouteBuildTaskType;
+  routeData?: RouteBuildTask['routeData'];
 };
 
-type LaneGate = {
-  limit: number;
-  active: number;
-  queue: Array<() => void>;
+export type RouteBuildSessionDeps = {
+  generator?: { generate: (points: [number, number][], config: RouteGenerationConfig) => Promise<unknown> };
 };
 
 const DEFAULT_LANE_CAPS: Record<string, number> = {
@@ -50,60 +49,127 @@ const DEFAULT_LANE_CAPS: Record<string, number> = {
 
 export class RouteBuildSession extends AbstractBuildSession<RouteBuildConfig> {
   private readonly tasks: RouteBuildTask[];
+  private readonly tasksById: Map<string, RouteBuildTask>;
   private readonly generator: RouteBuildSessionDeps['generator'];
-  private readonly taskQueue?: VtTaskQueueDb;
 
   constructor(nodeId: NodeId, config: RouteBuildConfig, tasks: RouteBuildTask[], deps?: RouteBuildSessionDeps) {
     super(nodeId, config);
     this.tasks = tasks;
+    this.tasksById = new Map(tasks.map((task) => [task.taskId, task]));
     this.generator = deps?.generator ?? new RouteGenerator();
-    this.taskQueue = deps?.taskQueue;
   }
 
   protected async processBatch(signal: AbortSignal): Promise<void> {
     if (signal.aborted) throw abortError('Route build aborted');
 
     const total = this.tasks.length;
-    let completed = 0;
-    let failed = 0;
+    let { completed, failed } = this.countTaskResults();
     this.updateProgress({ total, completed, failed }, 'idle');
 
-    const locationTasks = this.tasks.filter((task) => task.taskType === 'location_resolution');
-    const routeTasks = this.tasks.filter((task) => task.taskType === 'route_generation');
-    const validationTasks = this.tasks.filter((task) => task.taskType === 'validation');
-    const optimizationTasks = this.tasks.filter((task) => task.taskType === 'optimization');
+    const resolveTaskFilter = (taskType: RouteBuildTaskType) =>
+      (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => task.inputData?.taskType === taskType;
 
-    for (const task of locationTasks) {
-      await this.runTask(task, signal, () => Promise.resolve());
-      ({ completed, failed } = this.bumpCounts(task, completed, failed));
-      this.updateProgress({ total, completed, failed }, task.stage);
-    }
+    await runStageTasks<RouteBuildTaskQueueInput>({
+      nodeId: this.nodeId,
+      stage: 'fetch',
+      taskFilter: resolveTaskFilter('location_resolution'),
+      handler: async (task: TaskQueueRecord<RouteBuildTaskQueueInput>) =>
+        this.handleNoopRouteTask(task, 'location_resolution', 'location-resolution'),
+      failureHandling: 'continue',
+    } as {
+      nodeId: TaskQueueRecord['nodeId'];
+      stage: TaskStage;
+      handler: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => Promise<{ status: 'completed'; progress: number }>;
+      taskFilter?: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => boolean;
+      maxConcurrent?: number;
+      failureHandling?: 'continue' | 'stop' | 'skip';
+      lanePolicy?: {
+        enabled: boolean;
+        laneOfTask: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => string;
+        maxConcurrentForLane?: (lane: string, task: TaskQueueRecord<RouteBuildTaskQueueInput>) => number;
+      };
+    });
+    ({ completed, failed } = this.countTaskResults());
+    this.updateProgress({ total, completed, failed }, 'location-resolution');
 
-    if (routeTasks.length > 0) {
-      const parallel = Boolean(this.config.routeGeneration?.parallel);
-      const maxConcurrent = Math.max(1, this.config.routeGeneration?.maxConcurrent ?? 1);
-      const globalGate = createGate(parallel ? maxConcurrent : 1);
-      const laneGates = new Map<string, LaneGate>();
+    const globalMaxConcurrent = Math.max(1, this.config.routeGeneration?.maxConcurrent ?? 1);
+    await runStageTasks<RouteBuildTaskQueueInput>({
+      nodeId: this.nodeId,
+      stage: 'transform',
+      taskFilter: resolveTaskFilter('route_generation'),
+      handler: async (task: TaskQueueRecord<RouteBuildTaskQueueInput>, _signal: AbortSignal) =>
+        this.handleRouteGenerationTask(task, signal),
+      maxConcurrent: this.config.routeGeneration?.parallel ? globalMaxConcurrent : 1,
+      failureHandling: 'continue',
+      lanePolicy: {
+        enabled: true,
+        laneOfTask: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => this.resolveRouteLane(task),
+        maxConcurrentForLane: (lane: string) => {
+          const override = this.config.laneCaps?.[lane as RouteGenerationMethod];
+          return override ?? DEFAULT_LANE_CAPS[lane] ?? 1;
+        },
+      },
+    } as {
+      nodeId: TaskQueueRecord['nodeId'];
+      stage: TaskStage;
+      handler: (task: TaskQueueRecord<RouteBuildTaskQueueInput>, signal?: AbortSignal) => Promise<{ status: 'completed'; progress: number }>;
+      taskFilter?: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => boolean;
+      maxConcurrent?: number;
+      failureHandling?: 'continue' | 'stop' | 'skip';
+      lanePolicy?: {
+        enabled: boolean;
+        laneOfTask: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => string;
+        maxConcurrentForLane?: (lane: string, task: TaskQueueRecord<RouteBuildTaskQueueInput>) => number;
+      };
+    });
+    ({ completed, failed } = this.countTaskResults());
+    this.updateProgress({ total, completed, failed }, 'route-generation');
 
-      const runners = routeTasks.map((task) => this.runWithGates(task, signal, globalGate, laneGates)
-        .then(() => {
-          ({ completed, failed } = this.bumpCounts(task, completed, failed));
-          this.updateProgress({ total, completed, failed }, task.stage);
-        }));
-      await Promise.all(runners);
-    }
+    await runStageTasks<RouteBuildTaskQueueInput>({
+      nodeId: this.nodeId,
+      stage: 'transform',
+      taskFilter: resolveTaskFilter('validation'),
+      handler: async (task: TaskQueueRecord<RouteBuildTaskQueueInput>) =>
+        this.handleNoopRouteTask(task, 'validation', 'validation'),
+      failureHandling: 'continue',
+    } as {
+      nodeId: TaskQueueRecord['nodeId'];
+      stage: TaskStage;
+      handler: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => Promise<{ status: 'completed'; progress: number }>;
+      taskFilter?: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => boolean;
+      maxConcurrent?: number;
+      failureHandling?: 'continue' | 'stop' | 'skip';
+      lanePolicy?: {
+        enabled: boolean;
+        laneOfTask: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => string;
+        maxConcurrentForLane?: (lane: string, task: TaskQueueRecord<RouteBuildTaskQueueInput>) => number;
+      };
+    });
+    ({ completed, failed } = this.countTaskResults());
+    this.updateProgress({ total, completed, failed }, 'validation');
 
-    for (const task of validationTasks) {
-      await this.runTask(task, signal, () => Promise.resolve());
-      ({ completed, failed } = this.bumpCounts(task, completed, failed));
-      this.updateProgress({ total, completed, failed }, task.stage);
-    }
-
-    for (const task of optimizationTasks) {
-      await this.runTask(task, signal, () => Promise.resolve());
-      ({ completed, failed } = this.bumpCounts(task, completed, failed));
-      this.updateProgress({ total, completed, failed }, task.stage);
-    }
+    await runStageTasks<RouteBuildTaskQueueInput>({
+      nodeId: this.nodeId,
+      stage: 'vt',
+      taskFilter: resolveTaskFilter('optimization'),
+      handler: async (task: TaskQueueRecord<RouteBuildTaskQueueInput>) =>
+        this.handleNoopRouteTask(task, 'optimization', 'optimization'),
+      failureHandling: 'continue',
+    } as {
+      nodeId: TaskQueueRecord['nodeId'];
+      stage: TaskStage;
+      handler: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => Promise<{ status: 'completed'; progress: number }>;
+      taskFilter?: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => boolean;
+      maxConcurrent?: number;
+      failureHandling?: 'continue' | 'stop' | 'skip';
+      lanePolicy?: {
+        enabled: boolean;
+        laneOfTask: (task: TaskQueueRecord<RouteBuildTaskQueueInput>) => string;
+        maxConcurrentForLane?: (lane: string, task: TaskQueueRecord<RouteBuildTaskQueueInput>) => number;
+      };
+    });
+    ({ completed, failed } = this.countTaskResults());
+    this.updateProgress({ total, completed, failed }, 'optimization');
 
     if (failed > 0) {
       throw new Error('Route build completed with failures');
@@ -113,109 +179,105 @@ export class RouteBuildSession extends AbstractBuildSession<RouteBuildConfig> {
   protected onBuildProgressEvent(_event: BuildProgressEvent): void {
   }
 
-  private async runWithGates(
-    task: RouteBuildTask,
+  private async handleRouteGenerationTask(
+    task: TaskQueueRecord<RouteBuildTaskQueueInput>,
     signal: AbortSignal,
-    globalGate: LaneGate,
-    laneGates: Map<string, LaneGate>,
-  ): Promise<void> {
-    const method = task.routeData?.method ?? this.config.routeGeneration.method;
-    const laneGate = getLaneGate(laneGates, method, this.config.laneCaps);
-
-    await acquire(globalGate);
-    await acquire(laneGate);
-    try {
-      await this.runTask(task, signal, () => this.runRouteTask(task, method, signal));
-    } finally {
-      release(laneGate);
-      release(globalGate);
+  ): Promise<{ status: 'completed'; progress: number }> {
+    const localTask = this.findTask(task.taskId);
+    if (!localTask) {
+      throw new Error(`Unknown route task ${task.taskId}`);
     }
-  }
 
-  private async runTask(task: RouteBuildTask, signal: AbortSignal, work: () => Promise<void>): Promise<void> {
-    if (signal.aborted) throw abortError('Route build aborted');
-    task.status = 'processing';
-    await this.updateTaskQueue(task, { status: 'running', startedAt: Date.now(), progress: 0 });
-    this.updateProgress({ total: this.tasks.length }, task.stage);
+    localTask.status = 'running';
+    localTask.error = undefined;
+    const method = localTask.routeData?.method ?? this.config.routeGeneration.method;
+    const options = localTask.routeData?.methodOptions;
+    const start = localTask.routeData?.startCoordinates;
+    const end = localTask.routeData?.endCoordinates;
 
-    try {
-      await work();
-      task.status = 'completed';
-      await this.updateTaskQueue(task, { status: 'completed', progress: 100, completedAt: Date.now() });
-    } catch (error) {
-      task.status = 'failed';
-      task.error = error instanceof Error ? error.message : String(error);
-      await this.updateTaskQueue(task, { status: 'failed', errorMessage: task.error });
-    }
-  }
-
-  private async runRouteTask(task: RouteBuildTask, method: RouteGenerationMethod, signal: AbortSignal): Promise<void> {
-    if (signal.aborted) throw abortError('Route build aborted');
-    const start = task.routeData?.startCoordinates;
-    const end = task.routeData?.endCoordinates;
     if (!start || !end) {
-      throw new Error('Route build task missing coordinates');
+      const message = 'Route build task missing coordinates';
+      localTask.status = 'failed';
+      localTask.error = message;
+      this.updateProgressByTaskType(localTask.stage);
+      throw new Error(message);
     }
+
+    await this.runRouteTask([start, end], method, options, signal);
+
+    localTask.status = 'completed';
+    this.updateProgressByTaskType(localTask.stage);
+    return {
+      status: 'completed',
+      progress: 100,
+    };
+  }
+
+  private async handleNoopRouteTask(
+    task: TaskQueueRecord<RouteBuildTaskQueueInput>,
+    taskType: RouteBuildTaskType,
+    stage: RouteBuildTaskStage,
+  ): Promise<{ status: 'completed'; progress: number }> {
+    const localTask = this.findTask(task.taskId);
+    if (!localTask) {
+      throw new Error(`Unknown route task ${task.taskId}`);
+    }
+    if (localTask.taskType !== taskType) {
+      localTask.status = 'failed';
+      const error = `Unexpected route task type. expected=${taskType}, actual=${localTask.taskType}`;
+      localTask.error = error;
+      this.updateProgressByTaskType(stage);
+      throw new Error(error);
+    }
+    localTask.status = 'completed';
+    localTask.error = undefined;
+    this.updateProgressByTaskType(stage);
+    return {
+      status: 'completed',
+      progress: 100,
+    };
+  }
+
+  private async runRouteTask(
+    points: [number, number][],
+    method: RouteGenerationMethod,
+    options: RouteGenerationConfig['options'],
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (signal.aborted) throw abortError('Route build aborted');
     const config: RouteGenerationConfig = {
       method,
-      options: task.routeData?.methodOptions,
+      options,
     };
-    await this.generator?.generate([start, end], config);
+    await this.generator?.generate(points, config);
   }
 
-  private async updateTaskQueue(task: RouteBuildTask, updates: Partial<TaskQueueRecord>): Promise<void> {
-    if (!this.taskQueue) return;
-    await updateTask(this.taskQueue, task.taskId, updates);
+  private resolveRouteLane(task: TaskQueueRecord<RouteBuildTaskQueueInput>): string {
+    const fallbackMethod = this.config.routeGeneration.method;
+    return task.inputData?.routeData?.method ?? fallbackMethod;
   }
 
-  private bumpCounts(task: RouteBuildTask, completed: number, failed: number): { completed: number; failed: number } {
-    if (task.status === 'completed') {
-      return { completed: completed + 1, failed };
-    }
-    if (task.status === 'failed') {
-      return { completed, failed: failed + 1 };
+  private countTaskResults(): { completed: number; failed: number } {
+    let completed = 0;
+    let failed = 0;
+    for (const task of this.tasks) {
+      if (task.status === 'completed') {
+        completed += 1;
+      } else if (task.status === 'failed') {
+        failed += 1;
+      }
     }
     return { completed, failed };
   }
-}
 
-function createGate(limit: number): LaneGate {
-  return {
-    limit: Math.max(1, limit),
-    active: 0,
-    queue: [],
-  };
-}
-
-async function acquire(gate: LaneGate): Promise<void> {
-  if (gate.active < gate.limit) {
-    gate.active += 1;
-    return;
+  private findTask(taskId: string): RouteBuildTask | undefined {
+    return this.tasksById.get(taskId);
   }
-  await new Promise<void>((resolve) => gate.queue.push(resolve));
-  gate.active += 1;
-}
 
-function release(gate: LaneGate): void {
-  gate.active = Math.max(0, gate.active - 1);
-  const next = gate.queue.shift();
-  if (next && gate.active < gate.limit) {
-    next();
+  private updateProgressByTaskType(stage: RouteBuildTaskStage): void {
+    const { completed, failed } = this.countTaskResults();
+    this.updateProgress({ total: this.tasks.length, completed, failed }, stage);
   }
-}
-
-function getLaneGate(
-  lanes: Map<string, LaneGate>,
-  method: RouteGenerationMethod,
-  overrides: RouteBuildConfig['laneCaps'] | undefined,
-): LaneGate {
-  const key = method ?? 'direct';
-  const existing = lanes.get(key);
-  if (existing) return existing;
-  const cap = overrides?.[key] ?? DEFAULT_LANE_CAPS[key] ?? 1;
-  const gate = createGate(cap);
-  lanes.set(key, gate);
-  return gate;
 }
 
 function abortError(message: string): Error {

--- a/plugins/route-plugin/src/services/RouteBuildSessionOrchestrator.ts
+++ b/plugins/route-plugin/src/services/RouteBuildSessionOrchestrator.ts
@@ -3,8 +3,11 @@ import { RouteBuildManager, type RouteBuildRouteInput, type RouteBuildManagerDep
 import type { RouteBuildSession } from './RouteBuildSession.js';
 import { DEFAULT_ROUTE_BUILD_CONFIG } from '~/common/config/buildConfig';
 import type { RouteBuildConfig } from '@hierarchidb/route-api';
-import type { BuildProgressCallback, BuildProgressEvent, BuildSessionStatus, StageKey } from '@hierarchidb/batch-api';
-import { BaseBuildSessionManager } from '@hierarchidb/batch-runtime-services';
+import type { BuildProgressCallback, BuildSessionStatus } from '@hierarchidb/batch-api';
+import {
+  BaseBuildSessionManager,
+  toBuildProgressEventFromUpdate,
+} from '@hierarchidb/batch-runtime-services';
 
 export interface RouteBuildSessionConfig {
   routeGeneration?: Partial<RouteBuildConfig['routeGeneration']>;
@@ -25,17 +28,7 @@ export class RouteBuildSessionOrchestrator extends BaseBuildSessionManager {
     super();
     const emitter = {
       emit: (update: { jobId: string; progress: number; phase: string; ts: number }) => {
-        const event: BuildProgressEvent = {
-          nodeId: update.jobId as NodeId,
-          stage: update.phase as StageKey,
-          phase: update.progress >= 100 ? 'completed' : 'running',
-          timestamp: update.ts,
-          payload: {
-            total: 100,
-            completed: update.progress,
-            failed: 0,
-          },
-        };
+        const event = toBuildProgressEventFromUpdate(update);
         this.emitProgress(update.jobId as NodeId, event);
       },
     };

--- a/plugins/shape-plugin/src/common/types/index.ts
+++ b/plugins/shape-plugin/src/common/types/index.ts
@@ -39,5 +39,6 @@ export {
   mergeBuildConfig,
   mergeProcessingConfig,
   summarizeCheckboxState,
+  getPreferredCountryCodeFormat,
   validateBatchConfig,
 } from '~/services/utils/utils';

--- a/plugins/shape-plugin/src/services/utils/utils.ts
+++ b/plugins/shape-plugin/src/services/utils/utils.ts
@@ -28,6 +28,7 @@ import {
   ZOOM_BAND_MIN_RANGES,
   ZOOM_BAND_MIN_ZOOM,
 } from '@hierarchidb/util';
+export { resolveFetchStageStrategy } from '../batch/strategies/resolveFetchStageStrategy';
 
 export function getDataSourceConfig(dataSource?: DataSourceName | null) {
   if (!dataSource) return undefined;

--- a/plugins/shape-plugin/src/services/vt/shapePipeline.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipeline.ts
@@ -8,6 +8,9 @@ import { ephemeralDB, type EphemeralDB } from '@hierarchidb/gis-sdk';
 import { metadataLoader } from '~/services/metadata/MetadataLoader';
 import { shapeMutationAPIImpl } from '~/services/batch/ShapeBuildAPIClient';
 import {
+  runWithStageCheckpoint,
+} from '@hierarchidb/batch-runtime-services';
+import {
   buildBands,
   buildContinentLookup,
   buildCountryLookup,
@@ -370,47 +373,55 @@ export const runShapePipeline = async (params: ShapePipelineParams): Promise<voi
       stageHeartbeatAt: Date.now(),
     }).catch(() => {});
   };
-  const checkpoint = async <T>(stage: string, action: () => Promise<T>): Promise<T> => {
-    const startedAt = Date.now();
-    markPipelineCheckpoint(stage, 'start');
-    console.warn('[ShapePipeline][Checkpoint] start', JSON.stringify({
-      nodeId: params.nodeId,
-      runId: params.pipelineRunId ?? null,
-      stage,
-      startedAt,
-    }));
-    try {
-      const result = await action();
-      const finishedAt = Date.now();
-      markPipelineCheckpoint(stage, 'success');
-      console.warn('[ShapePipeline][Checkpoint] finish', JSON.stringify({
-        nodeId: params.nodeId,
-        runId: params.pipelineRunId ?? null,
-        stage,
-        outcome: 'success',
-        startedAt,
-        finishedAt,
-        elapsedMs: finishedAt - startedAt,
-      }));
-      return result;
-    } catch (error) {
-      const finishedAt = Date.now();
-      markPipelineCheckpoint(stage, 'error');
-      console.error('[ShapePipeline][Checkpoint] finish', JSON.stringify({
-        nodeId: params.nodeId,
-        runId: params.pipelineRunId ?? null,
-        stage,
-        outcome: 'error',
-        startedAt,
-        finishedAt,
-        elapsedMs: finishedAt - startedAt,
-        errorMessage: error instanceof Error ? error.message : String(error),
-        errorName: error instanceof Error ? error.name : undefined,
-        errorStack: error instanceof Error ? error.stack : undefined,
-      }));
-      throw error;
-    }
-  };
+
+  const checkpoint = async <T>(stage: string, action: () => Promise<T>): Promise<T> => runWithStageCheckpoint({
+    nodeId: params.nodeId,
+    stage,
+    action,
+    runId: params.pipelineRunId,
+    writeHeartbeat: async (checkpointStage, _phase) => {
+      markPipelineCheckpoint(checkpointStage, _phase);
+      return undefined;
+    },
+    logger: {
+      onStart: ({ stage, startedAt, memory }) => {
+        console.warn('[ShapePipeline][Checkpoint] start', JSON.stringify({
+          nodeId: params.nodeId,
+          runId: params.pipelineRunId ?? null,
+          stage,
+          startedAt,
+          memory,
+        }));
+      },
+      onSuccess: ({ stage, startedAt, elapsedMs, memory }) => {
+        const finishedAt = Date.now();
+        console.warn('[ShapePipeline][Checkpoint] finish', JSON.stringify({
+          nodeId: params.nodeId,
+          runId: params.pipelineRunId ?? null,
+          stage,
+          outcome: 'success',
+          startedAt,
+          finishedAt,
+          elapsedMs,
+          memory,
+        }));
+      },
+      onError: ({ stage, startedAt, elapsedMs, errorMessage, memory }) => {
+        const finishedAt = Date.now();
+        console.error('[ShapePipeline][Checkpoint] finish', JSON.stringify({
+          nodeId: params.nodeId,
+          runId: params.pipelineRunId ?? null,
+          stage,
+          outcome: 'error',
+          startedAt,
+          finishedAt,
+          elapsedMs,
+          errorMessage,
+          memory,
+        }));
+      },
+    },
+  });
 
   await checkpoint('prepare-pipeline-run', async () => preparePipelineRun(context));
 


### PR DESCRIPTION
## 変更概要

- vt-orchestrator の  を拡張し、
  - 
  - 
  - 失敗時の abort 処理対象をそのステージ実行対象に限定
  を実装し、失敗時戦略/並行度制御/停止時処理を共通 DSL で扱えるよう統一
- Route の  を  ベースへ刷新し、
  location/route/validation/optimization 各フェーズを明示的に実行
- batch-runtime-services に  /  を追加し、
   と  の進捗ハートビート/イベント生成を共通化
- Route タスク生成 () と stage 名の正規化整合を反映

## 影響範囲
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 

## 検証
- ユーザー報告どおり  /  は pass 済み

## 補足
- このPR には本タスク対象の変更に限定し、既存の他のワーキングツリー差分は含めていません。