### PR TITLE
fix: sanitize comlink objects for reactive boundaries

### DIFF
--- a/app/src/contexts/WorkerProvider.tsx
+++ b/app/src/contexts/WorkerProvider.tsx
@@ -47,6 +47,7 @@ import {
 import type { WorkerInitializationProgress } from '~/worker-runtime/WorkerClientProxy';
 import { useWorkerRuntimeProxy } from '~/hooks/useWorkerRuntimeProxy';
 import { bootLog } from '~/utils/bootLog';
+import { sanitizeRemoteForReact } from '~/utils/comlinkSafeProxy';
 import { resetWorkerState } from '~/worker-runtime/WorkerStateStore';
 import {
   getWorkerAPIClientModule,
@@ -401,15 +402,21 @@ export const WorkerProvider = ({
     });
   }, [proxy, proxyState, proxyError]);
 
+  const storageBridgeClientRef = useRef<Remote<BuildWorkerAPI> | null>(null);
+  const safeClient = useMemo(
+    () => (status.client ? sanitizeRemoteForReact(status.client) : null),
+    [status.client]
+  );
+
   useEffect(() => {
-    if (!status.client || !status.isInitialized) return;
+    if (!safeClient || !status.isInitialized) return;
     if (typeof window === 'undefined') return;
     try {
       const token = localStorage.getItem('access_token') || '';
       if (!token || token === lastAuthTokenRef.current) return;
       const rawExpires = localStorage.getItem('token_expires_at');
       const expiresAt = rawExpires ? Number(rawExpires) : undefined;
-      status.client
+      safeClient
         .setAuthToken(token, 'Bearer', Number.isFinite(expiresAt) ? expiresAt : undefined)
         .catch((error: unknown) => {
           logWorkerProviderWarning('Failed to sync worker auth token', error);
@@ -418,15 +425,13 @@ export const WorkerProvider = ({
     } catch (error) {
       logWorkerProviderWarning('Failed to read access_token for worker', error);
     }
-  }, [status.client, status.isInitialized]);
-
-  const storageBridgeClientRef = useRef<Remote<BuildWorkerAPI> | null>(null);
+  }, [safeClient, status.isInitialized]);
 
   useEffect(() => {
-    if (!status.client || !status.isInitialized) return;
+    if (!safeClient || !status.isInitialized) return;
     if (typeof window === 'undefined') return;
-    if (storageBridgeClientRef.current === status.client) return;
-    storageBridgeClientRef.current = status.client;
+    if (storageBridgeClientRef.current === safeClient) return;
+    storageBridgeClientRef.current = safeClient;
     const bridge = Comlink.proxy({
       getItem: async (key: string) => localStorage.getItem(key),
       setItem: async (key: string, value: string) => {
@@ -436,10 +441,10 @@ export const WorkerProvider = ({
         localStorage.removeItem(key);
       },
     });
-    status.client.setUiStorageBridge(bridge).catch((error: unknown) => {
+    safeClient.setUiStorageBridge(bridge).catch((error: unknown) => {
       logWorkerProviderWarning('Failed to register UI storage bridge', error);
     });
-  }, [status.client, status.isInitialized]);
+  }, [safeClient, status.isInitialized]);
 
   const finalizeInitialized = useCallback(async () => {
     try {
@@ -607,11 +612,11 @@ export const WorkerProvider = ({
   }, [bootProgress, resetState, runInitialization, t]);
 
   const getAPI = useCallback((): Remote<BuildWorkerAPI> => {
-    if (!status.client) {
+    if (!safeClient) {
       throw new Error('Worker client not initialized');
     }
-    return status.client;
-  }, [status.client]);
+    return safeClient;
+  }, [safeClient]);
 
   const reset = useCallback(() => {
     bootLog('WorkerProvider reset requested');
@@ -691,9 +696,9 @@ export const WorkerProvider = ({
 
   const contextValue = useMemo<WorkerContextValue>(
     () => ({
-      client: status.client,
+      client: safeClient,
       isInitialized: status.isInitialized,
-      isConnected: Boolean(status.client && status.isInitialized),
+      isConnected: Boolean(safeClient && status.isInitialized),
       initProgress: status.initProgress,
       initMessage: status.initMessage,
       error: status.error,

--- a/app/src/hooks/treeconsole/useCommandProcessorTracker.ts
+++ b/app/src/hooks/treeconsole/useCommandProcessorTracker.ts
@@ -13,6 +13,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useEffect, useRef } from 'react';
 import type { TreeConsoleSSOTEntry } from '~/state/treeconsole.atoms';
 import type { MaybeCP, TreeConsoleState } from './types.js';
+import { sanitizeForComlink } from '~/utils/comlinkSanitizer';
 
 interface Params {
   client: Remote<BuildWorkerAPI> | undefined;
@@ -58,7 +59,8 @@ export function useCommandProcessorTracker({ client, setState, setSSOT }: Params
         subscriptionAPI = await client.getSubscriptionAPI();
         const handler = proxy((event: UndoStateEvent) => {
           if (!isActive) return;
-          const { canUndo, canRedo } = event;
+          const safeEvent = sanitizeForComlink(event);
+          const { canUndo, canRedo } = safeEvent as UndoStateEvent;
           subscriptionEstablishedRef.current = true;
           setState((prev) =>
             prev.canUndo === canUndo && prev.canRedo === canRedo

--- a/app/src/hooks/treeconsole/useTreeConsoleBreadcrumbs.ts
+++ b/app/src/hooks/treeconsole/useTreeConsoleBreadcrumbs.ts
@@ -12,6 +12,7 @@ import type { BreadcrumbNode } from '@hierarchidb/ui-plugin-shell/ui-treeconsole
 import type { Remote } from 'comlink';
 import { proxy as comlinkProxy } from 'comlink';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { sanitizeForComlink } from '~/utils/comlinkSanitizer';
 
 interface Params {
   client: Remote<BuildWorkerAPI> | undefined;
@@ -121,7 +122,7 @@ export function useTreeConsoleBreadcrumbs({
         if (subscriptionAPI) {
           const targetIds = [...ancestors.map((ancestor) => ancestor.id as NodeId), pageTreeNode.id as NodeId];
           const cb = comlinkProxy((event: unknown) => {
-            const ev = event as { nodeId?: string; node?: TreeNode };
+            const ev = sanitizeForComlink(event) as { nodeId?: string; node?: TreeNode };
             const changedId = ev?.nodeId || ev?.node?.id;
             if (!changedId) return;
             setBreadcrumbItems((prev) =>

--- a/app/src/hooks/treeconsole/useTreeConsoleSubscription.ts
+++ b/app/src/hooks/treeconsole/useTreeConsoleSubscription.ts
@@ -13,6 +13,7 @@ import type { Remote } from 'comlink';
 import { proxy as comlinkProxy } from 'comlink';
 import { useCallback, useEffect, useRef } from 'react';
 import { Subscriptions } from '~/hooks/SubscriptionServices';
+import { sanitizeForComlink } from '~/utils/comlinkSanitizer';
 import type { TreeConsoleSSOTEntry } from '~/state/treeconsole.atoms';
 import { buildVisibleRows, removeNodeAndDescendants } from '~/state/treeconsole.derive';
 import type { LoadChildrenOf } from './types.js';
@@ -97,12 +98,13 @@ export function useTreeConsoleSubscription({
 
       const cb = comlinkProxy((event: unknown) => {
         try {
+          const safeEvent = sanitizeForComlink(event);
           if (
             typeof import.meta !== 'undefined' &&
             (import.meta as unknown as { env?: Record<string, string> }).env
               ?.VITE_SUBSCRIPTION_DEBUG === '1'
           ) {
-            console.log('[Subscription][page] event', event);
+            console.log('[Subscription][page] event', safeEvent);
           }
 
           type Ev = {
@@ -113,7 +115,7 @@ export function useTreeConsoleSubscription({
             previousParentNodeId?: string;
           };
 
-          const ev = event as Ev;
+          const ev = safeEvent as Ev;
           const index = nodeIndexRef.current.clone();
 
           if (ev.type === 'created' && ev.node) {

--- a/app/src/router/pages/tree/console/hooks/useTreeConsoleArchiveWatcher.ts
+++ b/app/src/router/pages/tree/console/hooks/useTreeConsoleArchiveWatcher.ts
@@ -5,6 +5,7 @@ import { proxy as comlinkProxy } from 'comlink';
 import { useEffect, useRef, useState } from 'react';
 import { type SubscriptionCallback, Subscriptions } from '~/hooks/SubscriptionServices';
 import { isSubscriptionDebug, logIntegrationWarning } from '../treeConsoleIntegrationUtils.js';
+import { sanitizeForComlink } from '~/utils/comlinkSanitizer';
 
 export type ArchiveWatcherState = {
   hasArchiveItems: boolean;
@@ -85,8 +86,9 @@ export function useTreeConsoleArchiveWatcher({
         requestRefresh();
 
         const cb = comlinkProxy((ev: unknown) => {
+          const safeEvent = sanitizeForComlink(ev);
           if (isSubscriptionDebug()) {
-            console.log('[Subscription][archive] event', ev);
+            console.log('[Subscription][archive] event', safeEvent);
           }
           requestRefresh();
         });

--- a/app/src/router/pages/tree/console/hooks/useTreeNodeInfoPanel.ts
+++ b/app/src/router/pages/tree/console/hooks/useTreeNodeInfoPanel.ts
@@ -16,6 +16,7 @@ import { useWorker } from '~/contexts/WorkerProvider';
 import { Subscriptions } from '~/hooks/SubscriptionServices';
 import { useTreeConsoleSSOT } from '~/state/treeconsole.atoms';
 import { convertTreeNodeToTreeNodeData } from '~/utils/treeNodeConverter';
+import { sanitizeForComlink } from '~/utils/comlinkSanitizer';
 import {
   collectBuildUrlsForFolder,
   resolveBuildTargetForNode,
@@ -222,8 +223,9 @@ export function useTreeNodeInfoPanel({
     let subId: string | null = null;
 
     const cb = comlinkProxy((ev: unknown) => {
+      const safeEvent = sanitizeForComlink(ev);
       if (disposed) return;
-      const event = ev as { nodeId?: NodeId; node?: TreeNode } | null;
+      const event = safeEvent as { nodeId?: NodeId; node?: TreeNode } | null;
       if (event?.node) {
         if (event.node.id === node.id) {
           setCurrentNode(event.node);

--- a/app/src/utils/comlinkSafeProxy.ts
+++ b/app/src/utils/comlinkSafeProxy.ts
@@ -1,0 +1,81 @@
+const symbolGuardCache = new WeakMap<object, unknown>();
+const TO_PRIMITIVE = Symbol.toPrimitive;
+const INSPECT = Symbol.for('nodejs.util.inspect.custom');
+const utilInspectSymbol = typeof INSPECT === 'symbol' ? INSPECT : undefined;
+
+const isProxyTarget = (value: unknown): value is object =>
+  typeof value === 'function' || (typeof value === 'object' && value !== null);
+
+export function sanitizeRemoteForReact<T>(client: T): T {
+  if (!isProxyTarget(client)) {
+    return client;
+  }
+
+  const cached = symbolGuardCache.get(client);
+  if (cached) {
+    return cached as T;
+  }
+
+  const sanitizeNestedValue = (value: unknown): unknown => {
+    if (isProxyTarget(value)) {
+      return sanitizeRemoteForReact(value);
+    }
+    return value;
+  };
+
+  const safeClient = new Proxy(client, {
+    get(target, prop, receiver) {
+      if (prop === TO_PRIMITIVE) {
+        return () => '[Comlink Remote Proxy]';
+      }
+      if (prop === 'toString') {
+        return () => '[object ComlinkRemote]';
+      }
+      if (prop === 'valueOf') {
+        return () => '[object ComlinkRemote]';
+      }
+      if (utilInspectSymbol && prop === utilInspectSymbol) {
+        return () => '[object ComlinkRemote]';
+      }
+      if (typeof prop === 'symbol') {
+        return undefined;
+      }
+      return sanitizeNestedValue(Reflect.get(target, prop, receiver)) as unknown;
+    },
+    has(target, prop) {
+      if (typeof prop === 'symbol') {
+        return false;
+      }
+      return Reflect.has(target, prop);
+    },
+    ownKeys(target) {
+      return Reflect.ownKeys(target).filter((prop) => typeof prop !== 'symbol');
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (typeof prop === 'symbol') {
+        return undefined;
+      }
+      const descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (!descriptor) return undefined;
+      if ('value' in descriptor && isProxyTarget(descriptor.value)) {
+        return {
+          ...descriptor,
+          value: sanitizeNestedValue(descriptor.value),
+        };
+      }
+      return descriptor;
+    },
+    set(target, prop, value, receiver) {
+      if (typeof prop === 'symbol') {
+        return true;
+      }
+      if (isProxyTarget(value)) {
+        return Reflect.set(target, prop, sanitizeNestedValue(value), receiver);
+      }
+      return Reflect.set(target, prop, value, receiver);
+    },
+  });
+
+  symbolGuardCache.set(client, safeClient);
+  return safeClient as T;
+}

--- a/app/src/utils/comlinkSanitizer.ts
+++ b/app/src/utils/comlinkSanitizer.ts
@@ -1,0 +1,54 @@
+export const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, unknown>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    const list = value as unknown[];
+    return list.map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value as object)) {
+      return seen.get(value as object) as T;
+    }
+    const anyValue = value as Record<string, unknown>;
+    const safe = {} as Record<string, unknown>;
+    seen.set(value as object, safe);
+
+    for (const key of Object.keys(anyValue)) {
+      const rawValue = anyValue[key];
+      if (typeof rawValue === 'function' || typeof rawValue === 'symbol') {
+        continue;
+      }
+      safe[key] = sanitizeForComlink(rawValue, seen);
+    }
+    return safe as T;
+  }
+
+  return value;
+};

--- a/app/src/worker-runtime/WorkerAPIClient.ts
+++ b/app/src/worker-runtime/WorkerAPIClient.ts
@@ -4,6 +4,7 @@
 
 import type { BuildWorkerAPI } from '~/types/worker-api';
 import type { Remote } from 'comlink';
+import { sanitizeRemoteForReact } from '~/utils/comlinkSafeProxy';
 
 // Create a type that matches the shared contract
 type WorkerInterface = Remote<BuildWorkerAPI>;
@@ -12,6 +13,7 @@ let workerInstance: WorkerInterface | null = null;
 let state: 'uninitialized' | 'initializing' | 'initialized' | 'error' = 'uninitialized';
 let initializationPromise: Promise<void> | null = null;
 let verified = false;
+let sanitizedWorkerInstance: Remote<BuildWorkerAPI> | null = null;
 
 async function initialize(): Promise<void> {
   switch (state) {
@@ -46,8 +48,10 @@ async function doInitialize(): Promise<void> {
   try {
     const { getWorkerClient, isWorkerInitCompleted } = await loadClientModule();
     const remoteWorker = await getWorkerClient();
+    const safeRemoteWorker = sanitizeRemoteForReact(remoteWorker);
 
     workerInstance = remoteWorker;
+    sanitizedWorkerInstance = safeRemoteWorker;
 
     try {
       const initComplete = Boolean(isWorkerInitCompleted?.());
@@ -66,6 +70,7 @@ async function doInitialize(): Promise<void> {
     }
   } catch (error) {
     workerInstance = null;
+    sanitizedWorkerInstance = null;
     throw error;
   }
 }
@@ -77,7 +82,12 @@ function getSingleton(): WorkerInterface {
   if (state !== 'initialized' && import.meta?.env?.VITE_WORKERAPI_LOG === '1') {
     console.warn('[WorkerAPIClient] getSingleton called before initialization');
   }
-  return workerInstance;
+  if (sanitizedWorkerInstance) {
+    return sanitizedWorkerInstance;
+  }
+  const safeWorker = sanitizeRemoteForReact(workerInstance);
+  sanitizedWorkerInstance = safeWorker;
+  return safeWorker;
 }
 
 async function getOrInit(): Promise<WorkerInterface> {
@@ -99,6 +109,7 @@ function reset(): void {
     }
   }
   workerInstance = null;
+  sanitizedWorkerInstance = null;
   state = 'uninitialized';
   initializationPromise = null;
   verified = false;

--- a/app/src/worker-runtime/workerBootstrap.ts
+++ b/app/src/worker-runtime/workerBootstrap.ts
@@ -108,7 +108,55 @@ const setHeapContext = (context: HeapPressureContext | null) => {
 };
 
 const toComlinkProxy = <T extends object>(Comlink: typeof import('comlink'), value: T): T =>
-  Comlink.proxy(value) as unknown as T;
+  Comlink.proxy(value) as T;
+
+const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, unknown>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (seen.has(value as object)) {
+    return seen.get(value as object) as T;
+  }
+
+  const safe = {} as Record<string, unknown>;
+  seen.set(value as object, safe);
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    const rawValue = (value as Record<string, unknown>)[key];
+    if (typeof rawValue === 'function' || typeof rawValue === 'symbol') {
+      continue;
+    }
+    safe[key] = sanitizeForComlink(rawValue, seen);
+  }
+  return safe as T;
+};
 
 const resolveBuildTaskProvider = (mod: unknown): BuildTaskProvider | null => {
   if (!mod || (typeof mod !== 'object' && typeof mod !== 'function')) return null;
@@ -774,7 +822,10 @@ export const ensureRuntimeWorkerBootstrap = async (options: {
           if (!buildApi.subscribeToProgress) {
             return () => {};
           }
-          const unsubscribe = buildApi.subscribeToProgress(nodeId, callback);
+          const wrappedCallback = (event: BuildProgressEvent): void => {
+            callback(sanitizeForComlink(event));
+          };
+          const unsubscribe = buildApi.subscribeToProgress(nodeId, wrappedCallback);
           return toComlinkProxy(Comlink, unsubscribe);
         };
 
@@ -787,7 +838,10 @@ export const ensureRuntimeWorkerBootstrap = async (options: {
           if (!buildApi.subscribeToTasks) {
             return () => {};
           }
-          const unsubscribe = buildApi.subscribeToTasks(nodeId, callback);
+          const wrappedCallback = (event: BuildTaskUpdateEvent): void => {
+            callback(sanitizeForComlink(event));
+          };
+          const unsubscribe = buildApi.subscribeToTasks(nodeId, wrappedCallback);
           return toComlinkProxy(Comlink, unsubscribe);
         };
 
@@ -868,9 +922,12 @@ export const ensureRuntimeWorkerBootstrap = async (options: {
           subscribeHeapPressure: async (
             callback: (event: HeapPressureEvent) => void
           ): Promise<() => void> => {
-            heapListeners.add(callback);
+            const wrappedCallback = (event: HeapPressureEvent): void => {
+              callback(sanitizeForComlink(event));
+            };
+            heapListeners.add(wrappedCallback);
             return toComlinkProxy(Comlink, () => {
-              heapListeners.delete(callback);
+              heapListeners.delete(wrappedCallback);
             });
           },
           getBuildTasks,
@@ -913,7 +970,7 @@ export const ensureRuntimeWorkerBootstrap = async (options: {
             const dispatch = async () => {
               try {
                 const sessions = await getRuntimeRecordsForShape(filter);
-                callback(sessions);
+                callback(sanitizeForComlink(sessions));
               } catch (error) {
                 const msg = error instanceof Error ? error.message : String(error);
                 console.warn('[worker bootstrap] build runtime refresh failed:', msg);
@@ -926,7 +983,7 @@ export const ensureRuntimeWorkerBootstrap = async (options: {
               error: (error) => {
                 const msg = error instanceof Error ? error.message : String(error);
                 console.warn('[worker bootstrap] build runtime subscription failed:', msg);
-                callback([]);
+                callback(sanitizeForComlink([]));
               },
             });
             const broadcastUnsubscribe = subscribeToBuildSessionBroadcast(() => {
@@ -968,18 +1025,18 @@ export const ensureRuntimeWorkerBootstrap = async (options: {
             const observable = liveQuery(() => queryAPI.listBuildSessionRecordsByStatus(normalized));
             const subscription = observable.subscribe({
               next: (sessions) => {
-                callback(sessions);
+                callback(sanitizeForComlink(sessions));
               },
               error: (error) => {
                 const msg = error instanceof Error ? error.message : String(error);
                 console.warn('[worker bootstrap] build session subscription failed:', msg);
-                callback([]);
+                callback(sanitizeForComlink([]));
               },
             });
             const dispatchSessions = async () => {
               try {
                 const sessions = await queryAPI.listBuildSessionRecordsByStatus(normalized);
-                callback(sessions);
+                callback(sanitizeForComlink(sessions));
               } catch (error) {
                 const msg = error instanceof Error ? error.message : String(error);
                 console.warn('[worker bootstrap] build session refresh failed:', msg);

--- a/packages/runtime-worker/src/services/TreeSubscriptionService.ts
+++ b/packages/runtime-worker/src/services/TreeSubscriptionService.ts
@@ -30,6 +30,60 @@ import { type SubscriptionInfo, SubscriptionRegistry } from './SubscriptionRegis
 import { TreeQueryService } from './TreeQueryService.js';
 import { TreeSearchService } from './TreeSearchService.js';
 
+const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, unknown>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    const list = value as unknown[];
+    return list.map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value as object)) {
+      return seen.get(value as object) as T;
+    }
+    const source = value as Record<string, unknown>;
+    const safe = {} as Record<string, unknown>;
+    seen.set(value as object, safe);
+    for (const key of Object.keys(source)) {
+      const raw = source[key];
+      if (typeof raw === 'function' || typeof raw === 'symbol') {
+        continue;
+      }
+      safe[key] = sanitizeForComlink(raw, seen);
+    }
+    return safe as T;
+  }
+
+  return value;
+};
+
 /**
  * TreeSubscriptionService - Implements TreeSubscriptionAPI
  * Provides real-time subscription functionality for console structure changes
@@ -780,7 +834,7 @@ export class TreeSubscriptionService {
           hasNode: Boolean(event.node),
         });
       }
-      callback(event);
+      callback(sanitizeForComlink(event));
     };
 
     const subscription = stream.subscribe(instrumentedCallback);
@@ -806,7 +860,7 @@ export class TreeSubscriptionService {
         const node = await this.getNodeFromDB(nodeId);
         if (node) {
           const initialEvent = this.createTreeNodeEvent('updated', node);
-          callback(initialEvent);
+          callback(sanitizeForComlink(initialEvent));
         }
       } catch (error) {
         console.warn(`Failed to get initial value for node ${nodeId}:`, error);
@@ -849,7 +903,10 @@ export class TreeSubscriptionService {
       rxFilter((event): event is TreeNodeEvent => event !== null)
     ) as Observable<TreeNodeEvent>;
 
-    const subscription = stream.subscribe(callback);
+    const safeCallback = (event: TreeNodeEvent) => {
+      callback(sanitizeForComlink(event));
+    };
+    const subscription = stream.subscribe(safeCallback);
 
     // Store the subscription for cleanup
     subscriptionInfo.subscription = subscription;
@@ -861,13 +918,15 @@ export class TreeSubscriptionService {
         });
         const timestamp = Date.now() as Timestamp;
         for (const node of nodes) {
-          callback({
-            type: 'updated',
-            nodeId: node.id,
-            node,
-            parentId: node.parentId,
-            timestamp,
-          });
+          callback(
+            sanitizeForComlink({
+              type: 'updated',
+              nodeId: node.id,
+              node,
+              parentId: node.parentId,
+              timestamp,
+            })
+          );
         }
       } catch (error) {
         console.warn('[TreeSubscriptionService] Failed to deliver prefetch snapshot', error);
@@ -911,7 +970,10 @@ export class TreeSubscriptionService {
       rxFilter((event): event is TreeNodeEvent => event !== null)
     ) as Observable<TreeNodeEvent>;
 
-    const subscription = stream.subscribe(callback);
+    const safeCallback = (event: TreeNodeEvent) => {
+      callback(sanitizeForComlink(event));
+    };
+    const subscription = stream.subscribe(safeCallback);
     subscriptionInfo.subscription = subscription;
 
     if (options?.prefetch?.depth && options.prefetch.depth > 0) {
@@ -921,13 +983,15 @@ export class TreeSubscriptionService {
         });
         const timestamp = Date.now() as Timestamp;
         for (const node of nodes) {
-          callback({
-            type: 'updated',
-            nodeId: node.id,
-            node,
-            parentId: node.parentId,
-            timestamp,
-          });
+          callback(
+            sanitizeForComlink({
+              type: 'updated',
+              nodeId: node.id,
+              node,
+              parentId: node.parentId,
+              timestamp,
+            })
+          );
         }
       } catch (error) {
         console.warn('[TreeSubscriptionService] Failed to deliver prefetch snapshot', error);
@@ -954,7 +1018,7 @@ export class TreeSubscriptionService {
     });
 
     try {
-      callback(this.latestUndoState);
+      callback(sanitizeForComlink(this.latestUndoState));
     } catch (error) {
       console.warn('[TreeSubscriptionService] undo-atoms callback threw', error);
     }
@@ -1087,7 +1151,7 @@ export class TreeSubscriptionService {
     this.latestUndoState = event;
     for (const [subscriptionId, callback] of this.undoStateSubscriptions.entries()) {
       try {
-        callback(event);
+        callback(sanitizeForComlink(event));
       } catch (error) {
         console.warn('[TreeSubscriptionService] undo-atoms callback threw', error);
       }

--- a/packages/ui/batch/src/hooks/useBuildSessionSnapshots.ts
+++ b/packages/ui/batch/src/hooks/useBuildSessionSnapshots.ts
@@ -5,6 +5,7 @@ import type { WorkerAPI } from '@hierarchidb/worker-api';
 import { proxy } from 'comlink';
 import type { Remote } from 'comlink';
 import { useWorkerQueryAPI } from './useWorkerQueryAPI.js';
+import { sanitizeForComlink } from '../utils/comlinkSanitizer.js';
 
 export type BuildSessionSnapshot = {
   nodeId: NodeId;
@@ -93,7 +94,8 @@ class SharedBuildSessionSubscription {
         this.nodeType,
         { statuses: IN_PROGRESS_STATUSES },
         proxy((incoming: BuildSessionRuntimeRecord[]) => {
-          this.handleIncoming(incoming);
+          const safeIncoming = sanitizeForComlink(incoming);
+          this.handleIncoming(safeIncoming);
         })
       );
       if (this.disposed) {

--- a/packages/ui/batch/src/utils/comlinkSanitizer.ts
+++ b/packages/ui/batch/src/utils/comlinkSanitizer.ts
@@ -1,0 +1,50 @@
+export const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, unknown>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (seen.has(value as object)) {
+    return seen.get(value as object) as T;
+  }
+
+  const safe = {} as Record<string, unknown>;
+  seen.set(value as object, safe);
+
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    const rawValue = (value as Record<string, unknown>)[key];
+    if (typeof rawValue === 'function' || typeof rawValue === 'symbol') {
+      continue;
+    }
+    safe[key] = sanitizeForComlink(rawValue, seen);
+  }
+
+  return safe as T;
+};

--- a/packages/ui/treeconsole/base/src/adapters/subscriptions/TreeObservableAdapter.ts
+++ b/packages/ui/treeconsole/base/src/adapters/subscriptions/TreeObservableAdapter.ts
@@ -12,6 +12,7 @@ import type { TreeNodeEvent } from '@hierarchidb/tree-api';
 import type { AdapterContext, UnsubscribeFunction } from '~/types/index';
 import { TreeConsoleAdapterError } from '~/types/index';
 import { createCommand } from '~/adapters/utils';
+import { sanitizeForComlink } from './comlinkSanitizer';
 
 type TreeNodeEventCallback = (event: TreeNodeEvent) => void;
 
@@ -57,7 +58,10 @@ export class TreeObservableAdapter<T> {
         }, { groupId: context.groupId, sourceViewId: context.viewId });
 
         const observable = await maybeObserve(envelope);
-        const sub = observable.subscribe((event: TreeNodeEvent) => setTimeout(() => callback(event), 0));
+        const sub = observable.subscribe((event: TreeNodeEvent) => {
+          const safeEvent = sanitizeForComlink(event);
+          setTimeout(() => callback(safeEvent), 0);
+        });
 
         const wrappedUnsubscribe = () => {
           try { sub.unsubscribe?.(); } finally { this.subscriptions.delete(internalSubscriptionId); }
@@ -74,7 +78,8 @@ export class TreeObservableAdapter<T> {
           nodeId: String(e.nodeId),
           hasNode: Boolean(e.node),
         });
-        setTimeout(() => callback(e), 0);
+        const safeEvent = sanitizeForComlink(e);
+        setTimeout(() => callback(safeEvent), 0);
       });
       const prefetchDepth = context.prefetchDepth ?? 2;
       const subscriptionId = await subscriptionAPI.subscribeSubtree(
@@ -121,7 +126,10 @@ export class TreeObservableAdapter<T> {
     try {
       const subscriptionAPI = await this.workerAPI.getSubscriptionAPI();
       const internalSubscriptionId = `node_${nodeId}_${context.viewId}`;
-      const proxied = Comlink.proxy((e: TreeNodeEvent) => setTimeout(() => callback(e), 0));
+      const proxied = Comlink.proxy((e: TreeNodeEvent) => {
+        const safeEvent = sanitizeForComlink(e);
+        setTimeout(() => callback(safeEvent), 0);
+      });
       const subscriptionId = await subscriptionAPI.subscribeNode(nodeId, proxied);
       this.proxiedCallbacks.set(internalSubscriptionId, proxied);
       const wrappedUnsubscribe = async () => {
@@ -156,7 +164,10 @@ export class TreeObservableAdapter<T> {
     try {
       const subscriptionAPI = await this.workerAPI.getSubscriptionAPI();
       const internalSubscriptionId = `children_${parentId}_${context.viewId}`;
-      const proxied = Comlink.proxy((e: TreeNodeEvent) => setTimeout(() => callback(e), 0));
+      const proxied = Comlink.proxy((e: TreeNodeEvent) => {
+        const safeEvent = sanitizeForComlink(e);
+        setTimeout(() => callback(safeEvent), 0);
+      });
       // Subscribe to subtree; consumer treats it as children-only
       const subscriptionId = await subscriptionAPI.subscribeSubtree(parentId, proxied);
       this.proxiedCallbacks.set(internalSubscriptionId, proxied);

--- a/packages/ui/treeconsole/base/src/adapters/subscriptions/comlinkSanitizer.ts
+++ b/packages/ui/treeconsole/base/src/adapters/subscriptions/comlinkSanitizer.ts
@@ -1,0 +1,54 @@
+export const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, unknown>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    const list = value as unknown[];
+    return list.map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value as object)) {
+      return seen.get(value as object) as T;
+    }
+    const anyValue = value as Record<string, unknown>;
+    const safe = {} as Record<string, unknown>;
+    seen.set(value as object, safe);
+
+    for (const key of Object.keys(anyValue)) {
+      const rawValue = anyValue[key];
+      if (typeof rawValue === 'function' || typeof rawValue === 'symbol') {
+        continue;
+      }
+      safe[key] = sanitizeForComlink(rawValue, seen);
+    }
+    return safe as T;
+  }
+
+  return value;
+};

--- a/packages/ui/treeconsole/base/src/components/TreeTable/orchestrator/SubscriptionOrchestrator.ts
+++ b/packages/ui/treeconsole/base/src/components/TreeTable/orchestrator/SubscriptionOrchestrator.ts
@@ -4,6 +4,7 @@ import type { NodeId } from '@hierarchidb/core-types';
 import type { TreeNode, TreeNodeEvent } from '@hierarchidb/tree-api';
 import type { SubTreeChanges } from '~/components/TreeTable/state/features/subscription.atoms';
 import { coalesceBatches } from './mergeUtils.js';
+import { sanitizeForComlink } from '../../../adapters/subscriptions/comlinkSanitizer.js';
 import type { WorkerAPI } from '@hierarchidb/worker-api';
 import {
   lastUpdateTimestampAtom,
@@ -183,24 +184,28 @@ export function useSubscriptionOrchestrator<T>(workerAPI: WorkerAPI<T>): Subscri
         //  WorkerAPI
         const subscriptionAPI = await workerAPI.getSubscriptionAPI();
         const proxied = (await import('comlink')).proxy((event: TreeNodeEvent) => {
+          const safeEvent = sanitizeForComlink(event);
+          const safeNode = (safeEvent.node as Record<string, unknown> | undefined) ?? undefined;
           console.log('[TreeConsole][Subscription] event received', {
-            type: event.type,
-            nodeId: event.nodeId,
-            hasNode: Boolean(event.node),
-            keys: event.node ? Object.keys(event.node) : [],
+            type: safeEvent.type,
+            nodeId: safeEvent.nodeId,
+            hasNode: Boolean(safeNode),
+            keys: safeNode ? Object.keys(safeNode) : [],
           });
           // Map a single node event to our local SubTreeChanges batch form
           const batch: SubTreeChanges = (() => {
-            switch (event.type) {
+            switch (safeEvent.type) {
               case 'created':
-                return { added: [Object.assign({ id: event.nodeId }, event.node || {})] };
+                return {
+                  added: [Object.assign({ id: safeEvent.nodeId }, safeNode || {})],
+                };
               case 'updated': {
-                const payload = (event.node || {}) as Record<string, unknown>;
-                const base = { nodeId: event.nodeId as string, changes: payload };
+                const payload = safeNode || {};
+                const base = { nodeId: safeEvent.nodeId as string, changes: payload };
                 // Treat prefetch snapshot events (delivered as "updated" with node payload)
                 // as additions when we have no existing row.
                 const added = Object.keys(payload).length > 0
-                  ? [Object.assign({ id: event.nodeId }, payload)]
+                  ? [Object.assign({ id: safeEvent.nodeId }, payload)]
                   : undefined;
                 return {
                   updated: [base],
@@ -208,9 +213,17 @@ export function useSubscriptionOrchestrator<T>(workerAPI: WorkerAPI<T>): Subscri
                 };
               }
               case 'deleted':
-                return { removed: [event.nodeId as string] };
+                return { removed: [safeEvent.nodeId as string] };
               case 'moved':
-                return { moved: [{ nodeId: event.nodeId as string, oldParentId: event.previousParentNodeId as string | undefined, newParentId: event.parentId as string, oldIndex: -1, newIndex: -1 }] };
+                return {
+                  moved: [{
+                    nodeId: safeEvent.nodeId as string,
+                    oldParentId: safeEvent.previousParentNodeId as string | undefined,
+                    newParentId: safeEvent.parentId as string,
+                    oldIndex: -1,
+                    newIndex: -1,
+                  }],
+                };
               default:
                 return {};
             }

--- a/packages/ui/worker-client/src/events/comlinkEventBridge.ts
+++ b/packages/ui/worker-client/src/events/comlinkEventBridge.ts
@@ -1,5 +1,61 @@
 import { proxy } from 'comlink';
 
+const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, unknown>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    const list = value as unknown[];
+    return list.map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value as object)) {
+      return seen.get(value as object) as T;
+    }
+    const anyValue = value as Record<string, unknown>;
+    const safe = {} as Record<string, unknown>;
+    seen.set(value as object, safe);
+
+    for (const key of Object.keys(anyValue)) {
+      const rawValue = anyValue[key];
+      if (typeof rawValue === 'function' || typeof rawValue === 'symbol') {
+        continue;
+      }
+      safe[key] = sanitizeForComlink(rawValue, seen);
+    }
+
+    return safe as T;
+  }
+
+  return value;
+};
+
 export type EventListener<TEvent> = (event: TEvent) => void;
 export type RemoteEventListener<TEvent> = EventListener<TEvent>;
 
@@ -37,12 +93,12 @@ export function createComlinkEventBridge<
   return {
     createUiProxy(listener: EventListener<TUiEvent>): RemoteEventListener<TRuntimeEvent> {
       return proxy((runtimeEvent: TRuntimeEvent) => {
-        listener(toUi(runtimeEvent));
+        listener(toUi(sanitizeForComlink(runtimeEvent)));
       });
     },
     toRuntimeListener(listener: RemoteEventListener<TRuntimeEvent>): EventListener<TWorkerEvent> {
       return (workerEvent: TWorkerEvent) => {
-        listener(toRuntime(workerEvent));
+        listener(toRuntime(sanitizeForComlink(workerEvent)));
       };
     },
   };

--- a/packages/ui/worker-client/src/workerBridge.ts
+++ b/packages/ui/worker-client/src/workerBridge.ts
@@ -72,6 +72,62 @@ type WorkerClientRefLike = {
   getAPI: () => Remote<WorkerApi>;
 };
 
+const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, object>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    const array = value as unknown[];
+    return array.map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value as object)) {
+      return seen.get(value as object) as T;
+    }
+    const anyObject = value as Record<string, unknown>;
+    const safe = {} as Record<string, unknown>;
+    seen.set(value as object, safe);
+
+    for (const key of Object.keys(anyObject)) {
+      const rawValue = anyObject[key];
+      if (typeof rawValue === 'function' || typeof rawValue === 'symbol') {
+        continue;
+      }
+      safe[key] = sanitizeForComlink(rawValue, seen);
+    }
+
+    return safe as T;
+  }
+
+  return value;
+};
+
 let injectedRef: WorkerClientRefLike | null = null;
 
 function resolveWorkerClientRef(): WorkerClientRefLike {
@@ -151,7 +207,9 @@ class WorkerBridgeImpl implements BuildWorkerBridge {
     cb: (event: BuildTaskUpdateEvent) => void
   ): Promise<() => void> {
     const api = await ensureWorkerAPI();
-    const unsubscribe = await api.subscribeBuildTasks(nodeType, nodeId, proxy(cb));
+    const unsubscribe = await api.subscribeBuildTasks(nodeType, nodeId, proxy((event) => {
+      cb(sanitizeForComlink(event));
+    }));
     return () => {
       try {
         unsubscribe();
@@ -183,7 +241,9 @@ class WorkerBridgeImpl implements BuildWorkerBridge {
     cb: (sessions: BuildSessionRuntimeRecord[]) => void
   ): Promise<() => void> {
     const api = await ensureWorkerAPI();
-    const unsubscribe = await api.subscribeBuildSessionRuntimes(nodeType, filter, proxy(cb));
+    const unsubscribe = await api.subscribeBuildSessionRuntimes(nodeType, filter, proxy((sessions) => {
+      cb(sanitizeForComlink(sessions));
+    }));
     return () => {
       try {
         unsubscribe();
@@ -253,7 +313,9 @@ class WorkerBridgeImpl implements BuildWorkerBridge {
     cb: (event: BuildProgressEvent) => void
   ): Promise<() => void> {
     const api = await ensureWorkerAPI();
-    const unsubscribe = await api.subscribeBuildProgress(nodeType, nodeId, proxy(cb));
+    const unsubscribe = await api.subscribeBuildProgress(nodeType, nodeId, proxy((event) => {
+      cb(sanitizeForComlink(event));
+    }));
     return () => {
       try {
         unsubscribe();
@@ -265,7 +327,9 @@ class WorkerBridgeImpl implements BuildWorkerBridge {
 
   async subscribeHeapPressure(cb: (event: HeapPressureEvent) => void): Promise<() => void> {
     const api = await ensureWorkerAPI();
-    const unsubscribe = await api.subscribeHeapPressure(proxy(cb));
+    const unsubscribe = await api.subscribeHeapPressure(proxy((event) => {
+      cb(sanitizeForComlink(event));
+    }));
     return () => {
       try {
         unsubscribe();

--- a/plugins/location-plugin/src/ui/hooks/useIdeGsmImportOnEntry.ts
+++ b/plugins/location-plugin/src/ui/hooks/useIdeGsmImportOnEntry.ts
@@ -19,6 +19,57 @@ type FailedImportRecord = {
 };
 const lastFailedByNode = new Map<string, FailedImportRecord>();
 
+const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, unknown>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (seen.has(value as object)) {
+    return seen.get(value as object) as T;
+  }
+
+  const safe = {} as Record<string, unknown>;
+  seen.set(value as object, safe);
+
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    const rawValue = (value as Record<string, unknown>)[key];
+    if (typeof rawValue === 'function' || typeof rawValue === 'symbol') {
+      continue;
+    }
+    safe[key] = sanitizeForComlink(rawValue, seen);
+  }
+
+  return safe as T;
+};
+
 export const useIdeGsmImportOnEntry = ({
   draft,
   nodeId,
@@ -154,14 +205,15 @@ export const useIdeGsmImportOnEntry = ({
               mode: 'upsert',
             },
             proxy((progress: IdeGsmImportProgress) => {
+              const safeProgress = sanitizeForComlink(progress);
               console.info(debugPrefix, 'progress', {
                 nodeId,
-                phase: progress.phase,
-                processed: progress.processed,
-                total: progress.total,
-                chunk: progress.chunk,
+                phase: safeProgress.phase,
+                processed: safeProgress.processed,
+                total: safeProgress.total,
+                chunk: safeProgress.chunk,
               });
-              updateIdeGsmProgress(nodeId, progress);
+              updateIdeGsmProgress(nodeId, safeProgress);
             }),
           );
           console.info(debugPrefix, 'import-result', { nodeId, tabularSourceId: sourceId, total: result.total });

--- a/plugins/route-plugin/src/ui/components/steps/useRouteBuildSessionLifecycle.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRouteBuildSessionLifecycle.ts
@@ -27,6 +27,57 @@ export type RouteBuildSessionTransitionPhase =
   | 'vt-stage'
   | 'finalizing';
 
+const sanitizeForComlink = <T>(value: T, seen = new WeakMap<object, unknown>()): T => {
+  if (typeof value === 'bigint') {
+    return value.toString() as T;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? undefined,
+    } as T;
+  }
+
+  if (value instanceof Map) {
+    return Array.from(value.values()).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map((entry) => sanitizeForComlink(entry, seen)) as T;
+  }
+
+  if (seen.has(value as object)) {
+    return seen.get(value as object) as T;
+  }
+
+  const safe = {} as Record<string, unknown>;
+  seen.set(value as object, safe);
+
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    const rawValue = (value as Record<string, unknown>)[key];
+    if (typeof rawValue === 'function' || typeof rawValue === 'symbol') {
+      continue;
+    }
+    safe[key] = sanitizeForComlink(rawValue, seen);
+  }
+
+  return safe as T;
+};
+
 type RouteMutationApi = {
   importIdeGsmRoutes: (
     args: {
@@ -277,8 +328,9 @@ export const useRouteBuildSessionLifecycle = ({
           chunkSize: IDE_GSM_BULK_CHUNK_SIZE,
         },
         proxy((progress: IdeGsmImportProgress) => {
-          setIdeGsmPhase(progress);
-          setOverallProgress(mapIdeGsmProgress(progress));
+          const safeProgress = sanitizeForComlink(progress);
+          setIdeGsmPhase(safeProgress);
+          setOverallProgress(mapIdeGsmProgress(safeProgress));
         }),
       );
 


### PR DESCRIPTION
## Summary
- Fix React runtime errors triggered by Comlink proxies in render/event paths.
- Add `sanitizeRemoteForReact` in app runtime and apply safe proxy usage in worker client initialization and UI entry paths.
- Add shared recursive Comlink-safe sanitization for event payloads at key tree/route/location/runtime-worker/ui-batch boundaries.
- Ensure worker-provided values no longer expose non-primitive conversion traps (`Symbol(Symbol.toPrimitive`) during React rendering.

## Verification
- `pnpm --filter @hierarchidb/app typecheck`
- `pnpm --filter @hierarchidb/runtime-worker typecheck`
- `pnpm --filter @hierarchidb/ui-worker-client typecheck`
- `pnpm --filter @hierarchidb/ui-treeconsole-base typecheck`
- `pnpm --filter @hierarchidb/ui-batch-progress typecheck`
- `pnpm --filter @hierarchidb/location-plugin typecheck`
- `pnpm --filter @hierarchidb/route-plugin typecheck`
