### PR TITLE
refactor(shape-plugin): split build step startup lifecycle hooks

### DIFF
--- a/plugins/shape-plugin/src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/integration/buildSessionStartup.integration.test.tsx
@@ -1,8 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BuildTaskUpdateEvent } from '@hierarchidb/batch-api';
-import { useShapeBuildTasks } from '~/ui/components/build-progress/useShapeBuildTasks';
-import { hasAwaitingFirstTaskSignal } from '~/ui/components/build-progress/awaitingFirstTaskSignal';
+import { useShapeBuildTasks } from '../../../components/build-progress/useShapeBuildTasks/useShapeBuildTasks';
+import { hasAwaitingFirstTaskSignal } from '../../../components/build-progress/awaitingFirstTaskSignal';
 
 const hoistedMocks = vi.hoisted(() => ({
   initializeMock: vi.fn<[], Promise<void>>(),

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/resolveAwaitingFirstTaskDecision.unit.test.ts
@@ -58,10 +58,18 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       isTaskStreamReady: true,
       expectTaskGeneration: false,
     });
-    expect(decision).toEqual({
+    expect(decision).toMatchObject({
       kind: 'success',
       reason: 'completed-without-generating-tasks',
       transitionFinish: {
+        level: 'info',
+        message: 'Build completed without generating tasks.',
+      },
+      taskExecutionStarted: {
+        queuedOnly: false,
+        hasProgressTaskSignal: false,
+      },
+      notification: {
         level: 'info',
         message: 'Build completed without generating tasks.',
       },
@@ -275,10 +283,18 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       isTaskStreamReady: true,
       expectTaskGeneration: true,
     });
-    expect(decision).toEqual({
+    expect(decision).toMatchObject({
       kind: 'success',
       reason: 'completed-before-first-task-update',
       transitionFinish: undefined,
+      taskExecutionStarted: {
+        queuedOnly: false,
+        hasProgressTaskSignal: false,
+      },
+      notification: {
+        level: 'info',
+        message: 'Build completed before first task update.',
+      },
     });
   });
 
@@ -293,10 +309,18 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       expectTaskGeneration: true,
       sessionProgressTotal: 5,
     });
-    expect(decision).toEqual({
+    expect(decision).toMatchObject({
       kind: 'success',
       reason: 'completed-with-session-progress-evidence',
       transitionFinish: {
+        level: 'info',
+        message: 'Build completed before task stream synchronization.',
+      },
+      taskExecutionStarted: {
+        queuedOnly: false,
+        hasProgressTaskSignal: true,
+      },
+      notification: {
         level: 'info',
         message: 'Build completed before task stream synchronization.',
       },
@@ -314,10 +338,18 @@ describe('resolveAwaitingFirstTaskDecision', () => {
       expectTaskGeneration: true,
       sessionProgressTotal: 5,
     });
-    expect(decision).toEqual({
+    expect(decision).toMatchObject({
       kind: 'success',
       reason: 'completed-with-session-progress-evidence',
       transitionFinish: {
+        level: 'info',
+        message: 'Build completed before task stream synchronization.',
+      },
+      taskExecutionStarted: {
+        queuedOnly: false,
+        hasProgressTaskSignal: false,
+      },
+      notification: {
         level: 'info',
         message: 'Build completed before task stream synchronization.',
       },

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useBuildProgressPanelState.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useBuildProgressPanelState.unit.test.ts
@@ -3,7 +3,7 @@ import {
   resolveCompletionFailedStageLabel,
   resolveActiveRunningStageId,
   shouldUpdateElapsedSnapshot,
-} from '~/ui/components/build-progress/useBuildProgressPanelState.utils';
+} from '~/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelState.utils';
 
 describe('shouldUpdateElapsedSnapshot', () => {
   it('returns true when there is no snapshot yet', () => {

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildAutoResume.reload.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildAutoResume.reload.unit.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import type { NodeId } from '@hierarchidb/core-types';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
-import { useShapeBuildAutoResume } from '~/ui/components/build-progress/useShapeBuildAutoResume';
+import { useShapeBuildAutoResume } from '../../../components/build-progress/useShapeBuildAutoResume/useShapeBuildAutoResume';
 
 describe('useShapeBuildAutoResume reload behavior', () => {
   const activeNodeId = 'node-1' as NodeId;

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildAutoResume.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildAutoResume.unit.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
-import { useShapeBuildAutoResume } from '~/ui/components/build-progress/useShapeBuildAutoResume';
+import { useShapeBuildAutoResume } from '../../../components/build-progress/useShapeBuildAutoResume/useShapeBuildAutoResume';
 
 const createLocalStorage = () => {
   const store = new Map<string, string>();

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTasks.unit.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BuildTaskUpdateEvent } from '@hierarchidb/batch-api';
-import { useShapeBuildTasks } from '~/ui/components/build-progress/useShapeBuildTasks';
+import { useShapeBuildTasks } from '../../../components/build-progress/useShapeBuildTasks/useShapeBuildTasks';
 
 const hoistedMocks = vi.hoisted(() => ({
   initializeMock: vi.fn<[], Promise<void>>(),

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/debug.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/debug.ts
@@ -1,4 +1,4 @@
-import type { BuildStatus } from '@hierarchidb/components/build-status';
+import type { BuildStatusSource } from '~/ui/components/build-progress/resolveBuildStatusSource';
 
 export type ShapeProgressStepDebugConfig = Partial<Record<'progress' | 'all', boolean>>;
 
@@ -31,7 +31,7 @@ export const emitShapeProgressStepTrace = (payload: ShapeProgressStepTracePayloa
 
 export type ShapeProgressStepTracePayload = {
   nodeId: string | null;
-  phase: BuildStatus;
+  phase: BuildStatusSource;
   progressTaskId: string | null;
   progressTaskStatus: string | null;
   progressTaskStage: string | null;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/startupTrace.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/startupTrace.ts
@@ -1,4 +1,4 @@
-import { type BuildStatus } from '@hierarchidb/components/build-status';
+import type { BuildStatusSource } from '~/ui/components/build-progress/resolveBuildStatusSource';
 import { getMemorySnapshot } from '@hierarchidb/ui-monitoring';
 
 export type BuildSessionTransitionPhase =
@@ -31,7 +31,7 @@ export type StartupStepMemorySnapshot = {
 
 export type ShapeProgressStepTracePayload = {
   nodeId: string | null;
-  phase: BuildStatus;
+  phase: BuildStatusSource;
   progressTaskId: string | null;
   progressTaskStatus: string | null;
   progressTaskStage: string | null;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
@@ -435,7 +435,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
   const { buildSessionTransitionElapsedMs: startupLifecycleElapsedMs } = useShapeBuildSessionStartupLifecycle({
     activeNodeId,
     buildSessionTransition,
-    buildStatus,
+    buildStatus: effectiveStatusSource,
     resolveTaskType: effectiveProgress?.progressTaskStage ?? null,
     effectiveProgress,
     displayTasks,

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle.ts
@@ -1,28 +1,27 @@
-import { useEffect, useState } from 'react';
-import type { BuildStatus } from '@hierarchidb/components/build-status';
+import { useState } from 'react';
+import { useShapeBuildSessionStartupTrace } from './useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupTrace';
+import { useShapeBuildSessionStartupProgressTerminalLog } from './useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupProgressTerminalLog';
+import { useShapeBuildSessionStartupTransitionTimers } from './useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupTransitionTimers';
+import { useShapeBuildSessionAwaitingFirstTaskDecision } from './useShapeBuildStepStartupLifecycle/useShapeBuildSessionAwaitingFirstTaskDecision';
 import type {
   BuildSessionTransitionNotificationLevel,
   BuildSessionTransitionState,
 } from '@hierarchidb/components/build-session';
-import type { BuildProgressStatus } from '~/ui/components/build-progress/shapeBuildProgressMapping';
 import type { BuildProgress } from '~/ui/components/build-progress/shapeBuildProgressMapping';
-import { isTaskPhaseDisplay } from '~/common/utils/taskMessages';
-import { resolveAwaitingFirstTaskDecision } from '~/ui/components/build-progress/resolveAwaitingFirstTaskDecision';
-import { resolveStartupTransitionWatchdogEvent } from '~/ui/components/build-progress/resolveStartupTransitionWatchdogEvent';
-import { UI_POLL_INTERVAL_MS } from './useShapeBuildStepHelpers/constants';
-import { emitShapeProgressStepTrace, isShapeProgressStepDebugEnabled } from './useShapeBuildStepHelpers/debug';
+import type { BuildProgressStatus } from '~/ui/components/build-progress/shapeBuildProgressMapping';
+import type { BuildStatusSource } from '~/ui/components/build-progress/resolveBuildStatusSource';
 import type {
   BuildSessionTransitionPhase,
   BuildStartupStep,
   BuildStartupStepOutcome,
-  ShapeProgressStepTracePayload,
 } from './useShapeBuildStepHelpers/startupTrace';
+import { UI_POLL_INTERVAL_MS } from './useShapeBuildStepHelpers/constants';
 import type { ShapeBuildTaskSummary } from '~/ui/atoms/shapeBuildProgressAtoms';
 
 type UseShapeBuildSessionStartupLifecycleArgs = {
   activeNodeId: string | null;
   buildSessionTransition: BuildSessionTransitionState<BuildSessionTransitionPhase>;
-  buildStatus: BuildStatus;
+  buildStatus: BuildStatusSource;
   resolveTaskType: string | null;
   effectiveProgress: BuildProgress | null;
   displayTasks: ShapeBuildTaskSummary[];
@@ -90,298 +89,57 @@ export const useShapeBuildSessionStartupLifecycle = ({
 }: UseShapeBuildSessionStartupLifecycleArgs) => {
   const [buildSessionTransitionElapsedMs, setBuildSessionTransitionElapsedMs] = useState(0);
 
-  useEffect(() => {
-    if (!isShapeProgressStepDebugEnabled()) return;
-    const nextTrace: ShapeProgressStepTracePayload = {
-      nodeId: activeNodeId,
-      phase: buildStatus,
-      progressTaskId: effectiveProgress?.progressTaskId ?? null,
-      progressTaskStatus: effectiveProgress?.progressTaskStatus ?? null,
-      progressTaskStage: resolveTaskType,
-      progressTaskProgress: effectiveProgress?.progressTaskProgress ?? null,
-      percentage: effectiveProgress?.percentage ?? null,
-      total: effectiveProgress?.total ?? 0,
-      completed: effectiveProgress?.completed ?? 0,
-      failed: effectiveProgress?.failed ?? 0,
-      skipped: effectiveProgress?.skipped ?? 0,
-      message: effectiveProgress?.message ?? null,
-    };
-    emitShapeProgressStepTrace(nextTrace);
-  }, [activeNodeId, buildStatus, effectiveProgress, resolveTaskType, emitShapeProgressStepTrace]);
-
-  useEffect(() => {
-    if (!buildSessionTransition.active) {
-      setBuildSessionTransitionElapsedMs(0);
-      return;
-    }
-    const intervalId = window.setInterval(() => {
-      const elapsedMs = Date.now() - buildSessionTransition.startedAt;
-      setBuildSessionTransitionElapsedMs(elapsedMs);
-      const watchdogEvent = resolveStartupTransitionWatchdogEvent({
-        elapsedMs,
-        warnStep: buildSessionTransitionWarnStepRef.current,
-      });
-      if (watchdogEvent.kind === 'none') return;
-      buildSessionTransitionWarnStepRef.current = watchdogEvent.nextWarnStep;
-      if (watchdogEvent.kind === 'timeout') {
-        emitBuildSessionTransitionLog('error', 'build session transition timeout', {
-          phase: buildSessionTransition.phase,
-          elapsedMs,
-        });
-        if (buildSessionTransition.phase === 'awaiting-first-task') {
-          finishBuildStartupStep('awaiting-first-task', 'error', {
-            reason: 'timeout-before-task-start',
-            elapsedMs,
-          });
-        }
-        finishBuildSessionTransition({
-          level: 'error',
-          message: `Build did not start task processing (${buildSessionTransition.phase}, ${Math.round(elapsedMs / 1000)}s).`,
-        });
-        return;
-      }
-      if (watchdogEvent.kind === 'long-wait') {
-        emitBuildSessionTransitionLog('warn', 'build session transition long wait', {
-          phase: buildSessionTransition.phase,
-          elapsedMs,
-        });
-        pushBuildSessionTransitionNotification(
-          'warning',
-          `Build start is still waiting at "${buildSessionTransition.phase}".`,
-        );
-        return;
-      }
-      emitBuildSessionTransitionLog('info', 'build session transition wait', {
-        phase: buildSessionTransition.phase,
-        elapsedMs,
-      });
-      pushBuildSessionTransitionNotification(
-        'info',
-        `Build start is taking longer than expected (${buildSessionTransition.phase}).`,
-      );
-    }, 1000);
-
-    setBuildSessionTransitionElapsedMs(Math.max(0, Date.now() - buildSessionTransition.startedAt));
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [
-    buildSessionTransition.active,
-    buildSessionTransition.phase,
-    buildSessionTransition.startedAt,
-    buildSessionTransitionWarnStepRef,
-    emitBuildSessionTransitionLog,
-    finishBuildStartupStep,
-    finishBuildSessionTransition,
-    pushBuildSessionTransitionNotification,
-  ]);
-
-  useEffect(() => {
-    if (!buildSessionTransition.active || buildSessionTransition.phase !== 'waiting-lock') {
-      buildSessionTransitionWaitLogStepRef.current = -1;
-      return;
-    }
-    const intervalMs = UI_POLL_INTERVAL_MS;
-    const tick = () => {
-      const elapsedMs = Date.now() - buildSessionTransition.startedAt;
-      const nextStep = Math.floor(elapsedMs / intervalMs);
-      if (nextStep <= buildSessionTransitionWaitLogStepRef.current) return;
-      buildSessionTransitionWaitLogStepRef.current = nextStep;
-      emitBuildSessionTransitionLog('info', 'build session waiting for lock', {
-        phase: buildSessionTransition.phase,
-        elapsedMs,
-        pollIntervalMs: intervalMs,
-      });
-    };
-    tick();
-    const intervalId = window.setInterval(tick, intervalMs);
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [
-    buildSessionTransition.active,
-    buildSessionTransition.phase,
-    buildSessionTransition.startedAt,
-    buildSessionTransitionWaitLogStepRef,
-    emitBuildSessionTransitionLog,
-  ]);
-
-  useEffect(() => {
-    if (!buildSessionTransition.active) return;
-    if (buildSessionTransition.phase !== 'awaiting-first-task') return;
-
-    const decisionInput = {
-      hasFirstTaskSignal,
-      hasStartedTasks,
-      hasProgressTaskSignal,
-      buildStatus,
-      taskCount: isTaskStreamReady ? displayTasks.length : undefined,
-      isTaskStreamReady,
-      expectTaskGeneration: awaitingFirstTaskExpectationRef.current,
-      sessionProgressTotal,
-      sessionStageId,
-    };
-
-    const decisionTraceKey = import.meta.env.DEV
-      ? JSON.stringify({
-        phase: buildSessionTransition.phase,
-        buildStatus: decisionInput.buildStatus,
-        hasFirstTaskSignal: decisionInput.hasFirstTaskSignal,
-        hasStartedTasks: decisionInput.hasStartedTasks,
-        hasProgressTaskSignal: decisionInput.hasProgressTaskSignal,
-        taskCount: decisionInput.taskCount,
-        isTaskStreamReady: decisionInput.isTaskStreamReady,
-        expectTaskGeneration: decisionInput.expectTaskGeneration,
-        sessionProgressTotal: decisionInput.sessionProgressTotal ?? null,
-        sessionStageId: decisionInput.sessionStageId ?? null,
-      })
-      : null;
-
-    if (decisionTraceKey && lastAwaitingFirstTaskDecisionTraceKeyRef.current !== decisionTraceKey) {
-      lastAwaitingFirstTaskDecisionTraceKeyRef.current = decisionTraceKey;
-      console.log('[ShapeAwaitingFirstTaskDecisionTrace] input', JSON.stringify({
-        nodeId: activeNodeId,
-        ...decisionInput,
-      }));
-    }
-
-    const decision = resolveAwaitingFirstTaskDecision(decisionInput);
-
-    if (import.meta.env.DEV && decision.kind !== 'continue') {
-      console.log('[ShapeAwaitingFirstTaskDecisionTrace] decision', JSON.stringify({
-        nodeId: activeNodeId,
-        decision,
-      }));
-    }
-
-    if (decision.kind === 'continue') return;
-
-    if (decision.kind === 'success') {
-      if (decision.taskExecutionStarted && !buildSessionTransitionTaskStartNotifiedRef.current) {
-        buildSessionTransitionTaskStartNotifiedRef.current = true;
-        emitBuildSessionTransitionLog('info', 'task execution started', {
-          tasks: displayTasks.length,
-          queuedOnly: decision.taskExecutionStarted.queuedOnly,
-          hasProgressTaskSignal: decision.taskExecutionStarted.hasProgressTaskSignal,
-        });
-        if (decision.notification) {
-          pushBuildSessionTransitionNotification(decision.notification.level, decision.notification.message);
-        }
-      }
-      finishBuildStartupStep('awaiting-first-task', 'success', {
-        reason: decision.reason,
-        tasks: displayTasks.length,
-        hasProgressTaskSignal,
-      });
-      if (decision.transitionFinish) {
-        finishBuildSessionTransition(decision.transitionFinish);
-      } else {
-        finishBuildSessionTransition();
-      }
-      return;
-    }
-
-    if (decision.kind === 'error') {
-      finishBuildStartupStep('awaiting-first-task', 'error', {
-        reason: decision.reason,
-      });
-      finishBuildSessionTransition(decision.transitionFinish);
-      return;
-    }
-
-    finishBuildStartupStep('awaiting-first-task', 'cancelled', {
-      reason: decision.reason,
-    });
-    finishBuildSessionTransition(decision.transitionFinish);
-  }, [
+  useShapeBuildSessionStartupTrace({
     activeNodeId,
     buildStatus,
-    buildSessionTransition.active,
-    buildSessionTransition.phase,
-    buildSessionTransitionTaskStartNotifiedRef,
-    buildSessionTransition.startedAt,
+    effectiveProgress,
+    resolveTaskType,
+  });
+
+  useShapeBuildSessionStartupProgressTerminalLog({
+    buildStatus,
+    effectiveProgress,
+    runtimeStatus,
+    resolvedTaskType,
+    completedTaskSequenceById,
+    progressTerminalLogKeyRef,
+    emitBuildSessionTransitionLog,
+    buildSessionTransition,
+  });
+
+  useShapeBuildSessionStartupTransitionTimers({
+    buildSessionTransition,
+    setBuildSessionTransitionElapsedMs,
     buildSessionTransitionWarnStepRef,
     buildSessionTransitionWaitLogStepRef,
+    emitBuildSessionTransitionLog,
+    pushBuildSessionTransitionNotification,
+    finishBuildStartupStep,
+    finishBuildSessionTransition,
+  });
+
+  useShapeBuildSessionAwaitingFirstTaskDecision({
+    activeNodeId,
+    buildSessionTransition,
+    buildStatus,
+    displayTasks,
     hasFirstTaskSignal,
-    hasProgressTaskSignal,
     hasStartedTasks,
+    hasProgressTaskSignal,
     isTaskStreamReady,
-    lastAwaitingFirstTaskDecisionTraceKeyRef,
     sessionProgressTotal,
     sessionStageId,
     awaitingFirstTaskExpectationRef,
-    displayTasks.length,
+    lastAwaitingFirstTaskDecisionTraceKeyRef,
+    buildSessionTransitionTaskStartNotifiedRef,
     emitBuildSessionTransitionLog,
+    pushBuildSessionTransitionNotification,
     finishBuildStartupStep,
     finishBuildSessionTransition,
-    pushBuildSessionTransitionNotification,
-  ]);
-
-  useEffect(() => {
-    if (!isShapeProgressStepDebugEnabled()) return;
-    const progressMessage = typeof effectiveProgress?.message === 'string'
-      ? effectiveProgress.message.trim()
-      : '';
-    const progressDisplay = effectiveProgress?.progressTaskDisplay;
-    if (!progressDisplay && !progressMessage) return;
-    if (!buildSessionTransition.active && buildStatus !== 'running' && runtimeStatus !== 'processing') return;
-    const progressTaskId = effectiveProgress?.progressTaskId;
-    const progressTaskSequence = effectiveProgress?.progressTaskSequence;
-    const progressTaskStatus = effectiveProgress?.progressTaskStatus;
-    const progressTaskTitle = typeof effectiveProgress?.progressTaskTitle === 'string'
-      ? effectiveProgress.progressTaskTitle.trim()
-      : '';
-    const canCheckStale = (
-      typeof progressTaskId === 'string'
-      && typeof progressTaskSequence === 'number'
-      && Number.isFinite(progressTaskSequence)
-      && (progressTaskStatus === 'running' || progressTaskStatus === 'queued')
-    );
-    if (canCheckStale) {
-      const completedSequence = completedTaskSequenceById.get(progressTaskId);
-      if (typeof completedSequence === 'number' && completedSequence >= progressTaskSequence) {
-        return;
-      }
-    }
-    const isPhaseMessage = isTaskPhaseDisplay(progressDisplay);
-    const isTerminalUpdate = (
-      progressTaskStatus === 'completed'
-      || ((effectiveProgress?.percentage ?? 0) >= 100 && !isPhaseMessage)
-    );
-    if (!isTerminalUpdate) return;
-    const key = `${progressTaskId ?? ''}:${progressTaskSequence ?? ''}:${progressTaskStatus ?? ''}:`
-      + `${progressDisplay?.kind ?? ''}:${progressDisplay?.key ?? ''}:${progressMessage}`;
-    if (progressTerminalLogKeyRef.current === key) return;
-    progressTerminalLogKeyRef.current = key;
-    emitBuildSessionTransitionLog('info', 'worker progress terminal update', {
-      stage: resolvedTaskType ?? null,
-      message: progressMessage || null,
-      displayKind: progressDisplay?.kind ?? null,
-      displayKey: progressDisplay?.key ?? null,
-      percentage: effectiveProgress?.percentage ?? null,
-      taskId: progressTaskId ?? null,
-      taskTitle: progressTaskTitle || null,
-      taskSequence: progressTaskSequence ?? null,
-      taskStatus: progressTaskStatus ?? null,
-    });
-  }, [
-    buildStatus,
-    runtimeStatus,
-    buildSessionTransition.active,
-    effectiveProgress?.message,
-    effectiveProgress?.percentage,
-    effectiveProgress?.progressTaskDisplay,
-    effectiveProgress?.progressTaskId,
-    effectiveProgress?.progressTaskSequence,
-    effectiveProgress?.progressTaskStatus,
-    effectiveProgress?.progressTaskTitle,
-    completedTaskSequenceById,
-    emitBuildSessionTransitionLog,
-    progressTerminalLogKeyRef,
-    resolvedTaskType,
-  ]);
+  });
 
   return {
     buildSessionTransitionElapsedMs,
+    pollIntervalMs: UI_POLL_INTERVAL_MS,
   };
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle/useShapeBuildSessionAwaitingFirstTaskDecision.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle/useShapeBuildSessionAwaitingFirstTaskDecision.ts
@@ -1,0 +1,315 @@
+import { useEffect } from 'react';
+import {
+  resolveAwaitingFirstTaskDecision,
+  type AwaitingFirstTaskDecision,
+  type AwaitingFirstTaskSuccessDecision,
+} from '~/ui/components/build-progress/resolveAwaitingFirstTaskDecision';
+import type { BuildSessionTransitionNotificationLevel } from '@hierarchidb/components/build-session';
+import type { ShapeBuildTaskSummary } from '~/ui/atoms/shapeBuildProgressAtoms';
+import type {
+  BuildSessionTransitionPhase,
+  BuildStartupStep,
+  BuildStartupStepOutcome,
+} from '../useShapeBuildStepHelpers/startupTrace';
+import type {
+  BuildSessionTransitionState,
+} from '@hierarchidb/components/build-session';
+import type { BuildStatusSource } from '~/ui/components/build-progress/resolveBuildStatusSource';
+
+type UseShapeBuildSessionAwaitingFirstTaskDecisionArgs = {
+  activeNodeId: string | null;
+  buildSessionTransition: BuildSessionTransitionState<BuildSessionTransitionPhase>;
+  buildStatus: BuildStatusSource;
+  displayTasks: ShapeBuildTaskSummary[];
+  hasFirstTaskSignal: boolean;
+  hasStartedTasks: boolean;
+  hasProgressTaskSignal: boolean;
+  isTaskStreamReady: boolean;
+  sessionProgressTotal?: number;
+  sessionStageId: string | null;
+  awaitingFirstTaskExpectationRef: { current: boolean };
+  lastAwaitingFirstTaskDecisionTraceKeyRef: { current: string | null };
+  buildSessionTransitionTaskStartNotifiedRef: { current: boolean };
+  emitBuildSessionTransitionLog: (
+    level: 'info' | 'warn' | 'error',
+    message: string,
+    payload?: Record<string, unknown>,
+  ) => void;
+  pushBuildSessionTransitionNotification: (
+    level: BuildSessionTransitionNotificationLevel,
+    message: string,
+  ) => void;
+  finishBuildStartupStep: (
+    step: BuildStartupStep,
+    outcome: BuildStartupStepOutcome,
+    extra?: Record<string, unknown>,
+  ) => void;
+  finishBuildSessionTransition: (options?: {
+    message?: string;
+    level?: BuildSessionTransitionNotificationLevel;
+  }) => void;
+};
+
+type SuccessDecision = AwaitingFirstTaskSuccessDecision;
+type ErrorDecision = Extract<AwaitingFirstTaskDecision, { kind: 'error' }>;
+type CancelledDecision = Extract<AwaitingFirstTaskDecision, { kind: 'cancelled' }>;
+
+const resolveDecisionInput = ({
+  hasFirstTaskSignal,
+  hasStartedTasks,
+  hasProgressTaskSignal,
+  buildStatus,
+  isTaskStreamReady,
+  awaitingFirstTaskExpectationRef,
+  sessionProgressTotal,
+  sessionStageId,
+  displayTasks,
+}: {
+  hasFirstTaskSignal: boolean;
+  hasStartedTasks: boolean;
+  hasProgressTaskSignal: boolean;
+  buildStatus: BuildStatusSource;
+  isTaskStreamReady: boolean;
+  awaitingFirstTaskExpectationRef: { current: boolean };
+  sessionProgressTotal?: number;
+  sessionStageId: string | null;
+  displayTasks: ShapeBuildTaskSummary[];
+}): Parameters<typeof resolveAwaitingFirstTaskDecision>[0] => ({
+  hasFirstTaskSignal,
+  hasStartedTasks,
+  hasProgressTaskSignal,
+  buildStatus,
+  taskCount: isTaskStreamReady ? displayTasks.length : undefined,
+  isTaskStreamReady,
+  expectTaskGeneration: awaitingFirstTaskExpectationRef.current,
+  sessionProgressTotal,
+  sessionStageId,
+});
+
+const createDecisionTraceKey = (input: {
+  phase: BuildSessionTransitionPhase;
+  buildStatus: BuildStatusSource;
+  hasFirstTaskSignal: boolean;
+  hasStartedTasks: boolean;
+  hasProgressTaskSignal: boolean;
+  taskCount: number | undefined;
+  isTaskStreamReady: boolean;
+  expectTaskGeneration: boolean;
+  sessionProgressTotal: number | undefined;
+  sessionStageId: string | null;
+}): string | null => {
+  if (!import.meta.env.DEV) return null;
+  return JSON.stringify({
+    phase: input.phase,
+    buildStatus: input.buildStatus,
+    hasFirstTaskSignal: input.hasFirstTaskSignal,
+    hasStartedTasks: input.hasStartedTasks,
+    hasProgressTaskSignal: input.hasProgressTaskSignal,
+    taskCount: input.taskCount,
+    isTaskStreamReady: input.isTaskStreamReady,
+    expectTaskGeneration: input.expectTaskGeneration,
+    sessionProgressTotal: input.sessionProgressTotal ?? null,
+    sessionStageId: input.sessionStageId ?? null,
+  });
+};
+
+const handleDecisionSuccess = ({
+  decision,
+  displayTasks,
+  hasProgressTaskSignal,
+  activeNodeId,
+  buildSessionTransitionTaskStartNotifiedRef,
+  emitBuildSessionTransitionLog,
+  pushBuildSessionTransitionNotification,
+  finishBuildStartupStep,
+  finishBuildSessionTransition,
+}: {
+  decision: SuccessDecision;
+  displayTasks: ShapeBuildTaskSummary[];
+  hasProgressTaskSignal: boolean;
+  activeNodeId: string | null;
+  buildSessionTransitionTaskStartNotifiedRef: { current: boolean };
+  emitBuildSessionTransitionLog: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs['emitBuildSessionTransitionLog'];
+  pushBuildSessionTransitionNotification: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs['pushBuildSessionTransitionNotification'];
+  finishBuildStartupStep: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs['finishBuildStartupStep'];
+  finishBuildSessionTransition: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs['finishBuildSessionTransition'];
+}): void => {
+  if (!buildSessionTransitionTaskStartNotifiedRef.current) {
+    buildSessionTransitionTaskStartNotifiedRef.current = true;
+    emitBuildSessionTransitionLog('info', 'task execution started', {
+      tasks: displayTasks.length,
+      queuedOnly: decision.taskExecutionStarted.queuedOnly,
+      hasProgressTaskSignal: decision.taskExecutionStarted.hasProgressTaskSignal,
+    });
+    pushBuildSessionTransitionNotification(
+      decision.notification.level,
+      decision.notification.message,
+    );
+  }
+  finishBuildStartupStep('awaiting-first-task', 'success', {
+    reason: decision.reason,
+    tasks: displayTasks.length,
+    hasProgressTaskSignal,
+  });
+  if (decision.transitionFinish) {
+    finishBuildSessionTransition(decision.transitionFinish);
+  } else {
+    finishBuildSessionTransition();
+  }
+  if (import.meta.env.DEV) {
+    console.log(
+      '[ShapeAwaitingFirstTaskDecisionTrace] decision',
+      JSON.stringify({
+        nodeId: activeNodeId,
+        decision,
+      }),
+    );
+  }
+};
+
+const handleDecisionFailure = ({
+  decision,
+  finishBuildStartupStep,
+  finishBuildSessionTransition,
+}: {
+  decision: ErrorDecision;
+  finishBuildStartupStep: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs['finishBuildStartupStep'];
+  finishBuildSessionTransition: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs['finishBuildSessionTransition'];
+}): void => {
+  finishBuildStartupStep('awaiting-first-task', 'error', {
+    reason: decision.reason,
+  });
+  finishBuildSessionTransition(decision.transitionFinish);
+};
+
+const handleDecisionCancelled = ({
+  decision,
+  finishBuildStartupStep,
+  finishBuildSessionTransition,
+}: {
+  decision: CancelledDecision;
+  finishBuildStartupStep: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs['finishBuildStartupStep'];
+  finishBuildSessionTransition: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs['finishBuildSessionTransition'];
+}): void => {
+  finishBuildStartupStep('awaiting-first-task', 'cancelled', {
+    reason: decision.reason,
+  });
+  finishBuildSessionTransition(decision.transitionFinish);
+};
+
+export const useShapeBuildSessionAwaitingFirstTaskDecision = ({
+  activeNodeId,
+  buildSessionTransition,
+  buildStatus,
+  displayTasks,
+  hasFirstTaskSignal,
+  hasStartedTasks,
+  hasProgressTaskSignal,
+  isTaskStreamReady,
+  sessionProgressTotal,
+  sessionStageId,
+  awaitingFirstTaskExpectationRef,
+  lastAwaitingFirstTaskDecisionTraceKeyRef,
+  buildSessionTransitionTaskStartNotifiedRef,
+  emitBuildSessionTransitionLog,
+  pushBuildSessionTransitionNotification,
+  finishBuildStartupStep,
+  finishBuildSessionTransition,
+}: UseShapeBuildSessionAwaitingFirstTaskDecisionArgs): void => {
+  useEffect(() => {
+    if (!buildSessionTransition.active) return;
+    if (buildSessionTransition.phase !== 'awaiting-first-task') return;
+
+    const decisionInput = resolveDecisionInput({
+      hasFirstTaskSignal,
+      hasStartedTasks,
+      hasProgressTaskSignal,
+      buildStatus,
+      isTaskStreamReady,
+      awaitingFirstTaskExpectationRef,
+      sessionProgressTotal,
+      sessionStageId,
+      displayTasks,
+    });
+    const decisionTraceKey = createDecisionTraceKey({
+      phase: buildSessionTransition.phase,
+      buildStatus,
+      hasFirstTaskSignal: decisionInput.hasFirstTaskSignal,
+      hasStartedTasks: decisionInput.hasStartedTasks,
+      hasProgressTaskSignal: decisionInput.hasProgressTaskSignal,
+      taskCount: decisionInput.taskCount,
+      isTaskStreamReady: decisionInput.isTaskStreamReady,
+      expectTaskGeneration: decisionInput.expectTaskGeneration,
+      sessionProgressTotal: decisionInput.sessionProgressTotal,
+      sessionStageId,
+    });
+    if (decisionTraceKey && lastAwaitingFirstTaskDecisionTraceKeyRef.current !== decisionTraceKey) {
+      lastAwaitingFirstTaskDecisionTraceKeyRef.current = decisionTraceKey;
+      console.log('[ShapeAwaitingFirstTaskDecisionTrace] input', JSON.stringify({
+        nodeId: activeNodeId,
+        ...decisionInput,
+      }));
+    }
+
+    const decision = resolveAwaitingFirstTaskDecision(decisionInput);
+    if (import.meta.env.DEV && decision.kind !== 'continue') {
+      console.log('[ShapeAwaitingFirstTaskDecisionTrace] decision', JSON.stringify({
+        nodeId: activeNodeId,
+        decision,
+      }));
+    }
+    if (decision.kind === 'continue') return;
+    switch (decision.kind) {
+    case 'success': {
+      handleDecisionSuccess({
+        decision,
+        displayTasks,
+        hasProgressTaskSignal,
+        activeNodeId,
+        buildSessionTransitionTaskStartNotifiedRef,
+        emitBuildSessionTransitionLog,
+        pushBuildSessionTransitionNotification,
+        finishBuildStartupStep,
+        finishBuildSessionTransition,
+      });
+      return;
+    }
+    case 'error': {
+      handleDecisionFailure({
+        decision,
+        finishBuildStartupStep,
+        finishBuildSessionTransition,
+      });
+      return;
+    }
+    case 'cancelled': {
+      handleDecisionCancelled({
+        decision,
+        finishBuildStartupStep,
+        finishBuildSessionTransition,
+      });
+      return;
+    }
+      default:
+        return;
+    }
+  }, [
+    activeNodeId,
+    buildSessionTransition,
+    buildStatus,
+    displayTasks.length,
+    hasFirstTaskSignal,
+    hasProgressTaskSignal,
+    hasStartedTasks,
+    isTaskStreamReady,
+    sessionProgressTotal,
+    sessionStageId,
+    awaitingFirstTaskExpectationRef,
+    lastAwaitingFirstTaskDecisionTraceKeyRef,
+    buildSessionTransitionTaskStartNotifiedRef,
+    emitBuildSessionTransitionLog,
+    pushBuildSessionTransitionNotification,
+    finishBuildStartupStep,
+    finishBuildSessionTransition,
+  ]);
+};

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupProgressTerminalLog.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupProgressTerminalLog.ts
@@ -1,0 +1,115 @@
+import { useEffect } from 'react';
+import { isTaskPhaseDisplay } from '~/common/utils/taskMessages';
+import type { BuildProgress } from '~/ui/components/build-progress/shapeBuildProgressMapping';
+import type { BuildSessionTransitionState } from '@hierarchidb/components/build-session';
+import type { BuildSessionTransitionPhase } from '../useShapeBuildStepHelpers/startupTrace';
+import type { BuildProgressStatus } from '~/ui/components/build-progress/shapeBuildProgressMapping';
+
+type UseShapeBuildSessionStartupProgressTerminalLogArgs = {
+  buildStatus: BuildProgressStatus['status'];
+  effectiveProgress: BuildProgress | null;
+  runtimeStatus: BuildProgressStatus['status'];
+  resolvedTaskType: string | undefined;
+  completedTaskSequenceById: Map<string, number>;
+  progressTerminalLogKeyRef: { current: string | null };
+  emitBuildSessionTransitionLog: (
+    level: 'info' | 'warn' | 'error',
+    message: string,
+    payload?: Record<string, unknown>,
+  ) => void;
+  buildSessionTransition: BuildSessionTransitionState<BuildSessionTransitionPhase>;
+};
+
+const shouldSkipStaleUpdate = (
+  progressTaskId: string | undefined,
+  progressTaskSequence: number | undefined,
+  progressTaskStatus: string | null | undefined,
+  completedTaskSequenceById: Map<string, number>,
+): boolean => {
+  if (!(
+    typeof progressTaskId === 'string'
+    && typeof progressTaskSequence === 'number'
+    && Number.isFinite(progressTaskSequence)
+    && (progressTaskStatus === 'running' || progressTaskStatus === 'queued')
+  )) {
+    return false;
+  }
+  const completedSequence = completedTaskSequenceById.get(progressTaskId);
+  return typeof completedSequence === 'number' && completedSequence >= progressTaskSequence;
+};
+
+export const useShapeBuildSessionStartupProgressTerminalLog = ({
+  buildStatus,
+  effectiveProgress,
+  runtimeStatus,
+  resolvedTaskType,
+  completedTaskSequenceById,
+  progressTerminalLogKeyRef,
+  emitBuildSessionTransitionLog,
+  buildSessionTransition,
+}: UseShapeBuildSessionStartupProgressTerminalLogArgs): void => {
+  useEffect(() => {
+    const progressMessage = typeof effectiveProgress?.message === 'string'
+      ? effectiveProgress.message.trim()
+      : '';
+    const progressDisplay = effectiveProgress?.progressTaskDisplay;
+    if (!progressDisplay && !progressMessage) return;
+    if (
+      !buildSessionTransition.active
+      && buildStatus !== 'processing'
+      && runtimeStatus !== 'processing'
+    ) return;
+
+    const progressTaskId = effectiveProgress?.progressTaskId;
+    const progressTaskSequence = effectiveProgress?.progressTaskSequence;
+    const progressTaskStatus = effectiveProgress?.progressTaskStatus;
+    const progressTaskTitle = typeof effectiveProgress?.progressTaskTitle === 'string'
+      ? effectiveProgress.progressTaskTitle.trim()
+      : '';
+
+    const isTerminalUpdate = (
+      progressTaskStatus === 'completed'
+      || ((effectiveProgress?.percentage ?? 0) >= 100 && !isTaskPhaseDisplay(progressDisplay))
+    );
+    if (!isTerminalUpdate) return;
+
+    const isStale = shouldSkipStaleUpdate(
+      progressTaskId,
+      progressTaskSequence,
+      progressTaskStatus,
+      completedTaskSequenceById,
+    );
+    if (isStale) return;
+
+    const key = `${progressTaskId ?? ''}:${progressTaskSequence ?? ''}:${progressTaskStatus ?? ''}:${progressDisplay?.kind ?? ''}:${progressDisplay?.key ?? ''}:${progressMessage}`;
+    if (progressTerminalLogKeyRef.current === key) return;
+    progressTerminalLogKeyRef.current = key;
+    emitBuildSessionTransitionLog('info', 'worker progress terminal update', {
+      stage: resolvedTaskType ?? null,
+      message: progressMessage || null,
+      displayKind: progressDisplay?.kind ?? null,
+      displayKey: progressDisplay?.key ?? null,
+      percentage: effectiveProgress?.percentage ?? null,
+      taskId: progressTaskId ?? null,
+      taskTitle: progressTaskTitle || null,
+      taskSequence: progressTaskSequence ?? null,
+      taskStatus: progressTaskStatus ?? null,
+    });
+  }, [
+    buildStatus,
+    runtimeStatus,
+    buildSessionTransition.active,
+    effectiveProgress?.message,
+    effectiveProgress?.percentage,
+    effectiveProgress?.progressTaskDisplay,
+    effectiveProgress?.progressTaskId,
+    effectiveProgress?.progressTaskSequence,
+    effectiveProgress?.progressTaskStatus,
+    effectiveProgress?.progressTaskTitle,
+    completedTaskSequenceById,
+    emitBuildSessionTransitionLog,
+    progressTerminalLogKeyRef,
+    resolvedTaskType,
+    buildSessionTransition,
+  ]);
+};

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupTrace.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupTrace.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { emitShapeProgressStepTrace, isShapeProgressStepDebugEnabled } from '../useShapeBuildStepHelpers/debug';
+import type { ShapeProgressStepTracePayload } from '../useShapeBuildStepHelpers/startupTrace';
+import type { BuildProgress } from '~/ui/components/build-progress/shapeBuildProgressMapping';
+import type { BuildStatusSource } from '~/ui/components/build-progress/resolveBuildStatusSource';
+
+type UseShapeBuildSessionStartupTraceArgs = {
+  activeNodeId: string | null;
+  buildStatus: BuildStatusSource;
+  effectiveProgress: BuildProgress | null;
+  resolveTaskType: string | null;
+};
+
+export const useShapeBuildSessionStartupTrace = ({
+  activeNodeId,
+  buildStatus,
+  effectiveProgress,
+  resolveTaskType,
+}: UseShapeBuildSessionStartupTraceArgs): void => {
+  useEffect(() => {
+    if (!isShapeProgressStepDebugEnabled()) return;
+    const nextTrace: ShapeProgressStepTracePayload = {
+      nodeId: activeNodeId,
+      phase: buildStatus,
+      progressTaskId: effectiveProgress?.progressTaskId ?? null,
+      progressTaskStatus: effectiveProgress?.progressTaskStatus ?? null,
+      progressTaskStage: resolveTaskType,
+      progressTaskProgress: effectiveProgress?.progressTaskProgress ?? null,
+      percentage: effectiveProgress?.percentage ?? null,
+      total: effectiveProgress?.total ?? 0,
+      completed: effectiveProgress?.completed ?? 0,
+      failed: effectiveProgress?.failed ?? 0,
+      skipped: effectiveProgress?.skipped ?? 0,
+      message: effectiveProgress?.message ?? null,
+    };
+    emitShapeProgressStepTrace(nextTrace);
+  }, [activeNodeId, buildStatus, effectiveProgress, resolveTaskType]);
+};

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupTransitionTimers.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle/useShapeBuildSessionStartupTransitionTimers.ts
@@ -1,0 +1,193 @@
+import { useEffect } from 'react';
+import { resolveStartupTransitionWatchdogEvent } from '../../resolveStartupTransitionWatchdogEvent';
+import { UI_POLL_INTERVAL_MS } from '../useShapeBuildStepHelpers/constants';
+import type {
+  BuildSessionTransitionNotificationLevel,
+  BuildSessionTransitionState,
+} from '@hierarchidb/components/build-session';
+import type {
+  BuildSessionTransitionPhase,
+  BuildStartupStep,
+  BuildStartupStepOutcome,
+} from '../useShapeBuildStepHelpers/startupTrace';
+
+type UseShapeBuildSessionStartupTransitionTimersArgs = {
+  buildSessionTransition: BuildSessionTransitionState<BuildSessionTransitionPhase>;
+  setBuildSessionTransitionElapsedMs: (value: number) => void;
+  buildSessionTransitionWarnStepRef: { current: 0 | 1 | 2 | 3 };
+  buildSessionTransitionWaitLogStepRef: { current: number };
+  emitBuildSessionTransitionLog: (
+    level: 'info' | 'warn' | 'error',
+    message: string,
+    payload?: Record<string, unknown>,
+  ) => void;
+  pushBuildSessionTransitionNotification: (
+    level: BuildSessionTransitionNotificationLevel,
+    message: string,
+  ) => void;
+  finishBuildStartupStep: (
+    step: BuildStartupStep,
+    outcome: BuildStartupStepOutcome,
+    extra?: Record<string, unknown>,
+  ) => void;
+  finishBuildSessionTransition: (options?: {
+    message?: string;
+    level?: BuildSessionTransitionNotificationLevel;
+  }) => void;
+};
+
+const handleTimeout = (
+  elapsedMs: number,
+  phase: BuildSessionTransitionPhase,
+  finishBuildStartupStep: UseShapeBuildSessionStartupTransitionTimersArgs['finishBuildStartupStep'],
+  finishBuildSessionTransition: UseShapeBuildSessionStartupTransitionTimersArgs['finishBuildSessionTransition'],
+  emitBuildSessionTransitionLog: UseShapeBuildSessionStartupTransitionTimersArgs['emitBuildSessionTransitionLog'],
+): void => {
+  emitBuildSessionTransitionLog('error', 'build session transition timeout', {
+    phase,
+    elapsedMs,
+  });
+  if (phase === 'awaiting-first-task') {
+    finishBuildStartupStep('awaiting-first-task', 'error', {
+      reason: 'timeout-before-task-start',
+      elapsedMs,
+    });
+  }
+  finishBuildSessionTransition({
+    level: 'error',
+    message: `Build did not start task processing (${phase}, ${Math.round(elapsedMs / 1000)}s).`,
+  });
+};
+
+const handleLongWait = (
+  elapsedMs: number,
+  phase: BuildSessionTransitionPhase,
+  emitBuildSessionTransitionLog: UseShapeBuildSessionStartupTransitionTimersArgs['emitBuildSessionTransitionLog'],
+  pushBuildSessionTransitionNotification: UseShapeBuildSessionStartupTransitionTimersArgs['pushBuildSessionTransitionNotification'],
+): void => {
+  emitBuildSessionTransitionLog('warn', 'build session transition long wait', {
+    phase,
+    elapsedMs,
+  });
+  pushBuildSessionTransitionNotification(
+    'warning',
+    `Build start is still waiting at \"${phase}\".`,
+  );
+};
+
+const handleWait = (
+  elapsedMs: number,
+  phase: BuildSessionTransitionPhase,
+  emitBuildSessionTransitionLog: UseShapeBuildSessionStartupTransitionTimersArgs['emitBuildSessionTransitionLog'],
+  pushBuildSessionTransitionNotification: UseShapeBuildSessionStartupTransitionTimersArgs['pushBuildSessionTransitionNotification'],
+): void => {
+  emitBuildSessionTransitionLog('info', 'build session transition wait', {
+    phase,
+    elapsedMs,
+  });
+  pushBuildSessionTransitionNotification(
+    'info',
+    `Build start is taking longer than expected (${phase}).`,
+  );
+};
+
+export const useShapeBuildSessionStartupTransitionTimers = ({
+  buildSessionTransition,
+  setBuildSessionTransitionElapsedMs,
+  buildSessionTransitionWarnStepRef,
+  buildSessionTransitionWaitLogStepRef,
+  emitBuildSessionTransitionLog,
+  pushBuildSessionTransitionNotification,
+  finishBuildStartupStep,
+  finishBuildSessionTransition,
+}: UseShapeBuildSessionStartupTransitionTimersArgs): void => {
+  useEffect(() => {
+    const phase = buildSessionTransition.phase;
+    if (phase === 'idle') {
+      setBuildSessionTransitionElapsedMs(0);
+      return;
+    }
+    if (!buildSessionTransition.active) {
+      setBuildSessionTransitionElapsedMs(0);
+      return;
+    }
+    const intervalId = window.setInterval(() => {
+      const elapsedMs = Date.now() - buildSessionTransition.startedAt;
+      setBuildSessionTransitionElapsedMs(elapsedMs);
+      const watchdogEvent = resolveStartupTransitionWatchdogEvent({
+        elapsedMs,
+        warnStep: buildSessionTransitionWarnStepRef.current,
+      });
+      if (watchdogEvent.kind === 'none') return;
+      buildSessionTransitionWarnStepRef.current = watchdogEvent.nextWarnStep;
+      if (watchdogEvent.kind === 'timeout') {
+        handleTimeout(
+          elapsedMs,
+          phase,
+          finishBuildStartupStep,
+          finishBuildSessionTransition,
+          emitBuildSessionTransitionLog,
+        );
+        return;
+      }
+      if (watchdogEvent.kind === 'long-wait') {
+        handleLongWait(
+          elapsedMs,
+          phase,
+          emitBuildSessionTransitionLog,
+          pushBuildSessionTransitionNotification,
+        );
+        return;
+      }
+      handleWait(
+        elapsedMs,
+        phase,
+        emitBuildSessionTransitionLog,
+        pushBuildSessionTransitionNotification,
+      );
+    }, 1000);
+    setBuildSessionTransitionElapsedMs(Math.max(0, Date.now() - buildSessionTransition.startedAt));
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [
+    buildSessionTransition.active,
+    buildSessionTransition.phase,
+    buildSessionTransition.startedAt,
+    buildSessionTransitionWarnStepRef,
+    emitBuildSessionTransitionLog,
+    finishBuildStartupStep,
+    finishBuildSessionTransition,
+    pushBuildSessionTransitionNotification,
+    setBuildSessionTransitionElapsedMs,
+  ]);
+
+  useEffect(() => {
+    if (!buildSessionTransition.active || buildSessionTransition.phase !== 'waiting-lock') {
+      buildSessionTransitionWaitLogStepRef.current = -1;
+      return;
+    }
+    const tick = () => {
+      const elapsedMs = Date.now() - buildSessionTransition.startedAt;
+      const nextStep = Math.floor(elapsedMs / UI_POLL_INTERVAL_MS);
+      if (nextStep <= buildSessionTransitionWaitLogStepRef.current) return;
+      buildSessionTransitionWaitLogStepRef.current = nextStep;
+      emitBuildSessionTransitionLog('info', 'build session waiting for lock', {
+        phase: buildSessionTransition.phase,
+        elapsedMs,
+        pollIntervalMs: UI_POLL_INTERVAL_MS,
+      });
+    };
+    tick();
+    const intervalId = window.setInterval(tick, UI_POLL_INTERVAL_MS);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [
+    buildSessionTransition.active,
+    buildSessionTransition.phase,
+    buildSessionTransition.startedAt,
+    buildSessionTransitionWaitLogStepRef,
+    emitBuildSessionTransitionLog,
+  ]);
+};

--- a/plugins/shape-plugin/src/ui/components/build-progress/resolveAwaitingFirstTaskDecision.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/resolveAwaitingFirstTaskDecision.ts
@@ -1,4 +1,4 @@
-import type { BuildStatus } from '@hierarchidb/components/build-status';
+import type { BuildStatusSource } from '~/ui/components/build-progress/resolveBuildStatusSource';
 import type { BuildSessionTransitionNotificationLevel } from '@hierarchidb/components/build-session';
 
 type Notification = {
@@ -26,8 +26,8 @@ export type AwaitingFirstTaskDecision =
       | 'completed-without-generating-tasks'
       | 'completed-before-first-task-update'
       | 'completed-with-session-progress-evidence';
-    taskExecutionStarted?: TaskExecutionStarted;
-    notification?: Notification;
+    taskExecutionStarted: TaskExecutionStarted;
+    notification: Notification;
     transitionFinish?: TransitionFinish;
   }
   | {
@@ -41,11 +41,16 @@ export type AwaitingFirstTaskDecision =
     transitionFinish: TransitionFinish;
   };
 
+export type AwaitingFirstTaskSuccessDecision = Extract<
+  AwaitingFirstTaskDecision,
+  { kind: 'success' }
+>;
+
 export type AwaitingFirstTaskDecisionInput = {
   hasFirstTaskSignal: boolean;
   hasStartedTasks: boolean;
   hasProgressTaskSignal: boolean;
-  buildStatus: BuildStatus;
+  buildStatus: BuildStatusSource;
   taskCount: number | undefined;
   isTaskStreamReady: boolean;
   expectTaskGeneration: boolean;
@@ -103,6 +108,14 @@ export const resolveAwaitingFirstTaskDecision = (
         return {
           kind: 'success',
           reason: 'completed-with-session-progress-evidence',
+          taskExecutionStarted: {
+            queuedOnly: false,
+            hasProgressTaskSignal: input.hasProgressTaskSignal,
+          },
+          notification: {
+            level: 'info',
+            message: 'Build completed before task stream synchronization.',
+          },
           transitionFinish: {
             level: 'info',
             message: 'Build completed before task stream synchronization.',
@@ -116,6 +129,14 @@ export const resolveAwaitingFirstTaskDecision = (
         return {
           kind: 'success',
           reason: 'completed-with-session-progress-evidence',
+          taskExecutionStarted: {
+            queuedOnly: false,
+            hasProgressTaskSignal: input.hasProgressTaskSignal,
+          },
+          notification: {
+            level: 'info',
+            message: 'Build completed before task stream synchronization.',
+          },
           transitionFinish: {
             level: 'info',
             message: 'Build completed before task stream synchronization.',
@@ -130,6 +151,14 @@ export const resolveAwaitingFirstTaskDecision = (
         return {
           kind: 'success',
           reason: 'completed-with-session-progress-evidence',
+          taskExecutionStarted: {
+            queuedOnly: false,
+            hasProgressTaskSignal: input.hasProgressTaskSignal,
+          },
+          notification: {
+            level: 'info',
+            message: 'Build completed before task stream synchronization.',
+          },
           transitionFinish: {
             level: 'info',
             message: 'Build completed before task stream synchronization.',
@@ -143,6 +172,16 @@ export const resolveAwaitingFirstTaskDecision = (
       reason: completedWithoutTasks
         ? 'completed-without-generating-tasks'
         : 'completed-before-first-task-update',
+      taskExecutionStarted: {
+        queuedOnly: false,
+        hasProgressTaskSignal: input.hasProgressTaskSignal,
+      },
+      notification: {
+        level: 'info',
+        message: completedWithoutTasks
+          ? 'Build completed without generating tasks.'
+          : 'Build completed before first task update.',
+      },
       transitionFinish: completedWithoutTasks
         ? {
           level: 'info',

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.debug.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.debug.ts
@@ -100,11 +100,14 @@ export const logTaskUpdate100 = (task: ShapeBuildTaskSummary): void => {
     return;
   }
   taskUpdate100LogCount += 1;
-  const messageParts = [
-    `[TaskUpdate100] ${task.taskId}`,
-    `status=${task.status}`,
-    `stage=${task.stage}`,
-    `progress=${task.progress ?? 0}`,
-  ];
-  console.log(messageParts.join(' '));
+
+  const taskIdParts = task.taskId.split(':');
+  const countryIndex = taskIdParts.length >= 4 ? taskIdParts[2] : taskIdParts[1];
+  const indexValue = taskIdParts.length >= 4 ? taskIdParts[3] : taskIdParts[2];
+  const resolvedCountry = countryIndex || 'unknown';
+  const resolvedIndex = typeof indexValue === 'string' && indexValue.length > 0 ? indexValue : '0';
+  const message = task.message ?? task.status;
+  console.log(
+    `[TaskUpdate100] ${resolvedCountry}, ${resolvedIndex}, ${message}, ${task.status}`,
+  );
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.handlers.events.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.handlers.events.ts
@@ -9,6 +9,19 @@ import {
   shouldPreferNextTask,
 } from './useShapeBuildTaskSync.comparison.utils.js';
 
+const normalizeTaskSnapshot = (tasks: unknown): RawTaskSummary[] => {
+  if (!Array.isArray(tasks)) {
+    return [];
+  }
+  const snapshot: RawTaskSummary[] = [];
+  for (const task of tasks) {
+    if (task && typeof task === 'object') {
+      snapshot.push(task as RawTaskSummary);
+    }
+  }
+  return snapshot;
+};
+
 type EventHandlerRefs = {
   tasksMapRef: MutableRefObject<Map<string, ShapeBuildTaskSummary>>;
   completedTasksRef: MutableRefObject<Map<string, ShapeBuildTaskSummary>>;
@@ -45,20 +58,35 @@ export const useShapeBuildTaskSyncEventHandlers = ({
   setError,
   markTaskStreamSynchronized,
 }: EventHandlerDeps) => {
+  const {
+    tasksMapRef,
+    completedTasksRef,
+    errorRef,
+    isLoadingRef,
+    bufferedSnapshotRef,
+    bufferedUpdatesRef,
+    bufferedSequenceRef,
+    pendingTasksRef,
+    committedTasksRef,
+    committedSequenceRef,
+    isMountedRef,
+    sessionNodeId,
+  } = refs;
+
   const handleSnapshot = useCallback((next: RawTaskSummary[]) => {
-    const snapshotTasks = next.map(resolveTaskSummary);
-    refs.bufferedSnapshotRef.current = snapshotTasks;
+    const snapshotTasks = normalizeTaskSnapshot(next).map(resolveTaskSummary);
+    bufferedSnapshotRef.current = snapshotTasks;
     scheduleBufferedFlush();
-    if (refs.errorRef.current !== null) {
+    if (errorRef.current !== null) {
       setError(null);
     }
-    if (refs.isLoadingRef.current) {
+    if (isLoadingRef.current) {
       setIsLoading(false);
     }
   }, [
-    refs.bufferedSnapshotRef,
-    refs.errorRef,
-    refs.isLoadingRef,
+    bufferedSnapshotRef,
+    errorRef,
+    isLoadingRef,
     resolveTaskSummary,
     scheduleBufferedFlush,
     setError,
@@ -67,12 +95,12 @@ export const useShapeBuildTaskSyncEventHandlers = ({
 
   const handleUpdate = useCallback((task: RawTaskSummary) => {
     const resolved = resolveTaskSummary(task);
-    const previous = refs.tasksMapRef.current.get(resolved.taskId);
+    const previous = tasksMapRef.current.get(resolved.taskId);
     const isEquivalent = previous ? areTasksEquivalentForView(previous, resolved) : false;
     const shouldPrefer = previous ? shouldPreferNextTask(previous, resolved) : true;
     if (previous && (isEquivalent || !shouldPrefer)) {
       emitRunningResidueLog('STALE_DROP', {
-        nodeId: refs.sessionNodeId,
+        nodeId: sessionNodeId,
         stage: resolved.stage,
         taskId: resolved.taskId,
         sequence: resolved.sequence ?? null,
@@ -86,7 +114,7 @@ export const useShapeBuildTaskSyncEventHandlers = ({
     }
     if (previous && previous.status !== resolved.status) {
       emitRunningResidueLog('STATUS_TRANSITION', {
-        nodeId: refs.sessionNodeId,
+        nodeId: sessionNodeId,
         stage: resolved.stage,
         taskId: resolved.taskId,
         sequence: resolved.sequence ?? null,
@@ -99,30 +127,34 @@ export const useShapeBuildTaskSyncEventHandlers = ({
     bufferTaskUpdate(resolved);
     scheduleBufferedFlush();
     logTaskUpdate100(resolved);
-    if (refs.errorRef.current !== null) {
+    if (errorRef.current !== null) {
       setError(null);
     }
-    if (refs.isLoadingRef.current) {
+    if (isLoadingRef.current) {
       setIsLoading(false);
     }
-    if (refs.sessionNodeId && markTaskStreamSynchronized) {
+    if (sessionNodeId && markTaskStreamSynchronized) {
       markTaskStreamSynchronized();
     }
   }, [
-    refs,
+    completedTasksRef,
+    tasksMapRef,
+    errorRef,
+    isLoadingRef,
     resolveTaskSummary,
     bufferTaskUpdate,
     scheduleBufferedFlush,
+    sessionNodeId,
     setError,
     setIsLoading,
     markTaskStreamSynchronized,
   ]);
 
   const handleDelete = useCallback((taskId: string) => {
-    const existing = refs.tasksMapRef.current.get(taskId);
+    const existing = tasksMapRef.current.get(taskId);
     if (!existing) {
       emitRunningResidueLog('STALE_DROP', {
-        nodeId: refs.sessionNodeId,
+        nodeId: sessionNodeId,
         stage: null,
         taskId,
         sequence: null,
@@ -135,7 +167,7 @@ export const useShapeBuildTaskSyncEventHandlers = ({
       return;
     }
     emitRunningResidueLog('STATUS_TRANSITION', {
-      nodeId: refs.sessionNodeId,
+      nodeId: sessionNodeId,
       source: 'event',
       eventType: 'delete',
       taskId,
@@ -144,39 +176,56 @@ export const useShapeBuildTaskSyncEventHandlers = ({
       prevStatus: existing.status ?? null,
       nextStatus: 'deleted',
     });
-    const nextMap = new Map(refs.tasksMapRef.current);
+
+    const nextMap = new Map(tasksMapRef.current);
     nextMap.delete(taskId);
-    refs.tasksMapRef.current = nextMap;
-    const nextCompletedMap = new Map(refs.completedTasksRef.current);
+    tasksMapRef.current = nextMap;
+
+    const nextCompletedMap = new Map(completedTasksRef.current);
     nextCompletedMap.delete(taskId);
-    refs.completedTasksRef.current = nextCompletedMap;
-    const nextCommittedSequences = new Map(refs.committedSequenceRef.current);
+    completedTasksRef.current = nextCompletedMap;
+
+    const nextCommittedSequences = new Map(committedSequenceRef.current);
     nextCommittedSequences.delete(taskId);
-    refs.committedSequenceRef.current = nextCommittedSequences;
-    refs.bufferedUpdatesRef.current.delete(taskId);
-    refs.bufferedSequenceRef.current.delete(taskId);
-    if (refs.bufferedSnapshotRef.current) {
-      refs.bufferedSnapshotRef.current = refs.bufferedSnapshotRef.current.filter((task) => task.taskId !== taskId);
+    committedSequenceRef.current = nextCommittedSequences;
+
+    bufferedUpdatesRef.current.delete(taskId);
+    bufferedSequenceRef.current.delete(taskId);
+    if (bufferedSnapshotRef.current) {
+      bufferedSnapshotRef.current = bufferedSnapshotRef.current.filter((item) => item.taskId !== taskId);
     }
+
     if (isCompletedAtFullProgress(existing)) {
-      refs.completedTasksRef.current.delete(taskId);
+      completedTasksRef.current.delete(taskId);
     }
-    const current = refs.pendingTasksRef.current ?? refs.committedTasksRef.current;
-    const next = current.filter((task) => task.taskId !== taskId);
-    if (refs.isMountedRef.current) {
+
+    const current = pendingTasksRef.current ?? committedTasksRef.current;
+    const next = current.filter((item) => item.taskId !== taskId);
+    if (isMountedRef.current) {
       setTasks(next);
     }
-    if (refs.errorRef.current !== null) {
+    if (errorRef.current !== null) {
       setError(null);
     }
-    if (refs.isLoadingRef.current) {
+    if (isLoadingRef.current) {
       setIsLoading(false);
     }
     if (markTaskStreamSynchronized) {
       markTaskStreamSynchronized();
     }
   }, [
-    refs,
+    completedTasksRef,
+    errorRef,
+    bufferedSnapshotRef,
+    bufferedUpdatesRef,
+    bufferedSequenceRef,
+    committedSequenceRef,
+    isMountedRef,
+    isLoadingRef,
+    pendingTasksRef,
+    tasksMapRef,
+    committedTasksRef,
+    sessionNodeId,
     setTasks,
     setError,
     setIsLoading,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.handlers.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.handlers.ts
@@ -1,5 +1,6 @@
 import { useShapeBuildTaskSyncCore } from './useShapeBuildTaskSync.core.js';
 import { useShapeBuildTaskSyncEventHandlers } from './useShapeBuildTaskSync.handlers.events.js';
+import { useMemo } from 'react';
 import type { RawTaskSummary, SyncArgs } from './useShapeBuildTaskSync.types.js';
 import type { HandlerRefs } from './useShapeBuildTaskSync.types.js';
 
@@ -89,10 +90,12 @@ export const useShapeBuildTaskSyncHandlers = ({
     markTaskStreamSynchronized,
   });
 
-  const withTypes = <T extends Record<string, unknown>>(value: T) => value;
+  const handleSnapshot = useMemo(() => {
+    return (snapshot: unknown) => events.handleSnapshot(snapshot as RawTaskSummary[]);
+  }, [events.handleSnapshot]);
 
-  return withTypes({
-    handleSnapshot: (snapshot: RawTaskSummary[]) => events.handleSnapshot(snapshot),
+  return useMemo(() => ({
+    handleSnapshot,
     handleUpdate: (task: RawTaskSummary) => events.handleUpdate(task),
     handleDelete: (taskId: string) => events.handleDelete(taskId),
     syncTasksRef: core.syncTasksRef,
@@ -101,5 +104,15 @@ export const useShapeBuildTaskSyncHandlers = ({
     resetPending: core.resetPending,
     scheduleFlush: core.scheduleFlush,
     resetDebugCounters: core.resetDebugCounters,
-  });
+  }), [
+    core.syncTasksRef,
+    core.syncLoadingRef,
+    core.syncErrorRef,
+    core.resetPending,
+    core.scheduleFlush,
+    core.resetDebugCounters,
+    events.handleDelete,
+    events.handleUpdate,
+    handleSnapshot,
+  ]);
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.state.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.state.ts
@@ -1,4 +1,5 @@
 import type { ShapeBuildTaskSummary } from '~/ui/atoms/shapeBuildProgressAtoms';
+import { useCallback } from 'react';
 import { isCompletedAtFullProgress } from './useShapeBuildTaskSync.comparison.utils.js';
 import type { HandlerRefs, SyncResult } from './useShapeBuildTaskSync.types.js';
 
@@ -40,7 +41,7 @@ export const useShapeBuildTaskSyncState = ({
     completedTasksRef,
   } = refs;
 
-  const syncTasksRef = (tasks: ShapeBuildTaskSummary[]) => {
+  const syncTasksRef = useCallback((tasks: ShapeBuildTaskSummary[]) => {
     pendingTasksRef.current = null;
     pendingDirtyRef.current = false;
     flushScheduledRef.current = false;
@@ -66,9 +67,23 @@ export const useShapeBuildTaskSyncState = ({
         .map((task) => [task.taskId, task]),
     );
     updateCommittedSequences(tasks);
-  };
+  }, [
+    pendingTasksRef,
+    pendingDirtyRef,
+    flushScheduledRef,
+    bufferedSnapshotRef,
+    bufferedUpdatesRef,
+    bufferedSequenceRef,
+    flushFrameRef,
+    flushTimeoutRef,
+    tasksRef,
+    committedTasksRef,
+    tasksMapRef,
+    completedTasksRef,
+    updateCommittedSequences,
+  ]);
 
-  const resetPending = () => {
+  const resetPending = useCallback(() => {
     pendingTasksRef.current = null;
     pendingDirtyRef.current = false;
     bufferedSnapshotRef.current = null;
@@ -84,7 +99,16 @@ export const useShapeBuildTaskSyncState = ({
       window.clearTimeout(flushTimeoutRef.current);
       flushTimeoutRef.current = null;
     }
-  };
+  }, [
+    pendingTasksRef,
+    pendingDirtyRef,
+    bufferedSnapshotRef,
+    bufferedUpdatesRef,
+    bufferedSequenceRef,
+    flushScheduledRef,
+    flushFrameRef,
+    flushTimeoutRef,
+  ]);
 
   return {
     syncTasksRef,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts
@@ -282,12 +282,12 @@ export const useShapeBuildTaskSyncScheduling = ({
     scheduleBufferedFlush,
     scheduleFlush,
     syncTasksRef,
-    syncLoadingRef: (loading: boolean) => {
+    syncLoadingRef: useCallback((loading: boolean) => {
       isLoadingRef.current = loading;
-    },
-    syncErrorRef: (error: Error | null) => {
+    }, [isLoadingRef]),
+    syncErrorRef: useCallback((error: Error | null) => {
       errorRef.current = error;
-    },
+    }, [errorRef]),
     resetPending,
   };
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks/useShapeBuildTasks.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTasks/useShapeBuildTasks.ts
@@ -46,7 +46,7 @@ export function useShapeBuildTasks(
   const [error, setError] = useAtom(tasksErrorAtom);
   const [isTaskStreamReady, setIsTaskStreamReady] = useState(false);
   const reportedFailuresRef = useRef<Set<string>>(new Set());
-  const handleSnapshotRef = useRef<(tasks: RawTaskSummary[]) => void>(() => {});
+  const handleSnapshotRef = useRef<(tasks: unknown) => void>(() => {});
   const handleUpdateRef = useRef<(task: RawTaskSummary) => void>(() => {});
   const handleDeleteRef = useRef<(taskId: string) => void>(() => {});
   const reconcileInFlightRef = useRef(false);
@@ -184,7 +184,7 @@ export function useShapeBuildTasks(
         if (cancelled || subscriptionIdRef.current !== subscriptionId) {
           return;
         }
-        handleSnapshotRef.current(latestTasks as RawTaskSummary[]);
+        handleSnapshotRef.current(latestTasks);
       } catch (err) {
         if (!cancelled && isDev) {
           console.debug('[ShapeBuildStep] task snapshot reconcile skipped', err);
@@ -247,7 +247,7 @@ export function useShapeBuildTasks(
     }
     try {
       const latestTasks = await bridgeRef.current.getBuildTasks(SHAPE_NODE_TYPE, nodeId);
-      handleSnapshotRef.current(latestTasks as RawTaskSummary[]);
+      handleSnapshotRef.current(latestTasks);
     } catch (err) {
       const errObj = err instanceof Error ? err : new Error('Failed to refresh build tasks');
       setError(errObj);

--- a/plugins/shape-plugin/vitest.config.ts
+++ b/plugins/shape-plugin/vitest.config.ts
@@ -16,17 +16,17 @@ export default defineConfig({
     pool: useForkPool ? 'forks' : 'threads',
     poolOptions: useForkPool
       ? {
-        forks: {
-          singleFork: true,
-          execArgv: ['--max-old-space-size=8192'],
-        },
-      }
+          forks: {
+            singleFork: true,
+            execArgv: ['--max-old-space-size=8192'],
+          },
+        }
       : {
-        threads: {
-          minThreads: 1,
-          maxThreads: 1,
+          threads: {
+            minThreads: 1,
+            maxThreads: 1,
+          },
         },
-      },
     include: [
       'src/**/*.test.ts',
       'src/**/*.test.tsx',
@@ -54,6 +54,48 @@ export default defineConfig({
   },
   resolve: {
     alias: [
+      { find: '~/i18n/index', replacement: path.resolve(__dirname, '../../packages/ui/i18n/src/i18n/index.ts') },
+      {
+        find: '~/debug/persistentDebugLog',
+        replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/debug/persistentDebugLog.ts'),
+      },
+      {
+        find: '~/utils/env',
+        replacement: path.resolve(__dirname, '../../packages/ui/i18n/src/utils/env.ts'),
+      },
+      {
+        find: '~/transform/topojsonGrid.js',
+        replacement: path.resolve(
+          __dirname,
+          '../../packages/vt-orchestrator/src/transform/topojsonGrid.ts',
+        ),
+      },
+      {
+        find: '~/transform/topojsonRuntimeAdapter.js',
+        replacement: path.resolve(
+          __dirname,
+          '../../packages/vt-orchestrator/src/transform/topojsonRuntimeAdapter.ts',
+        ),
+      },
+      {
+        find: /^~\/task\/(.*)$/,
+        replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/task/$1'),
+      },
+      { find: /^~\/contexts$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/contexts') },
+      { find: /^~\/types\/(.*)$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/types/$1') },
+      { find: /^~\/types$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/types') },
+      { find: /^~\/tiles\/(.*)$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/tiles/$1') },
+      { find: /^~\/tiles$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/tiles') },
+      { find: /^~\/transform\/(.*)$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/transform/$1') },
+      { find: /^~\/transform$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/transform') },
+      { find: /^~\/compareTaskOrder\/(.*)$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/compareTaskOrder/$1') },
+      { find: /^~\/compareTaskOrder$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/compareTaskOrder.ts') },
+      { find: /^~\/vt\/(.*)$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/vt/$1') },
+      { find: /^~\/vt$/, replacement: path.resolve(__dirname, '../../packages/vt-orchestrator/src/vt') },
+      { find: /^~\/hooks\/useLRUPanes$/, replacement: path.resolve(__dirname, '../../packages/ui/lru-splitview/src/hooks/useLRUPanes.ts') },
+      { find: /^~\/types\/LRUSplitView$/, replacement: path.resolve(__dirname, '../../packages/ui/lru-splitview/src/types/LRUSplitView.ts') },
+      { find: /^~\/(.*)$/, replacement: path.resolve(__dirname, 'src/$1') },
+      { find: '~', replacement: path.resolve(__dirname, 'src') },
       // Map legacy core imports to public dist builds for tests
       {
         find: '@hierarchidb/core',
@@ -69,15 +111,19 @@ export default defineConfig({
       },
       {
         find: '@hierarchidb/ui-worker-client',
-        replacement: path.resolve(__dirname, '../../packages/ui/worker-client/src/index.ts'),
+        replacement: path.resolve(__dirname, '../../packages/ui/worker-client/dist/index.js'),
       },
       {
         find: '@hierarchidb/ui-batch',
-        replacement: path.resolve(__dirname, '../../packages/ui/batch/src/index.ts'),
+        replacement: path.resolve(__dirname, '../../packages/ui/batch/dist/index.js'),
       },
       {
         find: '@hierarchidb/ui-batch-progress',
-        replacement: path.resolve(__dirname, '../../packages/ui/batch/src/index.ts'),
+        replacement: path.resolve(__dirname, '../../packages/ui/batch/dist/index.js'),
+      },
+      {
+        find: '@hierarchidb/ui-worker-provider',
+        replacement: path.resolve(__dirname, '../../packages/ui/worker-provider/dist/index.js'),
       },
       {
         find: '@hierarchidb/runtime-worker',
@@ -119,7 +165,7 @@ export default defineConfig({
       },
       {
         find: '@hierarchidb/download',
-        replacement: path.resolve(__dirname, '../../packages/download/src/index.ts'),
+        replacement: path.resolve(__dirname, '../../packages/download/dist/index.js'),
       },
       {
         find: '@hierarchidb/shape-store',


### PR DESCRIPTION
## 概要
- useShapeBuildStep の 400+ 行の開始シーケンス関連ロジックを別ファイルへ分離
  - useShapeBuildStepStartupLifecycle
  - startupTrace
- startup トレース/監視関連の型・ユーティリティを一元化し、主実装を薄くした
- 既存挙動を維持しつつ型エラー修正を反映

## 変更内容
- plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
- plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/startupTrace.ts
- plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStartupLifecycle.ts

## 検証
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --no-daemon
- result: all successful