### PR TITLE
Fix template-imported styler/shape nodes buildRequired default

### DIFF
--- a/app/src/features/templates/__tests__/nodeCreateTemplates.unit.test.ts
+++ b/app/src/features/templates/__tests__/nodeCreateTemplates.unit.test.ts
@@ -1,11 +1,65 @@
-import { describe, expect, it } from 'vitest';
+import type { TreeId, NodeId } from '@hierarchidb/core-types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  importNodeTemplateById,
   getNodeCreateTemplateMenuEntries,
   parseNodeCreateAction,
   resolveNodeTemplateExecution,
 } from '../nodeCreateTemplates.ts';
 
 describe('nodeCreateTemplates', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  const buildRequiredShapeTemplateData = {
+    nodes: [
+      {
+        nodeType: 'shape',
+        metadata: {
+          name: 'Shape A',
+          description: 'Imported shape',
+        },
+        draftMetadata: undefined,
+        draftData: {
+          buildConfig: { source: 'template' },
+        },
+      },
+    ],
+  };
+
+  const buildRequiredStylerTemplateData = {
+    nodes: [
+      {
+        nodeType: 'styler',
+        metadata: {
+          name: 'Styler A',
+          description: 'Imported styler',
+        },
+        draftMetadata: undefined,
+        draftData: {
+          source: 'template',
+        },
+      },
+    ],
+  };
+
+  const makeFetchMock = (templateData: unknown) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: {
+        get: () => 'application/json',
+      },
+      json: async () => templateData,
+    });
+
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+    return fetchMock;
+  };
+
   it('parses shape preset create action', () => {
     const parsed = parseNodeCreateAction('create:shape::preset:world-level0');
     expect(parsed).toEqual({
@@ -46,5 +100,177 @@ describe('nodeCreateTemplates', () => {
       'folder::template:population-2023'
     );
     expect(projectsEntries).toHaveLength(1);
+  });
+
+  it('adds buildRequired=true to shape nodes imported from templates when omitted', async () => {
+    const importNodes = vi.fn(async () => undefined);
+    const getImportExportAPI = vi.fn(async () => ({
+      importNodes,
+      detectFileFormat: vi.fn(() => 'json'),
+      importFile: vi.fn(),
+      exportNodes: vi.fn(async () => new Blob()),
+    }));
+    const client = {
+      getImportExportAPI,
+    } as {
+      getImportExportAPI: () => Promise<{
+        importNodes: ReturnType<typeof vi.fn>;
+        detectFileFormat: () => string;
+        importFile: () => Promise<void>;
+        exportNodes: () => Promise<Blob>;
+      }>;
+    };
+
+    const fetchMock = makeFetchMock(buildRequiredShapeTemplateData);
+
+    await importNodeTemplateById({
+      client,
+      treeId: 'r:tree' as TreeId,
+      targetParentId: 'r:parent' as NodeId,
+      templateId: 'population-2023',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(importNodes).toHaveBeenCalledTimes(1);
+    const payload = importNodes.mock.calls[0]?.[0];
+    expect(payload?.data?.nodes?.[0]).toMatchObject({
+      metadata: {
+        buildMetadata: {
+          buildRequired: true,
+        },
+      },
+      draftMetadata: {
+        buildMetadata: {
+          buildRequired: true,
+        },
+      },
+    });
+  });
+
+  it('preserves explicit buildMetadata when template node defines it', async () => {
+    const templateData = {
+      nodes: [
+        {
+          nodeType: 'styler',
+          metadata: {
+            name: 'Styler A',
+            description: 'Imported styler',
+            buildMetadata: {
+              buildRequired: false,
+            },
+          },
+          draftMetadata: {
+            buildMetadata: {
+              buildRequired: false,
+            },
+          },
+        },
+      ],
+    };
+    const importNodes = vi.fn(async () => undefined);
+    const getImportExportAPI = vi.fn(async () => ({
+      importNodes,
+      detectFileFormat: vi.fn(() => 'json'),
+      importFile: vi.fn(),
+      exportNodes: vi.fn(async () => new Blob()),
+    }));
+    const client = {
+      getImportExportAPI,
+    } as {
+      getImportExportAPI: () => Promise<{
+        importNodes: ReturnType<typeof vi.fn>;
+        detectFileFormat: () => string;
+        importFile: () => Promise<void>;
+        exportNodes: () => Promise<Blob>;
+      }>;
+    };
+
+    const fetchMock = makeFetchMock({
+      nodes: [
+        {
+          nodeType: 'styler',
+          metadata: {
+            name: 'Styler A',
+            description: 'Imported styler',
+            buildMetadata: {
+              buildRequired: false,
+            },
+          },
+          draftMetadata: {
+            buildMetadata: {
+              buildRequired: false,
+            },
+          },
+        },
+      ],
+    });
+
+    await importNodeTemplateById({
+      client,
+      treeId: 'r:tree' as TreeId,
+      targetParentId: 'r:parent' as NodeId,
+      templateId: 'population-2023',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(importNodes).toHaveBeenCalledTimes(1);
+    const payload = importNodes.mock.calls[0]?.[0];
+    expect(payload?.data?.nodes?.[0]).toMatchObject({
+      metadata: {
+        buildMetadata: {
+          buildRequired: false,
+        },
+      },
+      draftMetadata: {
+        buildMetadata: {
+          buildRequired: false,
+        },
+      },
+    });
+  });
+
+  it('adds buildRequired=true to styler nodes imported from templates when omitted', async () => {
+    const importNodes = vi.fn(async () => undefined);
+    const getImportExportAPI = vi.fn(async () => ({
+      importNodes,
+      detectFileFormat: vi.fn(() => 'json'),
+      importFile: vi.fn(),
+      exportNodes: vi.fn(async () => new Blob()),
+    }));
+    const client = {
+      getImportExportAPI,
+    } as {
+      getImportExportAPI: () => Promise<{
+        importNodes: ReturnType<typeof vi.fn>;
+        detectFileFormat: () => string;
+        importFile: () => Promise<void>;
+        exportNodes: () => Promise<Blob>;
+      }>;
+    };
+
+    const fetchMock = makeFetchMock(buildRequiredStylerTemplateData);
+
+    await importNodeTemplateById({
+      client,
+      treeId: 'r:tree' as TreeId,
+      targetParentId: 'r:parent' as NodeId,
+      templateId: 'population-2023',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(importNodes).toHaveBeenCalledTimes(1);
+    const payload = importNodes.mock.calls[0]?.[0];
+    expect(payload?.data?.nodes?.[0]).toMatchObject({
+      metadata: {
+        buildMetadata: {
+          buildRequired: true,
+        },
+      },
+      draftMetadata: {
+        buildMetadata: {
+          buildRequired: true,
+        },
+      },
+    });
   });
 });

--- a/app/src/features/templates/nodeCreateTemplates.ts
+++ b/app/src/features/templates/nodeCreateTemplates.ts
@@ -185,14 +185,41 @@ function toImportNode(node: TemplateNodeInput): {
   const normalizedData = normalizeRecord(node.data);
   const data =
     normalizedData && isPeerEntityPayload(normalizedData) ? normalizedData : undefined;
+  const normalizedDraftMetadata = normalizeRecord(node.draftMetadata);
+  const rawBuildMetadata = rawMetadata.buildMetadata;
+  const draftBuildMetadata = normalizedDraftMetadata?.buildMetadata;
+  const hasBuildMetadata = rawBuildMetadata != null || draftBuildMetadata != null;
+  const rawBuildMetadataObject =
+    typeof rawBuildMetadata === 'object' && rawBuildMetadata !== null
+      ? rawBuildMetadata
+      : undefined;
+  const draftBuildMetadataObject =
+    typeof draftBuildMetadata === 'object' && draftBuildMetadata !== null
+      ? draftBuildMetadata
+      : undefined;
+  const requiresBuildMetadataDefault = resolvedNodeType === 'shape' || resolvedNodeType === 'styler';
+  const importedMetadata = {
+    ...rawMetadata,
+    ...(requiresBuildMetadataDefault && !hasBuildMetadata
+      ? { buildMetadata: { buildRequired: true } }
+      : rawBuildMetadataObject
+      ? { buildMetadata: rawBuildMetadataObject }
+      : {}),
+  };
+  const importedDraftMetadata =
+    requiresBuildMetadataDefault && !hasBuildMetadata
+      ? { ...(normalizedDraftMetadata ?? {}), buildMetadata: { buildRequired: true } }
+      : draftBuildMetadataObject
+      ? { ...(normalizedDraftMetadata ?? {}), buildMetadata: draftBuildMetadataObject }
+      : normalizedDraftMetadata;
 
   return {
     name,
     version,
     nodeType: resolvedNodeType,
     description,
-    metadata: rawMetadata,
-    draftMetadata: normalizeRecord(node.draftMetadata),
+    metadata: importedMetadata,
+    draftMetadata: importedDraftMetadata,
     draftData: normalizeRecord(node.draftData) ?? undefined,
     data,
     children: children && children.length > 0 ? children : undefined,


### PR DESCRIPTION
## Summary
- Assign default buildMetadata.buildRequired=true for template-imported shape and styler nodes when missing.
- Keep explicit buildMetadata from template unchanged.
- Add/extend unit tests for template import conversion for shape/styler and explicit buildMetadata preservation.

## Validation
- pnpm --filter @hierarchidb/app exec vitest run src/features/templates/__tests__/nodeCreateTemplates.unit.test.ts