### PR TITLE
feat(shape): persist URL build config rules in step4

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #466 / `feat/shape/url-build-rules-persistence` / start: 2026-02-21 19:02 JST
 - #344 / `codex/refactor/build-session/residual-unification-344` / start: 2026-02-17 16:52 JST
 - #340 / `codex/refactor/runtime/sharedworker-only-build-session-340` / start: 2026-02-17 10:56 JST
 - #339 / `codex/docs/shape/session-manager-state-transition-339` / start: 2026-02-17 10:04 JST
@@ -114,6 +115,7 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- start: 2026-02-21 19:02 JST #466 Issue #466 を起票（https://github.com/kubohiroya/hierarchidb/issues/466）し、ブランチ `feat/shape/url-build-rules-persistence` を作成して着手。
 - update: 2026-02-17 17:12 JST #344 Issue DoD チェックを更新（全項目 `[x]`）し、コミット `8f7f8a299`（`refactor(build-session): drop shape UI coordinator control path`）を作成。
 - update: 2026-02-17 17:13 JST #344 ブランチ `codex/refactor/build-session/residual-unification-344` を push し、PR #345（https://github.com/kubohiroya/hierarchidb/pull/345, base: `main`）を作成。
 - update: 2026-02-17 17:10 JST #344 shape build-step の通常 start/stop/progress 経路から `@hierarchidb/session-coordinator` 依存を除去（`plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildStep.ts`）。`plugins/shape-plugin/package.json` から同依存を削除し、`pnpm tools:gen-plugin-registry` 実行で `packages/plugin-registry/generated/registry.ts` を同期。

--- a/plugins/shape-plugin/src/common/types/build.ts
+++ b/plugins/shape-plugin/src/common/types/build.ts
@@ -23,12 +23,25 @@ export type ShapeBuildFetchConfig = Omit<
 export type ShapeBuildTransformConfig = Omit<TransformConfig, 'maxConcurrent'>;
 export type ShapeBuildVtConfig = Omit<VTConfig, 'maxConcurrent' | 'dynamicConcurrency'>;
 
