### PR TITLE
fix(plugin-ui-sdk): type-safe draft metadata defaults

### DIFF
--- a/packages/plugin-ui-sdk/src/hooks/useTreeNodeUpdater.ts
+++ b/packages/plugin-ui-sdk/src/hooks/useTreeNodeUpdater.ts
@@ -215,11 +215,15 @@ export function useTreeNodeUpdater<
             existing.data !== null &&
             (existing.data ? Object.keys(existing.data as Record<string, unknown>).length > 0 : false);
           if (needsDraftMeta) {
-            const fallbackMetadata = {
+            const fallbackMetadata: TreeNodeMetadata = {
               ...(existingMetadata ?? { name: '', description: '', tags: [] }),
             };
-            const existingDraftMetadataRecord = existingDraftMetadata ?? {};
-            await wcAPI.updateTreeNodeDraftMetadata(nodeId, {
+            const existingDraftMetadataRecord: TreeNodeMetadata = existingDraftMetadata ?? {
+              name: '',
+              description: '',
+              tags: [],
+            };
+            const nextDraftMetadata: TreeNodeMetadata = {
               ...fallbackMetadata,
               ...existingDraftMetadataRecord,
               name:
@@ -233,21 +237,12 @@ export function useTreeNodeUpdater<
               tags: Array.isArray(existingDraftMetadataRecord.tags)
                 ? existingDraftMetadataRecord.tags
                 : fallbackMetadata.tags,
-            } as TreeNodeMetadata);
+            };
+            await wcAPI.updateTreeNodeDraftMetadata(nodeId, {
+              ...nextDraftMetadata,
+            });
             (existing as { draftMetadata?: TreeNodeMetadata | null }).draftMetadata = {
-              ...(existingDraftMetadataRecord as Record<string, unknown>),
-              ...fallbackMetadata,
-              name:
-                typeof existingDraftMetadataRecord.name === 'string'
-                  ? existingDraftMetadataRecord.name
-                  : fallbackMetadata.name,
-              description:
-                typeof existingDraftMetadataRecord.description === 'string'
-                  ? existingDraftMetadataRecord.description
-                  : fallbackMetadata.description,
-              tags: Array.isArray(existingDraftMetadataRecord.tags)
-                ? existingDraftMetadataRecord.tags
-                : fallbackMetadata.tags,
+              ...nextDraftMetadata,
             };
           }
           if (needsDraftData) {


### PR DESCRIPTION
## 問題
-  で  が  へフォールバックされ、 の型参照で TS2339 が発生していた。

## 修正内容
-  を  として明示し、空オブジェクトフォールバックでも必須キー型を満たす形で初期化。
- フォールバック後の draft metadata を  として1回だけ構築し、 と  更新の双方で再利用。

## 変更ファイル
- 

## 期待効果
-  の以下エラーが解消されるはずです。
  - 
