### PR TITLE
fix(plugin-ui-sdk): type-safe draft metadata defaults

### DIFF
--- a/packages/plugin-ui-sdk/src/hooks/useTreeNodeUpdater.ts
+++ b/packages/plugin-ui-sdk/src/hooks/useTreeNodeUpdater.ts
@@ -215,11 +215,15 @@ export function useTreeNodeUpdater<
             existing.data !== null &&
             (existing.data ? Object.keys(existing.data as Record<string, unknown>).length > 0 : false);
           if (needsDraftMeta) {
-            const fallbackMetadata = {
+            const fallbackMetadata: TreeNodeMetadata = {
               ...(existingMetadata ?? { name: '', description: '', tags: [] }),
             };
-            const existingDraftMetadataRecord = existingDraftMetadata ?? {};
-            const mergedMetadata = {
+            const existingDraftMetadataRecord: TreeNodeMetadata = existingDraftMetadata ?? {
+              name: '',
+              description: '',
+              tags: [],
+            };
+            const nextDraftMetadata: TreeNodeMetadata = {
               ...fallbackMetadata,
               ...existingDraftMetadataRecord,
               name:
@@ -233,9 +237,14 @@ export function useTreeNodeUpdater<
               tags: Array.isArray(existingDraftMetadataRecord.tags)
                 ? existingDraftMetadataRecord.tags
                 : fallbackMetadata.tags,
-            } as TreeNodeMetadata;
-            await wcAPI.updateTreeNodeDraftMetadata(nodeId, mergedMetadata);
-            (existing as { draftMetadata?: TreeNodeMetadata | null }).draftMetadata = mergedMetadata;
+            };
+            await wcAPI.updateTreeNodeDraftMetadata(nodeId, {
+              ...nextDraftMetadata,
+            });
+            (existing as { draftMetadata?: TreeNodeMetadata | null }).draftMetadata = {
+              ...nextDraftMetadata,
+            };
+>>>>>>> eef70a253 (fix(plugin-ui-sdk): type-safe draft metadata defaults)
           }
           if (needsDraftData) {
             await wcAPI.updateTreeNodeDraftData(


### PR DESCRIPTION
## issue
- fix tree node updater type error when existingDraftMetadataRecord was inferred as {}.

## fix
- keep existingDraftMetadataRecord as TreeNodeMetadata with safe fallback.
- build merged draft metadata once and reuse for update + local draft assignment.

## changed file
- packages/plugin-ui-sdk/src/hooks/useTreeNodeUpdater.ts

## expected
- @hierarchidb/plugin-ui-sdk build types TS2339 (name/description/tags does not exist on type {}) should be resolved.