+export type ShapeUrlMatchType = 'default' | 'regexp' | 'prefix';
+
+export interface ShapeBuildUrlRule {
+  key?: string;
+  matchType: ShapeUrlMatchType;
+  pattern?: string;
+  buildConfig?: ShapeBuildUrlConfigPatch;
+  enabled?: boolean;
+}
+
+export type ShapeBuildUrlConfigPatch = Omit<Partial<ShapeBuildConfig>, 'urlBuildConfigRules'>;
+
 export interface ShapeBuildConfig {
   dataSourceName: DataSourceName;
   fetchConfig: ShapeBuildFetchConfig;
   transformConfig: ShapeBuildTransformConfig;
   vtConfig: ShapeBuildVtConfig;
   cleanupConfig?: CleanupConfig;
+  urlBuildConfigRules?: ShapeBuildUrlRule[];
 }
 
 export interface ShapeProcessingConfig {
@@ -48,7 +61,14 @@ export interface ShapeProcessingConfig {
 export type ShapeRuntimeBuildConfig = BaseBuildConfig<DataSourceName>;
 
 export type BuildTaskType = TaskStage;
-export type BuildTaskStatus = 'idle' | 'queued' | 'running' | 'completed' | 'failed' | 'paused' | 'recycled';
+export type BuildTaskStatus =
+  | 'idle'
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'paused'
+  | 'recycled';
 
 export const BuildTaskResult = {
   WAIT: 'wait',
@@ -175,7 +195,6 @@ export interface ProgressInfo {
   taskType?: BuildTaskType | 'processing';
 }
 
-
 export interface BuildSession {
   nodeId: NodeId;
   draftId?: NodeId;
@@ -214,7 +233,6 @@ export type ShapeBuildCommandMap = {
 
 export type ShapeBuildCommand = keyof ShapeBuildCommandMap;
 export type ShapeBuildCommandPayload<K extends ShapeBuildCommand> = ShapeBuildCommandMap[K];
-
 
 export interface LayerConfig {
   name: string;

--- a/plugins/shape-plugin/src/common/types/index.ts
+++ b/plugins/shape-plugin/src/common/types/index.ts
@@ -5,6 +5,9 @@ export type {
   ShapeBuildFetchConfig,
   ShapeBuildTransformConfig,
   ShapeBuildVtConfig,
+  ShapeBuildUrlConfigPatch,
+  ShapeBuildUrlRule,
+  ShapeUrlMatchType,
   ShapeProcessingConfig,
   ShapeRuntimeBuildConfig,
 } from './build.ts';

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/createBuildStartDraftData.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/createBuildStartDraftData.unit.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createBuildStartDraftData } from '../../../components/build-progress/createBuildStartDraftData';
+import type { ShapeBuildUrlRule } from '../../../../common/types';
+import type { ShapeEntity } from '../../../../common/types';
 
 describe('createBuildStartDraftData', () => {
   it('persists live selection when current draft does not have selection', () => {
@@ -41,5 +43,35 @@ describe('createBuildStartDraftData', () => {
     expect(next.selectedArrayByCountries).toEqual({
       JP: [false, true, false],
     });
+  });
+
+  it('persists urlBuildConfigRules in buildConfig', () => {
+    const rule: ShapeBuildUrlRule = {
+      key: 'test',
+      matchType: 'regexp',
+      pattern: '.*',
+      buildConfig: {
+        transformConfig: {
+          tolerance: 0.2,
+        },
+      },
+    };
+    const next = createBuildStartDraftData({
+      currentDraftData: {
+        buildConfig: {
+          dataSourceName: 'gadm',
+          fetchConfig: {},
+          transformConfig: {},
+          vtConfig: {},
+        },
+      },
+      patch: {
+        buildConfig: {
+          urlBuildConfigRules: [rule],
+        } as ShapeEntity['buildConfig'],
+      },
+    });
+
+    expect(next.buildConfig?.urlBuildConfigRules).toEqual([rule]);
   });
 });

--- a/plugins/shape-plugin/src/ui/components/build-config/ShapeBuildConfigStep.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/ShapeBuildConfigStep.tsx
@@ -2,11 +2,16 @@ import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Stack, Typography } from '@mui/material';
 import type { AlertColor } from '@mui/material';
-import { BuildConfigShell, FetchConfigSection, VTConfigSection } from '@hierarchidb/ui-accordion-config';
+import {
+  BuildConfigShell,
+  FetchConfigSection,
+  VTConfigSection,
+} from '@hierarchidb/ui-accordion-config';
 import { TransformConfigSection } from './TransformConfigSection.js';
 import { ZoomBandConfigSection } from './ZoomBandConfigSection.js';
 import { CacheManagementSection } from './CacheManagementSection.tsx';
 import { FetchInvalidGeometryFilterCard } from './FetchInvalidGeometryFilterCard.tsx';
+import { UrlBuildConfigRulesSection } from './UrlBuildConfigRulesSection.tsx';
 import { useShapeBuildConfigStep } from './useShapeBuildConfigStep.js';
 import { useHeapPressureMonitor } from '@hierarchidb/ui-memory';
 import { useTranslation } from '~/ui/i18n';
@@ -31,7 +36,7 @@ import {
 import { shapeQueryAPIImpl } from '~/services/batch/ShapeBuildAPIClient';
 
 const toBuildConfigUpdate = (
-  partial: Partial<ShapeRuntimeBuildConfig>,
+  partial: Partial<ShapeRuntimeBuildConfig>
 ): Partial<ShapeBuildConfig> => {
   const next: Partial<ShapeBuildConfig> = {};
   if (partial.dataSourceName !== undefined) {
@@ -79,11 +84,11 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
   const { config, handleChange } = useShapeBuildConfigStep({ data, onChange });
   const processingConfig = useMemo(
     () => mergeProcessingConfig(DEFAULT_PROCESSING_CONFIG, data?.processingConfig),
-    [data?.processingConfig],
+    [data?.processingConfig]
   );
   const runtimeBuildConfig = useMemo(
     () => composeRuntimeBuildConfig(config, processingConfig),
-    [config, processingConfig],
+    [config, processingConfig]
   );
   const { event: heapPressure } = useHeapPressureMonitor();
   const heapWarning = useMemo(() => {
@@ -100,19 +105,25 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
           ratio: ratioPercent,
           used: usedMb,
           limit: limitMb,
-        },
+        }
       ),
     };
   }, [heapPressure, t]);
-  const filteringPreviewImages = useMemo(() => ({
-    weak: filteringLowUrl,
-    medium: filteringMediumUrl,
-    strong: filteringHighUrl,
-  }), []);
-  const updateRuntimeBuildConfig = useCallback((partial: Partial<ShapeRuntimeBuildConfig>) => {
-    const nextBuildConfig = mergeBuildConfig(config, toBuildConfigUpdate(partial));
-    handleChange(nextBuildConfig);
-  }, [config, handleChange]);
+  const filteringPreviewImages = useMemo(
+    () => ({
+      weak: filteringLowUrl,
+      medium: filteringMediumUrl,
+      strong: filteringHighUrl,
+    }),
+    []
+  );
+  const updateRuntimeBuildConfig = useCallback(
+    (partial: Partial<ShapeRuntimeBuildConfig>) => {
+      const nextBuildConfig = mergeBuildConfig(config, toBuildConfigUpdate(partial));
+      handleChange(nextBuildConfig);
+    },
+    [config, handleChange]
+  );
   const fetchState = useFetchConfigSection({
     config,
     nodeId: nodeId as NodeId,
@@ -124,17 +135,15 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
     <BuildConfigShell
       padding={2}
       spacing={2}
-      alert={heapWarning ? (
-        <Alert severity={heapWarning.severity} sx={{ alignItems: 'center' }}>
-          {heapWarning.message}
-        </Alert>
-      ) : null}
+      alert={
+        heapWarning ? (
+          <Alert severity={heapWarning.severity} sx={{ alignItems: 'center' }}>
+            {heapWarning.message}
+          </Alert>
+        ) : null
+      }
     >
-      <ZoomBandConfigSection
-        config={config}
-        onChange={handleChange}
-        disabled={disabled}
-      />
+      <ZoomBandConfigSection config={config} onChange={handleChange} disabled={disabled} />
       <FetchConfigSection
         t={t}
         buildConfig={runtimeBuildConfig}
@@ -143,19 +152,20 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
         showConcurrencyCard={false}
         showRetryCard={false}
         disabled={disabled}
-        additionalCards={(
+        additionalCards={
           <FetchInvalidGeometryFilterCard
             config={config}
             onChange={handleChange}
             disabled={disabled}
           />
-        )}
+        }
       />
-      <TransformConfigSection
+      <UrlBuildConfigRulesSection
         config={config}
         onChange={handleChange}
         disabled={disabled}
       />
+      <TransformConfigSection config={config} onChange={handleChange} disabled={disabled} />
       <VTConfigSection
         t={t}
         buildConfig={runtimeBuildConfig}
@@ -171,9 +181,10 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
 const ShapeBuildConfigRunningNotice: React.FC = () => {
   const { t } = useTranslation();
   const { stepComponents, onStepNavigate } = useDialogContext<Partial<ShapeEntity>>();
-  const buildStepIndex = useMemo(() => (
-    stepComponents.findIndex((step) => step.id === 'build')
-  ), [stepComponents]);
+  const buildStepIndex = useMemo(
+    () => stepComponents.findIndex((step) => step.id === 'build'),
+    [stepComponents]
+  );
   const handleOpenBuildStep = useCallback(() => {
     if (buildStepIndex < 0) return;
     onStepNavigate({ type: 'direct', targetIndex: buildStepIndex });
@@ -187,7 +198,7 @@ const ShapeBuildConfigRunningNotice: React.FC = () => {
       <Typography variant="body2" color="text.secondary">
         {t(
           'processing.buildRunning.body',
-          'A build session is currently running. Open the Build step to view progress.',
+          'A build session is currently running. Open the Build step to view progress.'
         )}
       </Typography>
       <Button variant="contained" onClick={handleOpenBuildStep} disabled={buildStepIndex < 0}>

--- a/plugins/shape-plugin/src/ui/components/build-config/UrlBuildConfigRulesSection.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/UrlBuildConfigRulesSection.tsx
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { ExpandMore as ExpandMoreIcon, Link as LinkIcon } from '@mui/icons-material';
+import { BuildConfigSectionTitle, getBuildConfigHoverCardSx } from '@hierarchidb/ui-accordion-config';
+import { useTranslation } from '~/ui/i18n';
+import type {
+  ShapeBuildConfig,
+  ShapeBuildUrlRule,
+  ShapeUrlMatchType,
+} from '~/common/types/index';
+
+type Props = {
+  config: ShapeBuildConfig;
+  onChange: (next: ShapeBuildConfig) => void;
+  disabled?: boolean;
+};
+
+const VALID_MATCH_TYPES = new Set<ShapeUrlMatchType>(['default', 'regexp', 'prefix']);
+
+const serializeRules = (rules?: ShapeBuildUrlRule[]): string => (
+  rules && rules.length > 0
+    ? JSON.stringify(rules, null, 2)
+    : ''
+);
+
+const parseRules = (raw: string): { value?: ShapeBuildUrlRule[]; error?: string } => {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { value: undefined };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Invalid JSON' };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { error: 'The JSON must be an array of rule objects.' };
+  }
+
+  const rules: ShapeBuildUrlRule[] = [];
+  for (let index = 0; index < parsed.length; index += 1) {
+    const entry = parsed[index];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return { error: `Rule ${index + 1} is not an object.` };
+    }
+
+    const record = entry as Record<string, unknown>;
+    const matchType = record.matchType;
+    if (typeof matchType !== 'string' || !VALID_MATCH_TYPES.has(matchType as ShapeUrlMatchType)) {
+      return { error: `Rule ${index + 1}: matchType must be default, regexp, or prefix.` };
+    }
+
+    if (matchType !== 'default') {
+      const pattern = record.pattern;
+      if (typeof pattern !== 'string' || pattern.length === 0) {
+        return { error: `Rule ${index + 1}: pattern is required for matchType ${matchType}.` };
+      }
+    }
+
+    const buildConfig = record.buildConfig;
+    if (buildConfig !== undefined && (typeof buildConfig !== 'object' || buildConfig === null || Array.isArray(buildConfig))) {
+      return { error: `Rule ${index + 1}: buildConfig must be an object.` };
+    }
+
+    if (record.key !== undefined && typeof record.key !== 'string') {
+      return { error: `Rule ${index + 1}: key must be a string.` };
+    }
+
+    rules.push(entry as ShapeBuildUrlRule);
+  }
+
+  return { value: rules };
+};
+
+export const UrlBuildConfigRulesSection: React.FC<Props> = ({ config, onChange, disabled }) => {
+  const { t } = useTranslation();
+  const hoverCardSx = getBuildConfigHoverCardSx(disabled);
+  const normalized = useMemo(
+    () => serializeRules(config.urlBuildConfigRules),
+    [config.urlBuildConfigRules],
+  );
+  const [text, setText] = useState(normalized);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setText(normalized);
+    setError('');
+  }, [normalized]);
+
+  const applyRules = useCallback((nextRules?: ShapeBuildUrlRule[]) => {
+    onChange({
+      ...config,
+      urlBuildConfigRules: nextRules,
+    });
+  }, [config, onChange]);
+
+  const handleBlur = useCallback(() => {
+    const { value, error: nextError } = parseRules(text);
+    if (nextError) {
+      setError(nextError);
+      return;
+    }
+    setError('');
+    applyRules(value);
+  }, [text, applyRules]);
+
+  const flushPendingRules = useCallback((options?: { emitError: boolean }) => {
+    const emitError = options?.emitError ?? true;
+    const { value, error: nextError } = parseRules(text);
+    if (nextError) {
+      if (emitError) {
+        setError((prev) => (prev || nextError));
+      }
+      return;
+    }
+    setError('');
+    applyRules(value);
+  }, [applyRules, text]);
+
+  useEffect(() => {
+    return () => {
+      flushPendingRules({ emitError: false });
+    };
+  }, [flushPendingRules]);
+
+  const handleChange = useCallback((nextText: string) => {
+    setText(nextText);
+    if (error) {
+      setError('');
+    }
+  }, [error]);
+
+  return (
+    <Accordion defaultExpanded>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="subtitle1">
+          {t('processing.urlRules.title', 'URL specific build config rules')}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{ p: 2 }}>
+        <Paper variant="outlined" sx={{ p: 2, ...hoverCardSx }}>
+          <Stack spacing={1.5} sx={{ opacity: disabled ? 0.6 : 1 }}>
+            <BuildConfigSectionTitle
+              icon={<LinkIcon fontSize="small" color="primary" />}
+              title={t('processing.urlRules.sectionTitle', 'URL-specific rules')}
+            />
+            <Typography variant="body2" color="text.secondary">
+              {t(
+                'processing.urlRules.description',
+                'Define per-URL overrides in JSON. This JSON is evaluated in order and each entry applies to matching URLs.',
+              )}
+            </Typography>
+            <TextField
+              size="small"
+              multiline
+              minRows={10}
+              maxRows={20}
+              value={text}
+              disabled={disabled}
+              onChange={(event) => handleChange(event.target.value)}
+              onBlur={handleBlur}
+              error={Boolean(error)}
+              helperText={error}
+              fullWidth
+              sx={{
+                '& .MuiInputBase-root': {
+                  alignItems: 'stretch',
+                  lineHeight: 1.5,
+                  fontFamily: 'monospace',
+                },
+              }}
+            />
+            <Alert severity="info" sx={{ whiteSpace: 'pre-line' }}>
+              {t(
+                'processing.urlRules.example',
+                `Example:
+[
+  { "key": "default", "matchType": "default", "buildConfig": { "transformConfig": { "tolerance": 0.12 } } },
+  { "key": "russia-coast", "matchType": "regexp", "pattern": "(?i).*russia.*", "buildConfig": { "transformConfig": { "tolerance": 0.3 } }
+]`,
+              )}
+            </Alert>
+          </Stack>
+        </Paper>
+      </AccordionDetails>
+    </Accordion>
+  );
+};


### PR DESCRIPTION
## Summary
- Adds Step4 UI support for URL-specific Shape build config rules with user-editable JSON in a dedicated accordion.
- Adds shared types for URL rule config:
  - `ShapeBuildUrlRule`
  - `ShapeUrlMatchType`
  - `ShapeBuildUrlConfigPatch`
- Persists `urlBuildConfigRules` through the build config draft path (`createBuildStartDraftData`).
- Adds unit test coverage for rule persistence.
- Updates `TASKS.md` Doing/運用ログ for this issue and branch.

Refs #466
