### PR TITLE
feat(folder-plugin): add folder export wizard step components

### DIFF
--- a/plugins/folder-plugin/docs/FOLDER_EXPORT_DESIGN.md
+++ b/plugins/folder-plugin/docs/FOLDER_EXPORT_DESIGN.md
@@ -1,0 +1,78 @@
+# Folder Export Dialog (Export Menu from Folder Context)
+
+## Goal
+
+Provide a folder-level export flow accessible from the folder node context menu and produce
+artifacts for the selected folder subtree via a guided multi-step dialog.
+
+## Scope
+
+This branch implements:
+
+1. **Import/Export continuity mode**
+   - Export a folder subtree and re-import it to another console as a reconstructed hierarchy.
+2. **External distribution mode**
+  - UI includes options for `pbf.zip` and `mvf`, and runtime emits vector-tile archives.
+
+## Route design
+
+- Context menu action for a folder is routed to:
+  - `/t/:treeId/:pageNodeId/:targetNodeId/folder/export/:mode/:step`
+- The host uses `loadNodeAction(...)` normally (no special archive-like branch).
+- `:mode` is used as dialog display mode (kept as route compatibility).
+- `:step` opens the wizard at the requested step index.
+- `:pageNodeId` falls back to `${treeId}:root` when omitted.
+
+## Step sequence (5 steps)
+
+1. **Purpose**
+   - `continuity` (default): app-side interoperability export.
+   - `distribution`: external distribution target.
+2. **Target Nodes**
+   - `all`: include all descendants under the folder.
+   - `shapeOnly`: include shape descendants only.
+3. **Output Format**
+  - `continuity` forces `json`.
+  - `distribution` allows `pbf.zip` / `mvf` in UI and runtime generates tile archives in those formats.
+4. **Options**
+   - `continuity`: fixed values.
+   - `distribution`: editable `minZoom`, `maxZoom`, `maxTileBytes`, `downloadPayload`.
+5. **Review**
+   - Summary and build trigger.
+
+## Execution logic (current)
+
+- Export is started from `Review` step capability (`canStartBuild`, `startBuild`).
+- `startBuild` logic:
+  - Resolve worker client via `__HDB_WORKER_CLIENT_REF__`.
+  - Resolve Query API + ImportExport API.
+  - Read the target node.
+  - Collect IDs by scope:
+    - `all`: target node + descendants via `includeChildren`.
+    - `shapeOnly`: filter descendant nodeType `shape`.
+  - Invoke `exportNodes(...)`.
+  - Download resulting payload as browser blob and save to disk.
+- `exportNodes` now collects `shape` vector tiles and emits `<nodeId>/<z>/<x>/<y>.pbf` entries plus
+  `metadata.json` / `summary.json` in the archive.
+
+## File naming / download
+
+- Filename uses target folder label (safe-char sanitized) + ISO timestamp.
+- Extension is derived from MIME type when present; otherwise falls back to selected format mapping.
+- Export count is shown in success notification.
+
+## Validation and error handling
+
+- `continuity`: format fixed to JSON.
+- `distribution`: validates option range when visible.
+- Validation errors are shown in each step.
+- Failures include: worker not ready, target not found, no exportable nodes, API failure, empty result.
+
+## Import interoperability
+
+- Exported JSON should be importable by folder-level import path and reconstruct hierarchy.
+- This design keeps export/import as a separate round-trip concern from the browser-side distribution pipeline.
+
+## Open items
+
+- Add step-wise progress and large artifact handling for browser memory safety (streaming / chunked output).

