### PR TITLE
fix(shape): stop elapsed timer after failed session completion

### DIFF
--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateRuntimeState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateRuntimeState.ts
@@ -133,6 +133,12 @@ export const useBuildProgressPanelStateRuntimeState = (
     status: summary.buildStatus,
   });
 
+  const hasInFlightOrQueuedTasks = useMemo(() => {
+    return Object.values(tasksByStage).some((tasks) =>
+      tasks.some((task) => task.status === 'running' || task.status === 'queued'),
+    );
+  }, [tasksByStage]);
+
   const computed = useBuildProgressPanelStateComputed({
     data: params.data,
     summary,
@@ -203,7 +209,7 @@ export const useBuildProgressPanelStateRuntimeState = (
     if (!snapshot) {
       return summary.totalElapsedMs;
     }
-    if ((summary.buildStatus === 'running' || summary.buildStatus === 'paused') && snapshot) {
+    if ((summary.buildStatus === 'running' && hasInFlightOrQueuedTasks) || summary.buildStatus === 'paused') {
       const drift = Math.max(0, elapsedTickMs - snapshot.capturedAt);
       return snapshot.elapsedMs + drift;
     }
@@ -211,7 +217,7 @@ export const useBuildProgressPanelStateRuntimeState = (
       return summary.totalElapsedMs;
     }
     return snapshot.elapsedMs;
-  }, [elapsedTickMs, summary.buildStatus, summary.totalElapsedMs]);
+  }, [elapsedTickMs, hasInFlightOrQueuedTasks, summary.buildStatus, summary.totalElapsedMs]);
 
   return {
     summary: {

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateSideEffects.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateSideEffects.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { MutableRefObject } from 'react';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
 import { isDev, logRunningResiduePanel, shouldUpdateElapsedSnapshot } from './useBuildProgressPanelState.utils.js';
@@ -75,6 +75,14 @@ export const useBuildProgressPanelStateSideEffects = (args: {
     mismatchSignatureRef,
   } = args;
 
+  const hasInFlightOrQueuedTasks = useMemo(() => {
+    return Object.values(tasksByStage).some((tasks) =>
+      tasks.some((task) => task.status === 'running' || task.status === 'queued'),
+    );
+  }, [tasksByStage]);
+
+  const shouldRunElapsedTicker = summary.buildStatus === 'running' && hasInFlightOrQueuedTasks;
+
   useEffect(() => {
     if (summary.buildStatus === 'completed') {
       if (!completionSnapshotData.isFinalStageLabel) return;
@@ -120,7 +128,7 @@ export const useBuildProgressPanelStateSideEffects = (args: {
 
   useEffect(() => {
     setElapsedTickMs(Date.now());
-    if (summary.buildStatus !== 'running') {
+    if (!shouldRunElapsedTicker) {
       return;
     }
     const timerId = window.setInterval(() => {
@@ -129,7 +137,7 @@ export const useBuildProgressPanelStateSideEffects = (args: {
     return () => {
       window.clearInterval(timerId);
     };
-  }, [setElapsedTickMs, summary.buildStatus]);
+  }, [setElapsedTickMs, shouldRunElapsedTicker]);
 
   useEffect(() => {
     if (shouldUpdateElapsedSnapshot({


### PR DESCRIPTION
## Summary
- Prevent total elapsed time from continuing to increase after build session ends in failed state.
- Gate elapsed ticker interval by (buildStatus === 'running' && running/queued tasks exist).
- Gate live elapsed drift application by same condition, while keeping paused behavior unchanged.

## Changes
- plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateSideEffects.ts
  - added in-flight task check (running/queued) for ticker start condition.
- plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateRuntimeState.ts
  - added same in-flight gating for drift-based elapsed calculation.
