### PR TITLE
fix(shape): stabilize build progress elapsed/task display

### DIFF
--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/BuildProgressStageContent/BuildProgressStageContent.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/BuildProgressStageContent/BuildProgressStageContent.tsx
@@ -1,5 +1,6 @@
 import { useBuildProgressStageContentState } from './useBuildProgressStageContentState.js';
 import { BuildProgressStageContentView } from './BuildProgressStageContentView.tsx';
+import type { BuildStatus } from '@hierarchidb/components/build-status';
 
 type BuildProgressStageContentProps = {
   showHeader?: boolean;
@@ -19,6 +20,7 @@ type BuildProgressStageContentProps = {
   }>;
   isTaskSummaryLoading: boolean;
   isTasksLoading: boolean;
+  buildStatus: BuildStatus;
   resolveStatusLabel: (statusValue?: string, skipped?: boolean) => string;
   resolveStatusColor: (statusValue?: string, skipped?: boolean) => 'default' | 'success' | 'error' | 'warning' | 'info';
   resolveTaskTitle: (task: import('../../taskItemCardList/types.js').TaskItemWithMetadata) => string;
@@ -34,6 +36,7 @@ export const BuildProgressStageContent = ({
   paneProgress,
   isTaskSummaryLoading,
   isTasksLoading,
+  buildStatus,
   resolveStatusLabel,
   resolveStatusColor,
   resolveTaskTitle,
@@ -47,6 +50,7 @@ export const BuildProgressStageContent = ({
     paneProgress,
     isTaskSummaryLoading,
     isTasksLoading,
+    buildStatus,
     resolveStatusLabel,
     resolveStatusColor,
     resolveTaskTitle,

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/BuildProgressStageContent/useBuildProgressStageContentState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/BuildProgressStageContent/useBuildProgressStageContentState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useBuildStageFilter } from '@hierarchidb/components';
 import { useAtomValue, useSetAtom } from 'jotai';
+import type { BuildStatus } from '@hierarchidb/components/build-status';
 import { type TaskItemWithMetadata } from '~/ui/components/build-progress/taskItemCardList/types';
 import { sortTransformTasks, sortVectorTileTasks } from '~/ui/components/build-progress/taskItemCardList/useTaskItemCardList';
 import { taskScrollTargetAtom, taskViewportRangeAtom } from '~/ui/atoms/shapeBuildProgressAtoms';
@@ -23,6 +24,7 @@ type BuildProgressStageContentStateArgs = {
   }>;
   isTaskSummaryLoading: boolean;
   isTasksLoading: boolean;
+  buildStatus: BuildStatus;
   resolveStatusLabel: (statusValue?: string, skipped?: boolean) => string;
   resolveStatusColor: (
     statusValue?: string,
@@ -69,6 +71,7 @@ export const useBuildProgressStageContentState = ({
   paneProgress,
   isTaskSummaryLoading,
   isTasksLoading,
+  buildStatus,
   resolveStatusLabel,
   resolveStatusColor,
   resolveTaskTitle,
@@ -77,6 +80,34 @@ export const useBuildProgressStageContentState = ({
 }: BuildProgressStageContentStateArgs): BuildProgressStageContentState => {
   const filter = useBuildStageFilter();
   const stageTasks = tasksByStage[stage.id] ?? [];
+  const isBuildInProgressState = buildStatus === 'running' || buildStatus === 'paused';
+  const cachedTasksByStageRef = useRef<Record<string, TaskItemWithMetadata[]>>({});
+  const previousBuildStatusRef = useRef<BuildStatus>(buildStatus);
+
+  useEffect(() => {
+    if (previousBuildStatusRef.current === buildStatus) return;
+    if (isBuildInProgressState && ![
+      'running',
+      'paused',
+    ].includes(previousBuildStatusRef.current)) {
+      cachedTasksByStageRef.current = {};
+    }
+    previousBuildStatusRef.current = buildStatus;
+  }, [buildStatus, isBuildInProgressState]);
+
+  useEffect(() => {
+    if (!isBuildInProgressState) return;
+    if (stageTasks.length > 0) {
+      cachedTasksByStageRef.current[stage.id] = stageTasks;
+    }
+  }, [isBuildInProgressState, stage.id, stageTasks]);
+
+  const stageTasksForDisplay = useMemo(() => {
+    if (isBuildInProgressState && stageTasks.length === 0) {
+      return cachedTasksByStageRef.current[stage.id] ?? [];
+    }
+    return stageTasks;
+  }, [isBuildInProgressState, stage.id, stageTasks]);
   const scrollTarget = useAtomValue(taskScrollTargetAtom);
   const setScrollTarget = useSetAtom(taskScrollTargetAtom);
   const viewportRange = useAtomValue(taskViewportRangeAtom);
@@ -87,13 +118,13 @@ export const useBuildProgressStageContentState = ({
   const disableVirtualization = typeof window !== 'undefined'
     && new URLSearchParams(window.location.search).has('noTaskVirtual');
 
-  const filteredTasks = useMemo(() => stageTasks.filter((task) => {
+  const filteredTasks = useMemo(() => stageTasksForDisplay.filter((task) => {
     if (!matchesSearchQuery(task)) return false;
     if (isTaskSkipped(task.display, task.message)) return filter.skippedMode;
     if (task.status === 'failed') return filter.failedMode;
     if (task.status === 'completed' || task.status === 'recycled') return filter.completedMode;
     return true;
-  }), [filter, stageTasks, matchesSearchQuery]);
+  }), [filter, matchesSearchQuery, stageTasksForDisplay]);
 
   const orderedTasks = useMemo(() => {
     if (stage.id === 'vt') return sortVectorTileTasks(filteredTasks);

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/useShapeBuildProgressPanelControllerOverlaySections.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/useShapeBuildProgressPanelControllerOverlaySections.tsx
@@ -53,6 +53,7 @@ export const useShapeBuildProgressPanelControllerOverlaySections = (
         paneProgress={paneProgressForDisplay ?? []}
         isTasksLoading={isTasksLoadingForDisplay}
         isTaskSummaryLoading={isTaskSummaryLoadingForDisplay}
+        buildStatus={summary.buildStatus}
         resolveStatusLabel={resolveStatusLabel}
         resolveStatusColor={resolveStatusColor}
         resolveTaskTitle={resolveTaskTitle}
@@ -66,6 +67,7 @@ export const useShapeBuildProgressPanelControllerOverlaySections = (
     isTaskSummaryLoadingForDisplay,
     isTasksLoadingForDisplay,
     paneProgressForDisplay,
+    summary.buildStatus,
     resolveStatusColor,
     resolveStatusLabel,
     matchesSearchQuery,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelState.utils.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelState.utils.ts
@@ -59,7 +59,7 @@ export const shouldUpdateElapsedSnapshot = (params: {
 }): boolean => {
   const { snapshot, totalElapsedMs, buildStatus } = params;
   if (!snapshot) return true;
-  if (buildStatus !== 'running') return true;
+  if (buildStatus !== 'running' && totalElapsedMs === 0) return false;
   if (totalElapsedMs === 0) return true;
   return totalElapsedMs > snapshot.elapsedMs;
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateRuntimeState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateRuntimeState.ts
@@ -125,6 +125,7 @@ export const useBuildProgressPanelStateRuntimeState = (
   const completionKeyRef = useRef<string | null>(null);
   const totalElapsedSnapshotRef = useRef<{ elapsedMs: number; capturedAt: number } | null>(null);
   const mismatchSignatureRef = useRef<Map<string, string>>(new Map());
+  const snapshotNodeIdRef = useRef<string | undefined>(undefined);
 
   const completion = useBuildCrashInsight({
     draft: params.data,
@@ -192,16 +193,24 @@ export const useBuildProgressPanelStateRuntimeState = (
     mismatchSignatureRef,
   });
 
+  if (nodeIdForLog !== snapshotNodeIdRef.current) {
+    snapshotNodeIdRef.current = nodeIdForLog;
+    totalElapsedSnapshotRef.current = null;
+  }
+
   const liveTotalElapsedMs = useMemo(() => {
     const snapshot = totalElapsedSnapshotRef.current;
-    if (summary.buildStatus === 'running' && snapshot) {
+    if (!snapshot) {
+      return summary.totalElapsedMs;
+    }
+    if ((summary.buildStatus === 'running' || summary.buildStatus === 'paused') && snapshot) {
       const drift = Math.max(0, elapsedTickMs - snapshot.capturedAt);
       return snapshot.elapsedMs + drift;
     }
-    if (summary.buildStatus !== 'running' && summary.totalElapsedMs === 0) {
-      return 0;
+    if (summary.totalElapsedMs > snapshot.elapsedMs) {
+      return summary.totalElapsedMs;
     }
-    return summary.totalElapsedMs;
+    return snapshot.elapsedMs;
   }, [elapsedTickMs, summary.buildStatus, summary.totalElapsedMs]);
 
   return {


### PR DESCRIPTION
## 概要
- Shape build 中の進捗表示で、経過時間とタスクリストが一時的な 0/skeleton 再表示で途切れる問題を修正しました。
- running/paused 中は直近のタスク一覧を保持して、再取得で empty になっても表示を維持し、
  サマリー/タスクの揺れを抑制します。
- 停止時の経過時間スナップショット更新条件を調整し、実測値を誤って 0 へ巻き戻さないようにしました。

## 変更点
- 
  -  を更新
- 
  - ノード切り替え時の経過時間スナップショット初期化
  -  の戻しロジックを調整
- 
  - / 時のステージタスクフォールバックキャッシュを追加
- 
  -  を prop として受け取り、上記フックへ渡す
- 
  -  呼び出しへ  を伝播

## 反映先
- base: 