--- a/plugins/folder-plugin/src/ui/components/folder-export/FolderExportFormatStep.tsx
+++ b/plugins/folder-plugin/src/ui/components/folder-export/FolderExportFormatStep.tsx
@@ -1,0 +1,75 @@
+import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup, Stack, Typography } from '@mui/material';
+import type { PluginStepProps } from '@hierarchidb/plugin-base';
+import { useEffect } from 'react';
+import type { FolderExportDraftData } from './types.js';
+import { normalizeFolderExportDraft } from './types.js';
+
+type Props = PluginStepProps<FolderExportDraftData>;
+
+export const FolderExportFormatStep = ({
+  data,
+  onChange,
+  setValid,
+  setError,
+  disabled,
+}: Props) => {
+  const draft = normalizeFolderExportDraft(data);
+  const isContinuity = draft.exportMode === 'continuity';
+  const updateDraft = (next: Partial<FolderExportDraftData>) => {
+    onChange({
+      ...draft,
+      ...next,
+    });
+  };
+
+  useEffect(() => {
+    if (isContinuity) {
+      if (draft.format !== 'json') {
+        onChange({
+          ...draft,
+          format: 'json',
+        });
+      }
+    }
+
+    const valid = isContinuity || draft.format === 'pbf.zip' || draft.format === 'mvf' || draft.format === 'json';
+    setValid(valid);
+    setError(valid ? null : '形式を選択してください。');
+  }, [draft.format, isContinuity, onChange, setError, setValid]);
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Output format</Typography>
+      {isContinuity ? (
+        <Typography variant="body2">
+          作業継続用途は内部継続形式の json を採用します。
+        </Typography>
+      ) : null}
+      <FormControl>
+        <FormLabel>形式</FormLabel>
+        <RadioGroup
+          value={draft.format}
+          onChange={(event) => {
+            if (disabled || isContinuity) return;
+            updateDraft({
+              format: event.target.value as FolderExportDraftData['format'],
+            });
+          }}
+        >
+          <FormControlLabel
+            value="pbf.zip"
+            control={<Radio />}
+            label="pbf.zip"
+            disabled={disabled || isContinuity}
+          />
+          <FormControlLabel
+            value="mvf"
+            control={<Radio />}
+            label="mvf"
+            disabled={disabled || isContinuity}
+          />
+        </RadioGroup>
+      </FormControl>
+    </Stack>
+  );
+};

--- a/plugins/folder-plugin/src/ui/components/folder-export/FolderExportOptionsStep.tsx
+++ b/plugins/folder-plugin/src/ui/components/folder-export/FolderExportOptionsStep.tsx
@@ -1,0 +1,111 @@
+import { Checkbox, FormControlLabel, Stack, TextField, Typography } from '@mui/material';
+import type { PluginStepProps } from '@hierarchidb/plugin-base';
+import { useEffect } from 'react';
+import type { FolderExportDraftData } from './types.js';
+import { normalizeFolderExportDraft } from './types.js';
+
+type Props = PluginStepProps<FolderExportDraftData>;
+
+const toDisplayString = (value: number): string => String(value);
+
+const toNumberOrFallback = (value: string, fallback: number): number => {
+  const next = Number(value);
+  return Number.isFinite(next) ? next : fallback;
+};
+
+export const FolderExportOptionsStep = ({
+  data,
+  onChange,
+  setValid,
+  setError,
+  disabled,
+}: Props) => {
+  const draft = normalizeFolderExportDraft(data);
+  const isContinuity = draft.exportMode === 'continuity';
+
+  const updateDraft = (next: Partial<FolderExportDraftData>) => {
+    onChange({
+      ...draft,
+      ...next,
+    });
+  };
+
+  const isDistributionValid =
+    draft.minZoom >= 0 &&
+    draft.maxZoom >= draft.minZoom &&
+    draft.maxTileBytes > 0 &&
+    Number.isFinite(draft.minZoom) &&
+    Number.isFinite(draft.maxZoom) &&
+    Number.isFinite(draft.maxTileBytes);
+
+  useEffect(() => {
+    const valid = isContinuity || isDistributionValid;
+    setValid(valid);
+    setError(valid ? null : '外部配信用のオプションを確認してください。');
+  }, [isContinuity, isDistributionValid, setError, setValid]);
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Distribution options</Typography>
+      {isContinuity ? (
+        <Typography variant="body2">
+          作業継続用途では配信オプションを固定値として扱います。
+        </Typography>
+      ) : (
+        <>
+          <TextField
+            label="minZoom"
+            type="number"
+            value={toDisplayString(draft.minZoom)}
+            disabled={disabled}
+            onChange={(event) => {
+              if (disabled) return;
+              updateDraft({
+                minZoom: toNumberOrFallback(event.target.value, draft.minZoom),
+              });
+            }}
+          />
+          <TextField
+            label="maxZoom"
+            type="number"
+            value={toDisplayString(draft.maxZoom)}
+            disabled={disabled}
+            onChange={(event) => {
+              if (disabled) return;
+              updateDraft({
+                maxZoom: toNumberOrFallback(event.target.value, draft.maxZoom),
+              });
+            }}
+          />
+          <TextField
+            label="maxTileBytes"
+            type="number"
+            value={toDisplayString(draft.maxTileBytes)}
+            disabled={disabled}
+            onChange={(event) => {
+              if (disabled) return;
+              updateDraft({
+                maxTileBytes: toNumberOrFallback(event.target.value, draft.maxTileBytes),
+              });
+            }}
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={draft.downloadPayload}
+                disabled={disabled}
+                onChange={(event) => {
+                  if (disabled) return;
+                  updateDraft({
+                    downloadPayload: event.target.checked,
+                  });
+                }}
+              />
+            }
+            label="downloadablePayload を含める"
+          />
+        </>
+      )}
+    </Stack>
+  );
+};

