### PR TITLE
fix(plugin-ui-sdk): remove leftover merge conflict marker

### DIFF
--- a/packages/plugin-ui-sdk/src/hooks/useTreeNodeUpdater.ts
+++ b/packages/plugin-ui-sdk/src/hooks/useTreeNodeUpdater.ts
@@ -244,7 +244,6 @@ export function useTreeNodeUpdater<
             (existing as { draftMetadata?: TreeNodeMetadata | null }).draftMetadata = {
               ...nextDraftMetadata,
             };
->>>>>>> eef70a253 (fix(plugin-ui-sdk): type-safe draft metadata defaults)
           }
           if (needsDraftData) {
             await wcAPI.updateTreeNodeDraftData(


### PR DESCRIPTION
## Problem
- Lint fails with 'Merge conflict marker encountered' in useTreeNodeUpdater.ts.

## Fix
- Removed stray conflict marker line (<<<<<<< ======= >>>>>>>) accidentally left in file.

## Changed file
- packages/plugin-ui-sdk/src/hooks/useTreeNodeUpdater.ts
