### PR TITLE
refactor(shape): unify step4 accordion summary UI

### DIFF
--- a/packages/plugin-ui-host/src/headless/usePluginDialogController/steps.tsx
+++ b/packages/plugin-ui-host/src/headless/usePluginDialogController/steps.tsx
@@ -71,6 +71,16 @@ const shallowEqualStepData = (a?: StepData, b?: StepData): boolean => {
   return true;
 };
 
+const isStepDataEqual = (a?: StepData, b?: StepData): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+};
+
 const StepAdapterComponent: React.FC<StepAdapterProps> = ({
   cfg,
   mode,
@@ -85,6 +95,11 @@ const StepAdapterComponent: React.FC<StepAdapterProps> = ({
   draftAtom,
 }) => {
   const [slice, setSlice] = useAtom(draftAtom);
+  const currentSliceRef = useRef<StepData>(slice);
+
+  useEffect(() => {
+    currentSliceRef.current = slice;
+  }, [slice]);
 
   useEffect(() => {
     const next = toRecord(stepData) ?? {};
@@ -93,10 +108,12 @@ const StepAdapterComponent: React.FC<StepAdapterProps> = ({
 
   const handleChange = useCallback(
     (patch: TreeNodeMetadata | Partial<PluginDefinedEntity>) => {
-      const current = toRecord(slice) ?? {};
+      const current = toRecord(currentSliceRef.current) ?? {};
       const nextData: Partial<PluginDefinedEntity> = { ...current, ...(patch as object) };
+      if (isStepDataEqual(toRecord(currentSliceRef.current), nextData)) {
+        return;
+      }
       onDataChange?.(nextData);
-      setSlice(nextData);
       const isBasicInfoStep = cfg.id === 'basic-info';
       if (!isBasicInfoStep) {
         const { name, description, tags, ...rest } = nextData as Record<string, unknown>;
@@ -108,8 +125,9 @@ const StepAdapterComponent: React.FC<StepAdapterProps> = ({
           ...(rest as Partial<PluginDefinedEntity>),
         }));
       }
+      setSlice(nextData);
     },
-    [cfg.id, onDataChange, setDraftData, setSlice, slice]
+    [cfg.id, onDataChange, setDraftData, setSlice]
   );
 
   const resolvedData = cfg.id === 'basic-info' ? stepData : (slice ?? {});

--- a/packages/ui/accordion-config/src/build-config/BuildConfigAccordionSummary.tsx
+++ b/packages/ui/accordion-config/src/build-config/BuildConfigAccordionSummary.tsx
@@ -1,0 +1,25 @@
+import { InfoOutlined as InfoOutlinedIcon } from '@mui/icons-material';
+import { Stack, Tooltip, Typography } from '@mui/material';
+import type { ReactNode } from 'react';
+
+type BuildConfigAccordionSummaryProps = {
+  icon: ReactNode;
+  title: string;
+  info: string;
+};
+
+export const BuildConfigAccordionSummary: React.FC<BuildConfigAccordionSummaryProps> = ({
+  icon,
+  title,
+  info,
+}) => (
+  <Stack direction="row" spacing={2} alignItems="center">
+    {icon}
+    <Typography variant="subtitle1" sx={{ fontSize: 'calc(1rem + 2px)', color: 'primary.main' }}>
+      {title}
+    </Typography>
+    <Tooltip title={info} placement="top">
+      <InfoOutlinedIcon color="action" fontSize="small" />
+    </Tooltip>
+  </Stack>
+);

--- a/packages/ui/accordion-config/src/build-config/FetchConfigSection.tsx
+++ b/packages/ui/accordion-config/src/build-config/FetchConfigSection.tsx
@@ -5,8 +5,8 @@ import {
   Box,
   Grid,
   Paper,
-  Stack,
   Typography,
+  Stack,
 } from '@mui/material';
 import {
   CloudDownload as CloudDownloadIcon,
@@ -18,6 +18,7 @@ import type { ReactNode } from 'react';
 import { WorkerNumberConfigCard } from './WorkerNumberConfigCard.js';
 import { DownloadRetryControls, type DownloadRetryConfig } from './DownloadRetryControls.js';
 import { BuildConfigSectionTitle } from './BuildConfigSectionTitle.js';
+import { BuildConfigAccordionSummary } from './BuildConfigAccordionSummary.js';
 import { getBuildConfigHoverCardSx } from './buildConfigCardStyles.js';
 
 type TranslateFn = (key: string, fallback?: string, options?: Record<string, unknown>) => string;
@@ -105,15 +106,14 @@ export const FetchConfigSection = <TDataSourceName,>({
   return (
     <Accordion defaultExpanded>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <CloudDownloadIcon color="primary" />
-          <Typography
-            variant="subtitle1"
-            sx={{ fontSize: 'calc(1rem + 2px)', color: 'primary.main' }}
-          >
-            {t('processing.fetch.title', 'Fetch')}
-          </Typography>
-        </Stack>
+        <BuildConfigAccordionSummary
+          icon={<CloudDownloadIcon color="primary" />}
+          title={t('processing.fetch.title', 'Fetch')}
+          info={t(
+            'processing.fetch.descriptionTooltip',
+            'Fetches source data, prepares filters, and provides input for transform.',
+          )}
+        />
       </AccordionSummary>
       <AccordionDetails sx={{ p: 1 }}>
         <Grid container rowSpacing={2} columnSpacing={2}>

--- a/packages/ui/accordion-config/src/build-config/VTConfigSection.tsx
+++ b/packages/ui/accordion-config/src/build-config/VTConfigSection.tsx
@@ -7,14 +7,12 @@ import {
   Stack,
   TextField,
   Typography,
-  Tooltip,
   Slider,
   InputAdornment,
 } from '@mui/material';
 import {
   BorderAll as BorderAllIcon,
   ExpandMore as ExpandMoreIcon,
-  InfoOutlined as InfoOutlinedIcon,
   Layers as LayersIcon,
   GridView as GridViewIcon,
   Speed as SpeedIcon,
@@ -28,6 +26,7 @@ import {
 } from '@mui/icons-material';
 import { useEffect, useMemo } from 'react';
 import type { BaseBuildConfig, DynamicConcurrencyConfig } from '@hierarchidb/gis-sdk';
+import { BuildConfigAccordionSummary } from './BuildConfigAccordionSummary.js';
 import { WorkerNumberConfigCard } from './WorkerNumberConfigCard.js';
 import { BuildConfigSectionTitle } from './BuildConfigSectionTitle.js';
 import { getBuildConfigHoverCardSx } from './buildConfigCardStyles.js';
@@ -88,24 +87,14 @@ export const VTConfigSection = <TDataSourceName,>({
   return (
     <Accordion defaultExpanded>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <LayersIcon color="primary" />
-          <Typography
-            variant="subtitle1"
-            sx={{ fontSize: 'calc(1rem + 2px)', color: 'primary.main' }}
-          >
-            {t('processing.vt.title', 'VT')}
-          </Typography>
-          <Tooltip
-            title={t(
-              'processing.tile.descriptionTooltip',
-              'Generate VT tiles for the selected zoom range.',
-            )}
-            placement="top"
-          >
-            <InfoOutlinedIcon color="action" fontSize="small" />
-          </Tooltip>
-        </Stack>
+        <BuildConfigAccordionSummary
+          icon={<LayersIcon color="primary" />}
+          title={t('processing.vt.title', 'VT generation')}
+          info={t(
+            'processing.tile.descriptionTooltip',
+            'Generate VT tiles for the selected zoom range.',
+          )}
+        />
       </AccordionSummary>
       <AccordionDetails sx={{ p: 1 }}>
         <Stack spacing={3}>

--- a/packages/ui/accordion-config/src/build-config/ZoomBandConfigSection.tsx
+++ b/packages/ui/accordion-config/src/build-config/ZoomBandConfigSection.tsx
@@ -5,12 +5,9 @@ import {
   AccordionSummary,
   Button,
   Stack,
-  Tooltip,
-  Typography,
 } from '@mui/material';
 import {
   ExpandMore as ExpandMoreIcon,
-  InfoOutlined as InfoOutlinedIcon,
   Settings as SettingsIcon,
 } from '@mui/icons-material';
 import {
@@ -23,6 +20,7 @@ import {
   ZOOM_BAND_MIN_RANGES,
   ZOOM_BAND_MIN_ZOOM,
 } from '@hierarchidb/util';
+import { BuildConfigAccordionSummary } from './BuildConfigAccordionSummary.js';
 import { ZoomBandRangeCard } from './ZoomBandRangeCard.js';
 
 export type ZoomBandConfigSectionProps = {
@@ -52,26 +50,14 @@ export const ZoomBandConfigSection: React.FC<ZoomBandConfigSectionProps> = ({
   return (
     <Accordion defaultExpanded>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <SettingsIcon color="primary" />
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Typography
-              variant="subtitle1"
-              sx={{ fontSize: 'calc(1rem + 2px)', color: 'primary.main' }}
-            >
-              {t('processing.zoomBandSettings.title', 'Zoom band settings')}
-            </Typography>
-            <Tooltip
-              title={t(
-                'processing.tile.zoomBandsSummary',
-                'Zoom bands follow the Transform range boundaries. The representative zoom is the smallest in each band.',
-              )}
-              placement="top"
-            >
-              <InfoOutlinedIcon color="action" fontSize="small" />
-            </Tooltip>
-          </Stack>
-        </Stack>
+        <BuildConfigAccordionSummary
+          icon={<SettingsIcon color="primary" />}
+          title={t('processing.zoomBandSettings.title', 'Zoom band settings')}
+          info={t(
+            'processing.tile.zoomBandsSummary',
+            'Zoom bands follow the Transform range boundaries. The representative zoom is the smallest in each band.',
+          )}
+        />
       </AccordionSummary>
       <AccordionDetails sx={{ p: 1 }}>
         <Stack spacing={2}>

--- a/packages/ui/accordion-config/src/index.ts
+++ b/packages/ui/accordion-config/src/index.ts
@@ -29,6 +29,7 @@ export type { PhaseConfigAccordionProps } from './components/PhaseConfigAccordio
 
 // Build config components
 export { BuildConfigSectionTitle } from './build-config/BuildConfigSectionTitle.js';
+export { BuildConfigAccordionSummary } from './build-config/BuildConfigAccordionSummary.js';
 export { BuildConfigShell } from './build-config/BuildConfigShell.js';
 export { DownloadRetryControls } from './build-config/DownloadRetryControls.js';
 export type { DownloadRetryConfig } from './build-config/DownloadRetryControls.js';

--- a/plugins/shape-plugin/src/ui/components/build-config/CacheManagementSection.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/CacheManagementSection.tsx
@@ -8,7 +8,6 @@ import {
   Paper,
   Stack,
   Switch,
-  Typography,
 } from '@mui/material';
 import {
   DeleteSweep as DeleteSweepIcon,
@@ -20,6 +19,7 @@ import type { FetchConfigSectionState } from '~/ui/hooks/useFetchConfigSection';
 import { useTranslation } from '~/ui/i18n';
 import {
   BuildConfigSectionTitle,
+  BuildConfigAccordionSummary,
   getBuildConfigHoverCardSx,
 } from '@hierarchidb/ui-accordion-config';
 import { UrlBuildConfigRulesSection } from './UrlBuildConfigRulesSection.tsx';
@@ -49,12 +49,14 @@ export const CacheManagementSection: React.FC<Props> = ({
   return (
     <Accordion defaultExpanded>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <DeleteSweepIcon color="primary" />
-          <Typography variant="subtitle1">
-            {t('processing.cache.title', 'Build Behaviours')}
-          </Typography>
-        </Stack>
+        <BuildConfigAccordionSummary
+          icon={<DeleteSweepIcon color="primary" />}
+          title={t('processing.cache.title', 'Miscellaneous')}
+          info={t(
+            'processing.cache.descriptionTooltip',
+            'Control how build outputs are retained or removed after each stage.',
+          )}
+        />
       </AccordionSummary>
       <AccordionDetails sx={{ p: 3 }}>
         <Stack spacing={2} alignItems="stretch">

--- a/plugins/shape-plugin/src/ui/components/build-config/TransformConfigSection.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/TransformConfigSection.tsx
@@ -13,7 +13,6 @@ import {
   Slider,
   Stack,
   Typography,
-  Tooltip,
 } from '@mui/material';
 import {
   DensityLarge as DensityLargeIcon,
@@ -22,7 +21,11 @@ import {
   InfoOutlined as InfoOutlinedIcon,
   Tune as TuneIcon,
 } from '@mui/icons-material';
-import { BuildConfigSectionTitle, getBuildConfigHoverCardSx } from '@hierarchidb/ui-accordion-config';
+import {
+  BuildConfigAccordionSummary,
+  BuildConfigSectionTitle,
+  getBuildConfigHoverCardSx,
+} from '@hierarchidb/ui-accordion-config';
 import { useTranslation } from '~/ui/i18n';
 import type { ShapeBuildConfig } from '~/common/types/index';
 import { useTransformConfigSection } from '~/ui/hooks/useTransformConfigSection';
@@ -73,21 +76,11 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
   return (
     <Accordion defaultExpanded>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <TuneIcon color="primary" />
-          <Typography
-            variant="subtitle1"
-            sx={{ fontSize: 'calc(1rem + 2px)', color: 'primary.main' }}
-          >
-            {t('processing.transform.title', 'Transform')}
-          </Typography>
-          <Tooltip
-            title={summaryHelp}
-            placement="top"
-          >
-            <InfoOutlinedIcon color="action" fontSize="small" />
-          </Tooltip>
-        </Stack>
+        <BuildConfigAccordionSummary
+          icon={<TuneIcon color="primary" />}
+          title={t('processing.transform.title', 'Transform')}
+          info={summaryHelp}
+        />
       </AccordionSummary>
       <AccordionDetails sx={{ p: 1 }}>
         <Stack spacing={2} sx={{ opacity: disabled ? 0.6 : 1 }}>

--- a/plugins/shape-plugin/src/ui/components/build-config/useShapeBuildConfigStep.ts
+++ b/plugins/shape-plugin/src/ui/components/build-config/useShapeBuildConfigStep.ts
@@ -63,6 +63,17 @@ const normalizeZoomBandConfig = (
   };
 };
 
+const isStepValueEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (a === null || a === undefined || b === null || b === undefined) return false;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+};
+
 export const useShapeBuildConfigStep = ({ data, onChange }: Args) => {
   const config = useMemo(() => {
     const baseConfig = resolveInitialBuildConfig();
@@ -82,21 +93,16 @@ export const useShapeBuildConfigStep = ({ data, onChange }: Args) => {
       return;
     }
     const nextConfig = normalizeZoomBandConfig(baseConfig, data.buildConfig);
-    const coefficient = data.buildConfig.transformConfig?.excludePolygonAreaCoefficient;
-    const rawBoundaries = data.buildConfig.transformConfig?.zoomBandBoundaries;
-    const normalizedBoundaries = nextConfig.transformConfig.zoomBandBoundaries;
-    const boundariesChanged = !areZoomBandBoundariesEqual(rawBoundaries, normalizedBoundaries);
-    if (!Number.isFinite(coefficient)) {
-      onChange({
-        buildConfig: nextConfig,
-        processingConfig: nextProcessingConfig,
-      });
-      return;
+    const nextPatch: Partial<ShapeEntity> = {};
+    if (!isStepValueEqual(data.buildConfig, nextConfig)) {
+      nextPatch.buildConfig = nextConfig;
     }
-    if (boundariesChanged || !data.processingConfig) {
+    if (!isStepValueEqual(data.processingConfig, nextProcessingConfig)) {
+      nextPatch.processingConfig = nextProcessingConfig;
+    }
+    if (Object.keys(nextPatch).length > 0) {
       onChange({
-        buildConfig: nextConfig,
-        processingConfig: nextProcessingConfig,
+        ...nextPatch,
       });
     }
   }, [data?.buildConfig, data?.processingConfig, onChange]);

--- a/plugins/shape-plugin/src/ui/components/steps-provider.tsx
+++ b/plugins/shape-plugin/src/ui/components/steps-provider.tsx
@@ -24,6 +24,16 @@ const registry = PluginStepRegistry.getInstance();
 
 type ShapeStepProps = PluginStepProps<Partial<ShapeEntity>>;
 
+const isSameShapeData = (left?: Partial<ShapeEntity>, right?: Partial<ShapeEntity>): boolean => {
+  if (left === right) return true;
+  if (left === null || left === undefined || right === null || right === undefined) return false;
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+};
+
 function createStepAdapter(
   Component: React.ComponentType<ShapeDialogStepProps>,
 ): (props: ShapeStepProps) => ReactElement {
@@ -43,9 +53,12 @@ function createStepAdapter(
         ...(latestDataRef.current ?? {}),
         ...updates,
       } as Partial<ShapeEntity>;
+      if (isSameShapeData(next, latestDataRef.current)) {
+        return;
+      }
       latestDataRef.current = next;
       props.onChange(next);
-    }, [props]);
+    }, [props.onChange]);
 
     return (
       <Component

--- a/plugins/shape-plugin/src/ui/locales/en.json
+++ b/plugins/shape-plugin/src/ui/locales/en.json
@@ -69,6 +69,7 @@
   "processing": {
     "fetch": {
       "title": "Fetch",
+      "descriptionTooltip": "Fetches source data, prepares filters, and provides input for transform.",
       "geometryIntakeGuard": {
         "title": "Fetch Geometry Intake Guard",
         "description": "Normalize and validate fetched geometry before transform to reduce unstable simplification artifacts.",
@@ -159,10 +160,11 @@
       "action": "Open Build Step"
     },
     "cache": {
-      "title": "Build Behaviours"
+      "title": "Miscellaneous",
+      "descriptionTooltip": "Control how build outputs are retained or removed for each stage."
     },
     "vt": {
-      "title": "VT Generation"
+      "title": "VT generation"
     },
     "download": {
       "title": "Fetch stage settings",
@@ -293,10 +295,11 @@
       "title": "Zoom band settings"
     },
     "cache": {
-      "title": "Cache management"
+      "title": "Cache management",
+      "descriptionTooltip": "Controls build output retention and cleanup behavior by stage."
     },
     "tile": {
-      "title": "VT Generation",
+      "title": "VT generation",
       "descriptionTooltip": "Generate VT tiles for the selected zoom range.",
       "basicSettings": "Basic settings",
       "basicPerformance": "Concurrency",

--- a/plugins/shape-plugin/src/ui/locales/ja.json
+++ b/plugins/shape-plugin/src/ui/locales/ja.json
@@ -69,6 +69,7 @@
   "processing": {
     "fetch": {
       "title": "Fetch",
+      "descriptionTooltip": "取得したデータを取り込み、フィルタリングを準備して transform へ渡します。",
       "geometryIntakeGuard": {
         "title": "Fetch Geometry Intake Guard",
         "description": "Transform 前に取得済みジオメトリを正規化・検証し、不安定な簡略化アーティファクトを抑制します。",
@@ -159,7 +160,8 @@
       "action": "ビルド画面を開く"
     },
     "cache": {
-      "title": "ビルド動作"
+      "title": "その他",
+      "descriptionTooltip": "ステージごとの生成物の保持・削除動作を設定します。"
     },
     "vt": {
       "title": "VT 生成"
@@ -293,7 +295,8 @@
       "title": "ズーム帯設定"
     },
     "cache": {
-      "title": "キャッシュ管理"
+      "title": "キャッシュ管理",
+      "descriptionTooltip": "ステージごとの生成物の保持・削除動作を設定します。"
     },
     "tile": {
       "title": "VT 生成",


### PR DESCRIPTION
## Summary
- Add shared Step4 accordion summary component: BuildConfigAccordionSummary with required props icon/title/info.
- Use it in Fetch, VT, Zoom band, Transform, and Miscellaneous(Cache management) sections to unify summary layout/style.
- Standardize VT summary title string and cache section naming.
- Keep summary tooltip behavior consistent via shared component.
- Fix runtime regressions introduced by extraction (Typography / InfoOutlinedIcon imports) in affected sections.

## Notes
- This PR contains the accumulated Step4 summary style unification changes and earlier fixes tied to those files.
- No dependency changes.