--- a/plugins/folder-plugin/src/ui/components/folder-export/FolderExportPurposeStep.tsx
+++ b/plugins/folder-plugin/src/ui/components/folder-export/FolderExportPurposeStep.tsx
@@ -1,0 +1,59 @@
+import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup, Stack, Typography } from '@mui/material';
+import type { PluginStepProps } from '@hierarchidb/plugin-base';
+import { useEffect } from 'react';
+import type { FolderExportDraftData } from './types.js';
+import { normalizeFolderExportDraft } from './types.js';
+
+type Props = PluginStepProps<FolderExportDraftData>;
+
+export const FolderExportPurposeStep = ({
+  data,
+  onChange,
+  setValid,
+  setError,
+  disabled,
+}: Props) => {
+  const draft = normalizeFolderExportDraft(data);
+  const updateDraft = (next: Partial<FolderExportDraftData>) => {
+    onChange({
+      ...draft,
+      ...next,
+    });
+  };
+
+  useEffect(() => {
+    setValid(draft.exportMode === 'continuity' || draft.exportMode === 'distribution');
+    setError(draft.exportMode ? null : '目的を選択してください。');
+  }, [draft.exportMode, setError, setValid]);
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Export purpose</Typography>
+      <FormControl>
+        <FormLabel>用途を選択</FormLabel>
+        <RadioGroup
+          value={draft.exportMode}
+          onChange={(event) => {
+            if (disabled) return;
+            updateDraft({
+              exportMode: event.target.value as FolderExportDraftData['exportMode'],
+            });
+          }}
+        >
+          <FormControlLabel
+            value="continuity"
+            control={<Radio />}
+            label="作業継続（Import continuity）"
+            disabled={disabled}
+          />
+          <FormControlLabel
+            value="distribution"
+            control={<Radio />}
+            label="外部配信用（External distribution）"
+            disabled={disabled}
+          />
+        </RadioGroup>
+      </FormControl>
+    </Stack>
+  );
+};

--- a/plugins/folder-plugin/src/ui/components/folder-export/FolderExportReviewStep.tsx
+++ b/plugins/folder-plugin/src/ui/components/folder-export/FolderExportReviewStep.tsx
@@ -1,0 +1,55 @@
+import { Divider, List, ListItem, ListItemText, Stack, Typography } from '@mui/material';
+import type { PluginStepProps } from '@hierarchidb/plugin-base';
+import { useEffect } from 'react';
+import type { FolderExportDraftData } from './types.js';
+import { normalizeFolderExportDraft } from './types.js';
+
+type Props = PluginStepProps<FolderExportDraftData>;
+
+export const FolderExportReviewStep = ({ data, setValid, setError }: Props) => {
+  const draft = normalizeFolderExportDraft(data);
+
+  useEffect(() => {
+    setValid(true);
+    setError(null);
+  }, [setError, setValid]);
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Review</Typography>
+      <List>
+        <ListItem>
+          <ListItemText primary="用途" secondary={draft.exportMode === 'continuity' ? '作業継続' : '外部配信'} />
+        </ListItem>
+        <Divider component="li" />
+        <ListItem>
+          <ListItemText
+            primary="対象"
+            secondary={draft.targetScope === 'shapeOnly' ? 'shape のみ' : 'shape/location/route 全件'}
+          />
+        </ListItem>
+        <Divider component="li" />
+        <ListItem>
+          <ListItemText
+            primary="フォーマット"
+            secondary={draft.format}
+          />
+        </ListItem>
+        <Divider component="li" />
+        <ListItem>
+          <ListItemText
+            primary="可視化パラメータ"
+            secondary={
+              `minZoom=${draft.minZoom}, maxZoom=${draft.maxZoom}, maxTileBytes=${draft.maxTileBytes}, downloadablePayload=${String(
+                draft.downloadPayload,
+              )}`
+            }
+          />
+        </ListItem>
+      </List>
+      <Typography color="text.secondary">
+        設定が完了したら「Start Build」ボタンからエクスポートを開始できます。
+      </Typography>
+    </Stack>
+  );
+};

--- a/plugins/folder-plugin/src/ui/components/folder-export/FolderExportTargetStep.tsx
+++ b/plugins/folder-plugin/src/ui/components/folder-export/FolderExportTargetStep.tsx
@@ -1,0 +1,57 @@
+import { FormControlLabel, Radio, RadioGroup, Stack, Typography } from '@mui/material';
+import type { PluginStepProps } from '@hierarchidb/plugin-base';
+import { useEffect } from 'react';
+import type { FolderExportDraftData } from './types.js';
+import { normalizeFolderExportDraft } from './types.js';
+
+type Props = PluginStepProps<FolderExportDraftData>;
+
+export const FolderExportTargetStep = ({
+  data,
+  onChange,
+  setValid,
+  setError,
+  disabled,
+}: Props) => {
+  const draft = normalizeFolderExportDraft(data);
+  const updateDraft = (next: Partial<FolderExportDraftData>) => {
+    onChange({
+      ...draft,
+      ...next,
+    });
+  };
+
+  useEffect(() => {
+    const valid = draft.targetScope === 'shapeOnly' || draft.targetScope === 'all';
+    setValid(valid);
+    setError(valid ? null : '対象ノードを選択してください。');
+  }, [draft.targetScope, setError, setValid]);
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Target nodes</Typography>
+      <RadioGroup
+        value={draft.targetScope}
+        onChange={(event) => {
+          if (disabled) return;
+          updateDraft({
+            targetScope: event.target.value as FolderExportDraftData['targetScope'],
+          });
+        }}
+      >
+        <FormControlLabel
+          value="all"
+          control={<Radio />}
+          label="shape/location/route を含む対象以下をすべて選択"
+          disabled={disabled}
+        />
+        <FormControlLabel
+          value="shapeOnly"
+          control={<Radio />}
+          label="shape のみ"
+          disabled={disabled}
+        />
+      </RadioGroup>
+    </Stack>
+  );
+};

--- a/plugins/folder-plugin/src/ui/components/folder-export/types.ts
+++ b/plugins/folder-plugin/src/ui/components/folder-export/types.ts
@@ -1,0 +1,50 @@
+export type FolderExportMode = 'continuity' | 'distribution';
+
+export type FolderExportScope = 'shapeOnly' | 'all';
+
+export type FolderExportFormat = 'json' | 'pbf.zip' | 'mvf';
+
+export interface FolderExportDraftData {
+  exportMode: FolderExportMode;
+  targetScope: FolderExportScope;
+  format: FolderExportFormat;
+  minZoom: number;
+  maxZoom: number;
+  maxTileBytes: number;
+  downloadPayload: boolean;
+}
+
+export const createDefaultFolderExportDraft = (): FolderExportDraftData => ({
+  exportMode: 'continuity',
+  targetScope: 'all',
+  format: 'json',
+  minZoom: 0,
+  maxZoom: 10,
+  maxTileBytes: 1_048_576,
+  downloadPayload: false,
+});
+
+export const normalizeFolderExportDraft = (
+  data: FolderExportDraftData | undefined,
+): FolderExportDraftData => {
+  const defaults = createDefaultFolderExportDraft();
+  const draft: FolderExportDraftData = {
+    ...defaults,
+    ...(data ?? {}),
+  };
+  const exportMode: FolderExportMode = draft.exportMode === 'distribution' ? 'distribution' : 'continuity';
+  const targetScope: FolderExportScope = draft.targetScope === 'shapeOnly' ? 'shapeOnly' : 'all';
+  const format =
+    draft.format === 'pbf.zip' || draft.format === 'mvf' || draft.format === 'json'
+      ? draft.format
+      : exportMode === 'continuity'
+        ? 'json'
+        : 'pbf.zip';
+
+  return {
+    ...draft,
+    exportMode,
+    targetScope,
+    format,
+  };
+};


### PR DESCRIPTION
## Summary
- Add folder export design doc for route/steps.
- Add folder export wizard draft typing () and default/normalization helpers.
- Add multi-step UI components:
  - 
  - 
  - 
  - 
  - 

## Notes
- This commit prepares the folder-level export flow surface; wiring into context menu and dialog registration is expected in a follow-up commit.

## Verification
- Not executed in this commit (UI shell draft only).