### PR TITLE
feat(shape): add second simplify tolerance curve and retry count controls

### DIFF
--- a/packages/gis-sdk/src/config.ts
+++ b/packages/gis-sdk/src/config.ts
@@ -132,6 +132,8 @@ export interface TransformConfig {
   hybridFilterConfig: HybridFilterConfig;
   deleteOnComplete: boolean;
   toleranceByBand: number[];
+  retryCount?: number;
+  retryToleranceByBand?: number[];
   retryToleranceStep?: number;
   quantize?: number;
   areaThreshold: number;

--- a/packages/shape-api/src/defaults.ts
+++ b/packages/shape-api/src/defaults.ts
@@ -1,8 +1,7 @@
 import { DEFAULT_ZOOM_BAND_BOUNDARIES } from '@hierarchidb/util';
 
-const DEFAULT_TRANSFORM_TOLERANCE_BY_BAND = DEFAULT_ZOOM_BAND_BOUNDARIES
-  .slice(0, -1)
-  .map(() => 0.1);
+const DEFAULT_TRANSFORM_TOLERANCE_BY_BAND = [8, 6, 3, 1];
+const DEFAULT_RETRY_TOLERANCE_BY_BAND = [9, 7, 4, 2];
 
 export const DEFAULT_BUILD_CONFIG = {
   dataSourceName: 'geoboundaries',
@@ -44,6 +43,9 @@ export const DEFAULT_BUILD_CONFIG = {
     },
     deleteOnComplete: false,
     toleranceByBand: DEFAULT_TRANSFORM_TOLERANCE_BY_BAND,
+    retryCount: 4,
+    retryToleranceByBand: DEFAULT_RETRY_TOLERANCE_BY_BAND,
+    retryToleranceStep: 0.02,
     areaThreshold: 1.0,
     excludePolygonAreaCoefficient: 1,
     omitDetailsConfig: {

--- a/packages/ui/tone-curve-editor/src/ToneCurveEditor.tsx
+++ b/packages/ui/tone-curve-editor/src/ToneCurveEditor.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 
 const ANCHOR_EPSILON = 1e-6;
 const DEFAULT_LINE_COLOR = '#0b5ed7';
+const DEFAULT_SECONDARY_LINE_COLOR = '#ef4444';
+const DEFAULT_SECONDARY_LINE_DASH = '6 4';
+const DEFAULT_STROKE_WIDTH = 2;
 
 interface AxisRange {
   min: number;
@@ -23,9 +26,17 @@ export interface ToneCurveAxisRange {
   yRange: [number, number];
 }
 
+export interface ToneCurveLineStyle {
+  lineColor?: string;
+  anchorPointColor?: string;
+  lineWidth?: number;
+  lineDashArray?: string;
+}
+
 export interface ToneCurveEditorProps extends ToneCurveAxisRange {
   width: number;
   height: number;
+  anchors?: ReadonlyArray<ToneCurveAnchor>;
   xFixedValues?: Array<number | undefined>;
   yFixedValues?: Array<number | undefined>;
   xEndpointRange?: [number, number];
@@ -34,12 +45,41 @@ export interface ToneCurveEditorProps extends ToneCurveAxisRange {
   yMarks?: Array<ToneCurveAxisMark>;
   xSnapStep?: number;
   ySnapStep?: number;
+  allowAnchorCountChange?: boolean;
   lineColor?: string;
   anchorPointColor?: string;
   onChange?: (anchors: ReadonlyArray<ToneCurveAnchor>) => void;
+  lineStyles?: ReadonlyArray<ToneCurveLineStyle>;
+  overlaySeries?: ReadonlyArray<ToneCurveOverlaySeries>;
   className?: string;
   style?: React.CSSProperties;
 }
+
+export interface ToneCurveOverlaySeries {
+  anchors?: ReadonlyArray<ToneCurveAnchor>;
+  xFixedValues?: Array<number | undefined>;
+  yFixedValues?: Array<number | undefined>;
+  allowAnchorCountChange?: boolean;
+  lineColor?: string;
+  anchorPointColor?: string;
+  lineWidth?: number;
+  lineDashArray?: string;
+  editable?: boolean;
+  onChange?: (anchors: ReadonlyArray<ToneCurveAnchor>) => void;
+}
+
+type ResolvedOverlaySeries = {
+  anchors: ReadonlyArray<ToneCurveAnchor>;
+  xFixedValues: Array<number | undefined>;
+  yFixedValues: Array<number | undefined>;
+  lineColor: string;
+  anchorPointColor: string;
+  lineWidth: number;
+  lineDashArray?: string;
+  editable: boolean;
+  allowAnchorCountChange: boolean;
+  onChange?: (anchors: ReadonlyArray<ToneCurveAnchor>) => void;
+};
 
 const toAxisRange = (value: [number, number], fallbackMin: number, fallbackMax: number): AxisRange => {
   const [a, b] = value;
@@ -121,9 +161,34 @@ const normalizeAxisValues = (
   return result;
 };
 
+const formatAnchorValueLabel = (value: number): string => {
+  if (!Number.isFinite(value)) {
+    return '';
+  }
+
+  if (Math.abs(value - Math.round(value)) < 1e-9) {
+    return String(Math.round(value));
+  }
+
+  return String(Number.parseFloat(value.toFixed(3)));
+};
+
+const areAnchorsEqual = (left: ReadonlyArray<ToneCurveAnchor>, right: ReadonlyArray<ToneCurveAnchor>): boolean => {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i]?.x !== right[i]?.x || left[i]?.y !== right[i]?.y) {
+      return false;
+    }
+  }
+  return true;
+};
+
 export function ToneCurveEditor({
   width,
   height,
+  anchors: externalAnchors,
   xRange,
   yRange,
   xFixedValues,
@@ -134,17 +199,53 @@ export function ToneCurveEditor({
   yMarks,
   xSnapStep,
   ySnapStep,
+  allowAnchorCountChange = true,
   lineColor,
   anchorPointColor,
   onChange,
+  lineStyles = [],
+  overlaySeries = [],
   className,
   style,
 }: ToneCurveEditorProps): React.JSX.Element {
   const svgRef = React.useRef<SVGSVGElement | null>(null);
-  const activeAnchorIndexRef = React.useRef<number | null>(null);
+  const activeAnchorRef = React.useRef<{
+    type: 'main' | 'overlay';
+    curveIndex: number | null;
+    anchorIndex: number;
+  } | null>(null);
 
-  const resolvedLineColor = lineColor ?? DEFAULT_LINE_COLOR;
-  const resolvedAnchorPointColor = anchorPointColor ?? DEFAULT_LINE_COLOR;
+  const getLineStyle = React.useCallback(
+    (curveIndex: number): {
+      lineColor: string;
+      anchorPointColor: string;
+      lineWidth: number;
+      lineDashArray?: string;
+    } => {
+      const configured = lineStyles[curveIndex];
+      const isPrimary = curveIndex === 0;
+      const defaultLineColor = isPrimary
+        ? (lineColor ?? DEFAULT_LINE_COLOR)
+        : curveIndex === 1
+          ? DEFAULT_SECONDARY_LINE_COLOR
+          : DEFAULT_LINE_COLOR;
+      const defaultDashArray = isPrimary ? undefined : (curveIndex === 1 ? DEFAULT_SECONDARY_LINE_DASH : undefined);
+      const defaultAnchorColor = isPrimary
+        ? (anchorPointColor ?? DEFAULT_LINE_COLOR)
+        : defaultLineColor;
+
+      const resolvedLineColor = configured?.lineColor ?? defaultLineColor;
+      const resolvedAnchorColor = configured?.anchorPointColor ?? defaultAnchorColor;
+
+      return {
+        lineColor: resolvedLineColor,
+        anchorPointColor: resolvedAnchorColor,
+        lineWidth: configured?.lineWidth ?? DEFAULT_STROKE_WIDTH,
+        lineDashArray: configured?.lineDashArray ?? defaultDashArray,
+      };
+    },
+    [anchorPointColor, lineColor, lineStyles],
+  );
 
   const baseXRange = React.useMemo(
     () => toAxisRange(xRange, 0, 1),
@@ -173,13 +274,32 @@ export function ToneCurveEditor({
     [normalizedYRange.max, normalizedYRange.min, yMarks],
   );
 
-  const targetAnchorCount = React.useMemo(
-    () => Math.max(
+  const resolveTargetAnchorCount = React.useCallback(
+    (xValues: Array<number | undefined> | undefined, yValues: Array<number | undefined> | undefined): number => Math.max(
       2,
-      xFixedValues?.length ?? 0,
-      yFixedValues?.length ?? 0,
+      xValues?.length ?? 0,
+      yValues?.length ?? 0,
     ),
-    [xFixedValues?.length, yFixedValues?.length],
+    [],
+  );
+  const resolvedOverlaySeriesInput = React.useMemo(
+    () => (Array.isArray(overlaySeries) ? overlaySeries : []),
+    [overlaySeries],
+  );
+  const normalizeFixedValueArray = React.useCallback((
+    values: ReadonlyArray<number | undefined> | Array<number | undefined> | undefined,
+  ): Array<number | undefined> => (
+    Array.isArray(values) ? values : []
+  ), []);
+  const normalizeAnchorArray = React.useCallback((
+    points: ReadonlyArray<ToneCurveAnchor> | ToneCurveAnchor[] | undefined,
+  ): ToneCurveAnchor[] => (
+    Array.isArray(points) ? [...points] : []
+  ), []);
+
+  const targetAnchorCount = React.useMemo(
+    () => resolveTargetAnchorCount(xFixedValues, yFixedValues),
+    [resolveTargetAnchorCount, xFixedValues, yFixedValues],
   );
 
   const fixedHorizontalValues = React.useMemo(
@@ -201,35 +321,47 @@ export function ToneCurveEditor({
     return Math.min(max, Math.max(min, value));
   }, []);
 
-  const initialAnchors = React.useMemo(
-    () => {
+  const createAnchorsFromInputs = React.useCallback(
+    (
+      externalAnchors: ReadonlyArray<ToneCurveAnchor> | undefined,
+      fixedXValues: Array<number | undefined> = [],
+      fixedYValues: Array<number | undefined> = [],
+    ): ToneCurveAnchor[] => {
+      const safeFixedXValues = normalizeFixedValueArray(fixedXValues);
+      const safeFixedYValues = normalizeFixedValueArray(fixedYValues);
+      const count = resolveTargetAnchorCount(safeFixedXValues, safeFixedYValues);
+      const normalizedFixedX = normalizeAxisValues(safeFixedXValues, count);
+      const normalizedFixedY = normalizeAxisValues(safeFixedYValues, count);
       const next: ToneCurveAnchor[] = [];
       const widthRange = normalizedXRange.max - normalizedXRange.min;
       const heightRange = normalizedYRange.max - normalizedYRange.min;
 
-      for (let i = 0; i < targetAnchorCount; i += 1) {
+      for (let i = 0; i < count; i += 1) {
+        const externalAnchor = externalAnchors?.[i];
+        const externalAnchorX = externalAnchor && Number.isFinite(externalAnchor.x) ? externalAnchor.x : undefined;
+        const externalAnchorY = externalAnchor && Number.isFinite(externalAnchor.y) ? externalAnchor.y : undefined;
         const isFirst = i === 0;
-        const isLast = i === targetAnchorCount - 1;
+        const isLast = i === count - 1;
         const defaultX = isFirst
           ? normalizedXRange.min
           : isLast
             ? normalizedXRange.max
-            : normalizedXRange.min + (widthRange * i) / (targetAnchorCount - 1 || 1);
+            : normalizedXRange.min + (widthRange * i) / (count - 1 || 1);
         const defaultY = isFirst
           ? normalizedYRange.min
           : isLast
             ? normalizedYRange.max
-            : normalizedYRange.min + (heightRange * i) / (targetAnchorCount - 1 || 1);
+            : normalizedYRange.min + (heightRange * i) / (count - 1 || 1);
 
-        const fixedX = fixedHorizontalValues[i];
-        const fixedY = fixedVerticalValues[i];
+        const fixedX = normalizedFixedX[i];
+        const fixedY = normalizedFixedY[i];
 
         next.push({
           x: fixedX === undefined
-            ? snapValue(defaultX, xSnapStep)
+            ? snapValue(externalAnchorX ?? defaultX, xSnapStep)
             : clamp(fixedX, normalizedXRange.min, normalizedXRange.max),
           y: fixedY === undefined
-            ? snapValue(defaultY, ySnapStep)
+            ? snapValue(externalAnchorY ?? defaultY, ySnapStep)
             : clamp(fixedY, normalizedYRange.min, normalizedYRange.max),
         });
       }
@@ -237,26 +369,30 @@ export function ToneCurveEditor({
       return next;
     },
     [
-      fixedHorizontalValues,
-      fixedVerticalValues,
-      xSnapStep,
-      ySnapStep,
+      clamp,
       normalizedXRange.max,
       normalizedXRange.min,
       normalizedYRange.max,
       normalizedYRange.min,
-      targetAnchorCount,
-      clamp,
+      normalizeFixedValueArray,
+      resolveTargetAnchorCount,
+      xSnapStep,
+      ySnapStep,
     ],
+  );
+
+  const initialAnchors = React.useMemo(
+    () => createAnchorsFromInputs(externalAnchors, fixedHorizontalValues, fixedVerticalValues),
+    [createAnchorsFromInputs, externalAnchors, fixedHorizontalValues, fixedVerticalValues],
   );
 
   const inner = React.useMemo(
     () => ({
-      paddingLeft: 22,
+      paddingLeft: 54,
       paddingRight: 16,
       paddingTop: 12,
       paddingBottom: 22,
-      width: Math.max(width - 38, 80),
+      width: Math.max(width - 70, 80),
       height: Math.max(height - 34, 80),
     }),
     [width, height],
@@ -305,9 +441,10 @@ export function ToneCurveEditor({
       values: ToneCurveAnchor[],
       fixedXValues: Array<number | undefined>,
       fixedYValues: Array<number | undefined>,
+      fallbackAnchors: ToneCurveAnchor[] = initialAnchors,
     ): ToneCurveAnchor[] => {
       if (values.length < 2) {
-        return initialAnchors;
+        return fallbackAnchors;
       }
 
       const count = values.length;
@@ -358,13 +495,115 @@ export function ToneCurveEditor({
   );
 
   const [anchors, setAnchors] = React.useState<ToneCurveAnchor[]>(initialAnchors);
+  const previousAnchorsRef = React.useRef<ToneCurveAnchor[]>(initialAnchors);
+  const resolvedOverlaySeries = React.useMemo<ResolvedOverlaySeries[]>(
+    () => resolvedOverlaySeriesInput.map((overlaySeriesItem, overlayIndex): ResolvedOverlaySeries => {
+      const safeSeries: ToneCurveOverlaySeries = overlaySeriesItem ?? {};
+      const safeCount = resolveTargetAnchorCount(
+        normalizeFixedValueArray(safeSeries.xFixedValues),
+        normalizeFixedValueArray(safeSeries.yFixedValues),
+      );
+      const resolvedStyle = getLineStyle(overlayIndex + 1);
+      const resolvedLineColor = safeSeries.lineColor ?? resolvedStyle.lineColor;
+      const resolvedAnchorPointColor = safeSeries.anchorPointColor
+        ?? resolvedLineColor
+        ?? resolvedStyle.anchorPointColor;
+
+      return {
+        anchors: safeSeries.anchors ?? [],
+        xFixedValues: normalizeAxisValues(
+          normalizeFixedValueArray(safeSeries.xFixedValues),
+          safeCount,
+        ),
+        yFixedValues: normalizeAxisValues(
+          normalizeFixedValueArray(safeSeries.yFixedValues),
+          safeCount,
+        ),
+        allowAnchorCountChange: safeSeries.allowAnchorCountChange ?? false,
+        lineColor: resolvedLineColor,
+        anchorPointColor: resolvedAnchorPointColor,
+        lineWidth: safeSeries.lineWidth ?? resolvedStyle.lineWidth,
+        lineDashArray: safeSeries.lineDashArray ?? resolvedStyle.lineDashArray,
+        editable: safeSeries.editable ?? true,
+        onChange: safeSeries.onChange,
+      };
+    }),
+    [normalizeFixedValueArray, getLineStyle, resolvedOverlaySeriesInput, resolveTargetAnchorCount],
+  );
+  const [overlayAnchors, setOverlayAnchors] = React.useState<ToneCurveAnchor[][]>(() =>
+    resolvedOverlaySeries.map((series) => createAnchorsFromInputs(series.anchors, series.xFixedValues, series.yFixedValues)),
+  );
+  const syncedOverlaySignatureRef = React.useRef<string>('');
+
+  const overlaySignature = React.useMemo(
+    () => resolvedOverlaySeries
+      .map((series, index) => {
+        const style = getLineStyle(index + 1);
+        const anchorsSignature = series.anchors
+          ?.map((anchor) => `${Number.isFinite(anchor.x) ? anchor.x : ''}:${Number.isFinite(anchor.y) ? anchor.y : ''}`)
+          .join('|') ?? '';
+        const xFixedValueCount = series.xFixedValues.length;
+        const yFixedValueCount = series.yFixedValues.length;
+
+        return `${xFixedValueCount}-${yFixedValueCount}-${series.lineColor ?? style.lineColor}-${series.anchorPointColor ?? style.anchorPointColor}-${series.lineWidth}-${series.lineDashArray ?? style.lineDashArray ?? ''}-${series.editable}-${anchorsSignature}`;
+      })
+      .join('||'),
+    [resolvedOverlaySeries, getLineStyle],
+  );
 
   React.useEffect(() => {
+    if (overlaySignature === syncedOverlaySignatureRef.current) {
+      return;
+    }
+
+    syncedOverlaySignatureRef.current = overlaySignature;
+    setOverlayAnchors(
+      resolvedOverlaySeries.map((series) => createAnchorsFromInputs(
+        series.anchors,
+        series.xFixedValues,
+        series.yFixedValues,
+      )),
+    );
+  }, [createAnchorsFromInputs, overlaySignature, resolvedOverlaySeries]);
+
+  const fixedXSignature = React.useMemo(
+    () => fixedHorizontalValues.map((value) => (Number.isFinite(value) ? `${value}` : '')).join('|'),
+    [fixedHorizontalValues],
+  );
+  const externalAnchorsSignature = React.useMemo(
+    () => externalAnchors
+      ?.map((anchor) => `${Number.isFinite(anchor.x) ? anchor.x : ''}:${Number.isFinite(anchor.y) ? anchor.y : ''}`)
+      .join('|') ?? '',
+    [externalAnchors],
+  );
+  const syncedFixedSignatureRef = React.useRef<string>(fixedXSignature);
+  const syncedAnchorsSignatureRef = React.useRef<string>(externalAnchorsSignature);
+  const syncedAnchorCountRef = React.useRef<number>(initialAnchors.length);
+
+  React.useEffect(() => {
+    if (
+      fixedXSignature === syncedFixedSignatureRef.current
+      && externalAnchorsSignature === syncedAnchorsSignatureRef.current
+      && syncedAnchorCountRef.current === initialAnchors.length
+    ) {
+      return;
+    }
+
+    syncedFixedSignatureRef.current = fixedXSignature;
+    syncedAnchorsSignatureRef.current = externalAnchorsSignature;
+    syncedAnchorCountRef.current = initialAnchors.length;
     setAnchors(initialAnchors);
-  }, [initialAnchors]);
+  }, [externalAnchorsSignature, initialAnchors, fixedXSignature]);
 
   React.useEffect(() => {
-    onChange?.(anchors);
+    if (!onChange) {
+      return;
+    }
+    if (areAnchorsEqual(previousAnchorsRef.current, anchors)) {
+      return;
+    }
+    previousAnchorsRef.current = anchors;
+    onChange(anchors);
   }, [anchors, onChange]);
 
   const sortedPoints = React.useMemo(
@@ -372,10 +611,34 @@ export function ToneCurveEditor({
     [anchors],
   );
 
+  const sortedOverlayPoints = React.useMemo(
+    () => (Array.isArray(overlayAnchors) ? overlayAnchors : [])
+      .map((curveAnchors) => normalizeAnchorArray(curveAnchors).sort((a, b) => a.x - b.x)),
+    [overlayAnchors, normalizeAnchorArray],
+  );
+
   const pathPoints = React.useMemo(
     () => sortedPoints.map((anchor) => `${xToScreen(anchor.x)},${yToScreen(anchor.y)}`).join(' '),
     [sortedPoints, xToScreen, yToScreen],
   );
+  const overlayPathPoints = React.useMemo(
+    () => sortedOverlayPoints.map(
+      (points) => normalizeAnchorArray(points).map((anchor) => `${xToScreen(anchor.x)},${yToScreen(anchor.y)}`).join(' '),
+    ),
+    [normalizeAnchorArray, sortedOverlayPoints, xToScreen, yToScreen],
+  );
+  const anchorYMarks = React.useMemo(() => {
+    const dedupeEpsilon = 1e-9;
+    const raw = anchors.map((anchor) => anchor.y).filter((value) => Number.isFinite(value));
+    const uniqueSorted = raw
+      .filter((value, index, values) => values.findIndex((candidate) => Math.abs(candidate - value) <= dedupeEpsilon) === index)
+      .sort((left, right) => right - left);
+
+    return uniqueSorted.map((value) => ({
+      value,
+      label: formatAnchorValueLabel(value),
+    }));
+  }, [anchors]);
 
   const fixedXForCount = React.useCallback(
     (count: number): Array<number | undefined> => {
@@ -399,10 +662,55 @@ export function ToneCurveEditor({
     [fixedVerticalValues],
   );
 
+  const fixedXForOverlayCount = React.useCallback(
+    (curve: ResolvedOverlaySeries | undefined, count: number): Array<number | undefined> => {
+      const next = new Array<number | undefined>(count).fill(undefined);
+      const fixedValues = curve?.xFixedValues ?? [];
+      for (let i = 0; i < count; i += 1) {
+        next[i] = i < fixedValues.length ? fixedValues[i] : undefined;
+      }
+      return next;
+    },
+    [],
+  );
+
+  const fixedYForOverlayCount = React.useCallback(
+    (curve: ResolvedOverlaySeries | undefined, count: number): Array<number | undefined> => {
+      const next = new Array<number | undefined>(count).fill(undefined);
+      const fixedValues = curve?.yFixedValues ?? [];
+      for (let i = 0; i < count; i += 1) {
+        next[i] = i < fixedValues.length ? fixedValues[i] : undefined;
+      }
+      return next;
+    },
+    [],
+  );
+
   const getAnchorCursor = React.useCallback(
-    (index: number, count: number): string => {
-      const fixedX = fixedXForCount(count)[index];
-      const fixedY = fixedYForCount(count)[index];
+    (
+      index: number,
+      count: number,
+      type: 'main' | 'overlay',
+      overlayIndex: number | null,
+      editable: boolean,
+    ): string => {
+      if (!editable) {
+        return 'not-allowed';
+      }
+      const overlayCurve = overlayIndex === null
+        ? undefined
+        : resolvedOverlaySeries[overlayIndex];
+
+      const fixedX = type === 'main'
+        ? fixedXForCount(count)[index]
+        : overlayCurve
+          ? fixedXForOverlayCount(overlayCurve, count)[index]
+          : undefined;
+      const fixedY = type === 'main'
+        ? fixedYForCount(count)[index]
+        : overlayCurve
+          ? fixedYForOverlayCount(overlayCurve, count)[index]
+          : undefined;
 
       const canMoveX = fixedX === undefined;
       const canMoveY = fixedY === undefined;
@@ -421,16 +729,38 @@ export function ToneCurveEditor({
 
       return 'not-allowed';
     },
-    [fixedXForCount, fixedYForCount],
+    [fixedXForCount, fixedYForCount, fixedXForOverlayCount, fixedYForOverlayCount, resolvedOverlaySeries],
   );
 
   const isDraggable = React.useCallback(
-    (index: number, count: number): boolean => {
-      const fixedX = fixedXForCount(count)[index];
-      const fixedY = fixedYForCount(count)[index];
+    (
+      index: number,
+      count: number,
+      type: 'main' | 'overlay',
+      overlayIndex: number | null,
+      editable: boolean,
+    ): boolean => {
+      if (!editable) {
+        return false;
+      }
+
+      const overlayCurve = overlayIndex === null
+        ? undefined
+        : resolvedOverlaySeries[overlayIndex];
+
+      const fixedX = type === 'main'
+        ? fixedXForCount(count)[index]
+        : overlayCurve
+          ? fixedXForOverlayCount(overlayCurve, count)[index]
+          : undefined;
+      const fixedY = type === 'main'
+        ? fixedYForCount(count)[index]
+        : overlayCurve
+          ? fixedYForOverlayCount(overlayCurve, count)[index]
+          : undefined;
       return fixedX === undefined || fixedY === undefined;
     },
-    [fixedXForCount, fixedYForCount],
+    [fixedXForCount, fixedYForCount, fixedXForOverlayCount, fixedYForOverlayCount, resolvedOverlaySeries],
   );
 
   const addAnchor = React.useCallback(() => {
@@ -499,26 +829,92 @@ export function ToneCurveEditor({
   }, [fixedXForCount, fixedYForCount, normalizeAnchors]);
 
   const updateAnchor = React.useCallback(
-    (index: number, clientX: number, clientY: number) => {
+    (curveType: 'main' | 'overlay', anchorIndex: number, overlayIndex: number | null, clientX: number, clientY: number) => {
       const point = screenToData(clientX, clientY);
       if (!point) {
         return;
       }
 
-      setAnchors((current) => {
-        if (index < 0 || index >= current.length) {
+      if (curveType === 'main') {
+        setAnchors((current) => {
+          const index = anchorIndex;
+          if (index < 0 || index >= current.length) {
+            return current;
+          }
+
+          const list = [...current];
+          const target = list[index];
+          const prev = index > 0 ? list[index - 1] : null;
+          const next = index < list.length - 1 ? list[index + 1] : null;
+          const isFirst = index === 0;
+          const isLast = index === list.length - 1;
+          const fixedX = fixedXForCount(list.length)[index];
+          const fixedY = fixedYForCount(list.length)[index];
+
+          const minX = isFirst
+            ? normalizedXRange.min
+            : prev
+              ? prev.x + ANCHOR_EPSILON
+              : normalizedXRange.min;
+          const maxX = isLast
+            ? normalizedXRange.max
+            : next
+              ? next.x - ANCHOR_EPSILON
+              : normalizedXRange.max;
+
+          const clampedX = fixedX === undefined
+            ? clamp(point.x, minX, maxX)
+            : clamp(fixedX, normalizedXRange.min, normalizedXRange.max);
+
+          const clampedY = fixedY === undefined
+            ? clamp(point.y, normalizedYRange.min, normalizedYRange.max)
+            : clamp(fixedY, normalizedYRange.min, normalizedYRange.max);
+
+          list[index] = {
+            ...target,
+            x: fixedX === undefined ? snapValue(clampedX, xSnapStep) : clampedX,
+            y: fixedY === undefined ? snapValue(clampedY, ySnapStep) : clampedY,
+          };
+
+          return list;
+        });
+        return;
+      }
+
+      if (overlayIndex === null || overlayIndex < 0 || overlayIndex >= resolvedOverlaySeries.length) {
+        return;
+      }
+
+      const overlayCurve = resolvedOverlaySeries[overlayIndex];
+      if (!overlayCurve) {
+        return;
+      }
+
+      const fallbackAnchors = createAnchorsFromInputs(
+        overlayCurve.anchors,
+        overlayCurve.xFixedValues,
+        overlayCurve.yFixedValues,
+      );
+
+      setOverlayAnchors((current) => {
+        const currentCurve = current[overlayIndex];
+        if (!currentCurve) {
           return current;
         }
 
-        const list = [...current];
+        const list = [...currentCurve].sort((left, right) => left.x - right.x);
+        const index = anchorIndex;
+        if (index < 0 || index >= list.length) {
+          return current;
+        }
+
         const target = list[index];
         const prev = index > 0 ? list[index - 1] : null;
         const next = index < list.length - 1 ? list[index + 1] : null;
         const isFirst = index === 0;
         const isLast = index === list.length - 1;
-        const fixedX = fixedXForCount(list.length)[index];
-        const fixedY = fixedYForCount(list.length)[index];
-
+        const fixedX = fixedXForOverlayCount(overlayCurve, list.length)[index];
+        const fixedY = fixedYForOverlayCount(overlayCurve, list.length)[index];
         const minX = isFirst
           ? normalizedXRange.min
           : prev
@@ -533,48 +929,83 @@ export function ToneCurveEditor({
         const clampedX = fixedX === undefined
           ? clamp(point.x, minX, maxX)
           : clamp(fixedX, normalizedXRange.min, normalizedXRange.max);
-
         const clampedY = fixedY === undefined
           ? clamp(point.y, normalizedYRange.min, normalizedYRange.max)
           : clamp(fixedY, normalizedYRange.min, normalizedYRange.max);
 
-        list[index] = {
+        const nextCurve = [...list];
+        nextCurve[index] = {
           ...target,
           x: fixedX === undefined ? snapValue(clampedX, xSnapStep) : clampedX,
           y: fixedY === undefined ? snapValue(clampedY, ySnapStep) : clampedY,
         };
 
-        return list;
+        const normalizedCurve = normalizeAnchors(
+          nextCurve,
+          fixedXForOverlayCount(overlayCurve, nextCurve.length),
+          fixedYForOverlayCount(overlayCurve, nextCurve.length),
+          fallbackAnchors,
+        );
+        const nextAnchors = [...current];
+        nextAnchors[overlayIndex] = normalizedCurve;
+        if (overlayCurve.onChange) {
+          overlayCurve.onChange(normalizedCurve);
+        }
+        return nextAnchors;
       });
     },
-    [clamp, fixedXForCount, fixedYForCount, normalizedXRange.max, normalizedXRange.min, normalizedYRange.max, normalizedYRange.min, screenToData, xSnapStep, ySnapStep],
+    [
+      clamp,
+      createAnchorsFromInputs,
+      fixedXForCount,
+      fixedYForCount,
+      fixedXForOverlayCount,
+      fixedYForOverlayCount,
+      normalizeAnchors,
+      normalizedXRange.max,
+      normalizedXRange.min,
+      normalizedYRange.max,
+      normalizedYRange.min,
+      resolvedOverlaySeries,
+      screenToData,
+      xSnapStep,
+      ySnapStep,
+    ],
   );
 
   const handlePointPointerDown = React.useCallback(
-    (index: number) => (event: React.PointerEvent<SVGCircleElement>) => {
-      if (!isDraggable(index, sortedPoints.length)) {
+    (curveType: 'main' | 'overlay', overlayIndex: number | null, index: number, editable: boolean) => (event: React.PointerEvent<SVGCircleElement>) => {
+      const count = curveType === 'main'
+        ? sortedPoints.length
+        : (overlayIndex === null ? 0 : sortedOverlayPoints[overlayIndex]?.length ?? 0);
+
+      if (!isDraggable(index, count, curveType, overlayIndex, editable)) {
         event.preventDefault();
         return;
       }
 
       event.preventDefault();
-      activeAnchorIndexRef.current = index;
+      activeAnchorRef.current = {
+        type: curveType,
+        curveIndex: overlayIndex,
+        anchorIndex: index,
+      };
       event.currentTarget.setPointerCapture(event.pointerId);
     },
-    [isDraggable, sortedPoints.length],
+    [isDraggable, sortedOverlayPoints, sortedPoints.length],
   );
 
   React.useEffect(() => {
     const onPointerMove = (event: PointerEvent): void => {
-      const index = activeAnchorIndexRef.current;
-      if (index === null) {
+      const activeAnchor = activeAnchorRef.current;
+      if (!activeAnchor) {
         return;
       }
-      updateAnchor(index, event.clientX, event.clientY);
+      updateAnchor(activeAnchor.type, activeAnchor.anchorIndex, activeAnchor.curveIndex, event.clientX, event.clientY);
     };
 
     const onPointerUp = (): void => {
-      activeAnchorIndexRef.current = null;
+      activeAnchorRef.current = null;
     };
 
     window.addEventListener('pointermove', onPointerMove);
@@ -587,16 +1018,21 @@ export function ToneCurveEditor({
     };
   }, [updateAnchor]);
 
+  const mainCurveStyle = getLineStyle(0);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10, width, ...style }} className={className}>
       <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <button type="button" onClick={addAnchor} aria-label="Add anchor">
-          +
-        </button>
-        <button type="button" onClick={removeAnchor} disabled={anchors.length <= 2} aria-label="Remove anchor">
-          -
-        </button>
-        <span style={{ fontSize: 12 }}>{`Anchors: ${anchors.length}`}</span>
+        {allowAnchorCountChange ? (
+          <>
+            <button type="button" onClick={addAnchor} aria-label="Add anchor">
+              +
+            </button>
+            <button type="button" onClick={removeAnchor} disabled={anchors.length <= 2} aria-label="Remove anchor">
+              -
+            </button>
+          </>
+        ) : null}
       </div>
       <svg
         ref={svgRef}
@@ -645,16 +1081,8 @@ export function ToneCurveEditor({
         ))}
         {normalizedYMarks.map((mark) => (
           <g key={`y-mark-${mark.value}-${mark.label}`}>
-            <line
-              x1={inner.paddingLeft - 6}
-              y1={yToScreen(mark.value)}
-              x2={inner.paddingLeft}
-              y2={yToScreen(mark.value)}
-              stroke="#64748b"
-              strokeWidth={1}
-            />
             <text
-              x={inner.paddingLeft - 10}
+              x={inner.paddingLeft - 18}
               y={yToScreen(mark.value) + 3}
               textAnchor="end"
               fontSize={10}
@@ -664,21 +1092,79 @@ export function ToneCurveEditor({
             </text>
           </g>
         ))}
-        <polyline fill="none" stroke={resolvedLineColor} strokeWidth={2} points={pathPoints} />
+        {anchorYMarks.map((mark) => (
+          <g key={`anchor-y-mark-${mark.value}-${mark.label}`}>
+            <text
+              x={inner.paddingLeft - 18}
+              y={yToScreen(mark.value) + 3}
+              textAnchor="end"
+              fontSize={10}
+              fill="#0f172a"
+            >
+              {mark.label}
+            </text>
+          </g>
+        ))}
+        <polyline
+          fill="none"
+          stroke={mainCurveStyle.lineColor}
+          strokeWidth={mainCurveStyle.lineWidth}
+          strokeDasharray={mainCurveStyle.lineDashArray}
+          points={pathPoints}
+        />
         {sortedPoints.map((anchor, index) => {
-          const cursor = getAnchorCursor(index, sortedPoints.length);
+          const cursor = getAnchorCursor(index, sortedPoints.length, 'main', null, true);
           return (
             <g key={`${index}`}>
               <circle
                 cx={xToScreen(anchor.x)}
                 cy={yToScreen(anchor.y)}
                 r={5}
-                fill={resolvedAnchorPointColor}
+                fill={mainCurveStyle.anchorPointColor}
                 stroke="#fff"
                 strokeWidth={1.5}
-                onPointerDown={handlePointPointerDown(index)}
+                onPointerDown={handlePointPointerDown('main', null, index, true)}
                 style={{ cursor }}
               />
+            </g>
+          );
+        })}
+        {overlayPathPoints.map((points, overlayIndex) => {
+          const overlayCurve = resolvedOverlaySeries[overlayIndex];
+          if (!overlayCurve) {
+            return null;
+          }
+
+          const curvePoints = sortedOverlayPoints[overlayIndex];
+          if (!curvePoints) {
+            return null;
+          }
+
+          return (
+            <g key={`overlay-${overlayIndex}`}>
+              <polyline
+                fill="none"
+                stroke={overlayCurve.lineColor}
+                strokeWidth={overlayCurve.lineWidth}
+                strokeDasharray={overlayCurve.lineDashArray}
+                points={points}
+              />
+              {curvePoints.map((anchor, pointIndex) => {
+                const cursor = getAnchorCursor(pointIndex, curvePoints.length, 'overlay', overlayIndex, overlayCurve.editable);
+                return (
+                  <circle
+                    key={`overlay-${overlayIndex}-anchor-${pointIndex}`}
+                    cx={xToScreen(anchor.x)}
+                    cy={yToScreen(anchor.y)}
+                    r={5}
+                    fill={overlayCurve.anchorPointColor}
+                    stroke="#fff"
+                    strokeWidth={1.5}
+                    onPointerDown={handlePointPointerDown('overlay', overlayIndex, pointIndex, overlayCurve.editable)}
+                    style={{ cursor }}
+                  />
+                );
+              })}
             </g>
           );
         })}

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler/transformByBandRetrySimplify.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler/transformByBandRetrySimplify.ts
@@ -1,8 +1,5 @@
 import type { Feature, FeatureCollection } from 'geojson';
 
-const MAX_BISECTION_STEPS = 8;
-const BISECTION_STEP_DECAY_FACTOR = 2;
-
 export type RetrySimplifyFeatureResult = {
   feature: Feature;
   vertexCount: number;
@@ -28,8 +25,8 @@ export type RetryFeatureParams = {
   feature: Feature;
   baseTolerance: number;
   retryVertexLimit: number;
-  retryToleranceStep: number;
-  maxRetrySteps: number;
+  retryToleranceSecond: number;
+  maxRetryAttempts: number;
   featureIndex: number;
   featureTotal: number;
   runRetrySimplifyAttempt: (tolerance: number) => Promise<Feature | null>;
@@ -64,8 +61,8 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     feature,
     baseTolerance,
     retryVertexLimit,
-    retryToleranceStep,
-    maxRetrySteps,
+    retryToleranceSecond,
+    maxRetryAttempts,
     featureIndex,
     featureTotal,
     runRetrySimplifyAttempt,
@@ -94,18 +91,12 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     };
   }
 
-  let lastFailTolerance = baseTolerance;
-  let successTolerance: number | null = null;
-  let successIndex: number | null = null;
-  let bestFeature: Feature | null = null;
-  let bestTolerance = baseTolerance;
-  let bestVertexCount = baseVertexCount;
   let lastAttemptFeature: Feature = feature;
   let lastAttemptVertexCount = baseVertexCount;
   let lastAttemptTolerance = baseTolerance;
   let retryAttempts = 0;
 
-  if (retryToleranceStep <= 0) {
+  if (maxRetryAttempts <= 0 || !Number.isFinite(retryToleranceSecond)) {
     return {
       feature,
       vertexCount: baseVertexCount,
@@ -115,13 +106,16 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     };
   }
 
-  for (let i = 0; i < maxRetrySteps; i += 1) {
-    const nextToleranceValue = baseTolerance + retryToleranceStep * (i + 1);
+  for (let attempt = 0; attempt < maxRetryAttempts; attempt += 1) {
+    const attemptNumber = attempt + 2;
+    const nextToleranceValue = attemptNumber === 2
+      ? retryToleranceSecond
+      : baseTolerance + (retryToleranceSecond - baseTolerance) * (2 ** (attemptNumber - 2));
     await updateRetrySimplifyAttemptPhase({
       featureIndex,
       featureTotal,
       attempt: retryAttempts + 1,
-      attemptTotal: maxRetrySteps,
+      attemptTotal: maxRetryAttempts,
       tolerance: nextToleranceValue,
     });
     const retryFeature = await runRetrySimplifyAttempt(nextToleranceValue);
@@ -134,56 +128,7 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     lastAttemptVertexCount = retryVertexCount;
 
     if (retryVertexCount < retryVertexLimit) {
-      successTolerance = nextToleranceValue;
-      successIndex = i;
-      bestFeature = retryFeature;
-      bestTolerance = nextToleranceValue;
-      bestVertexCount = retryVertexCount;
       break;
-    }
-
-    lastFailTolerance = nextToleranceValue;
-  }
-
-  if (bestFeature && successTolerance !== null && successIndex !== null) {
-    const bisectionSteps = Math.max(0, MAX_BISECTION_STEPS - Math.ceil(successIndex / BISECTION_STEP_DECAY_FACTOR));
-    const bisectionAttemptTotal = maxRetrySteps + bisectionSteps;
-    let low = lastFailTolerance;
-    let high = successTolerance;
-
-    for (let stepIndex = 0; stepIndex < bisectionSteps; stepIndex += 1) {
-      const mid = (low + high) / 2;
-      await updateRetrySimplifyAttemptPhase({
-        featureIndex,
-        featureTotal,
-        attempt: retryAttempts + 1,
-        attemptTotal: bisectionAttemptTotal,
-        tolerance: mid,
-      });
-      const midFeature = await runRetrySimplifyAttempt(mid);
-      retryAttempts += 1;
-      lastAttemptTolerance = mid;
-      if (!midFeature?.geometry) break;
-
-      const midVertexCount = countVerticesFromGeometry(midFeature.geometry);
-      if (midVertexCount < retryVertexLimit) {
-        high = mid;
-        bestFeature = midFeature;
-        bestTolerance = mid;
-        bestVertexCount = midVertexCount;
-      } else {
-        low = mid;
-      }
-    }
-
-    if (bestFeature) {
-      return {
-        feature: bestFeature,
-        vertexCount: bestVertexCount,
-        overLimit: false,
-        retryAttempts,
-        finalTolerance: bestTolerance,
-      };
     }
   }
 

--- a/plugins/shape-plugin/src/common/types/build.ts
+++ b/plugins/shape-plugin/src/common/types/build.ts
@@ -1,4 +1,4 @@
-import type { TaskDisplayPayload, TaskStage } from '../../../../../packages/build-api';
+import type { TaskDisplayPayload, TaskStage } from '@hierarchidb/build-api';
 import type { NodeId } from '@hierarchidb/core-types';
 import type {
   BaseBuildConfig,
@@ -11,10 +11,6 @@ import type {
 } from '@hierarchidb/gis-sdk';
 import type { BuildSessionConfig, ResourceUsage, StageStatus } from '@hierarchidb/shape-store';
 import type { DataSourceName } from './data-source.js';
-
-//import type { ObsolateBuildConfig, HybridFilterConfig } from './ObsolateBuildConfig.ts';
-//import type { ObsolateBuildConfig } from './ObsolateBuildConfig.ts';
-//import type { FeatureFilterMethod, ExtractionMode } from './processing.js';
 
 export type ShapeBuildFetchConfig = Omit<
   FetchConfig,

--- a/plugins/shape-plugin/src/services/utils/toleranceByBand.ts
+++ b/plugins/shape-plugin/src/services/utils/toleranceByBand.ts
@@ -1,7 +1,7 @@
 import type { ToneCurveAnchor } from '@hierarchidb/ui-tone-curve-editor';
 
 export const TOLERANCE_MIN = 0;
-export const TOLERANCE_MAX = 2;
+export const TOLERANCE_MAX = 12;
 
 const resolveNumericToleranceValue = (value: unknown, fallback: number): number => (
   typeof value === 'number' && Number.isFinite(value) ? clampTolerance(value, fallback) : fallback
@@ -12,6 +12,13 @@ export const clampTolerance = (value: number, fallback: number): number => {
     return fallback;
   }
   return Math.min(TOLERANCE_MAX, Math.max(TOLERANCE_MIN, value));
+};
+
+const clampInRange = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, value));
 };
 
 export const resolveToleranceByBand = (
@@ -50,6 +57,10 @@ export const normalizeToleranceByBand = (
 const resolveBandBoundaryRepValues = (zoomBandBoundaries: number[]): number[] => {
   const count = Math.max(0, zoomBandBoundaries.length - 1);
   return zoomBandBoundaries.slice(0, count);
+};
+
+const resolveToneCurveBoundaryRepValues = (zoomBandBoundaries: number[]): number[] => {
+  return [...zoomBandBoundaries];
 };
 
 const resolveBandIndexForZoom = (zoomBandBoundaries: number[], zoom: number): number => {
@@ -122,6 +133,7 @@ export const buildToneCurveAnchorsFromToleranceByBand = (
   toleranceByBand: number[] | undefined,
   zoomBandBoundaries: number[],
   fallback = 0.1,
+  fallbackAnchors?: readonly number[],
 ): ToneCurveAnchor[] => {
   const bandCount = Math.max(0, zoomBandBoundaries.length - 1);
   if (bandCount === 0) {
@@ -131,9 +143,22 @@ export const buildToneCurveAnchorsFromToleranceByBand = (
     ];
   }
 
-  const reps = resolveBandBoundaryRepValues(zoomBandBoundaries);
-  const normalized = normalizeToleranceByBand(toleranceByBand, bandCount, fallback);
-  return reps.map((x, index) => ({ x, y: normalized[index] ?? 0.1 }));
+  const reps = resolveToneCurveBoundaryRepValues(zoomBandBoundaries);
+  const boundaryCount = zoomBandBoundaries.length;
+  const resolvedFallbackAnchors = fallbackAnchors ?? [];
+  const rawNormalized = Array.from({ length: boundaryCount }, (_, index) => (
+    index < reps.length
+      ? resolveNumericToleranceValue(
+        toleranceByBand?.[index],
+        index < resolvedFallbackAnchors.length ? (resolvedFallbackAnchors[index] ?? fallback) : fallback,
+      )
+      : fallback
+  ));
+
+  return reps.map((x, index) => ({
+    x,
+    y: rawNormalized[index] ?? fallback,
+  }));
 };
 
 export const buildToleranceByBandFromToneCurveAnchors = (
@@ -149,21 +174,31 @@ export const buildToleranceByBandFromToneCurveAnchors = (
     return Array.from({ length: bandCount }, () => fallback);
   }
 
-  const sortedAnchors = [...anchors].sort((left: ToneCurveAnchor, right: ToneCurveAnchor) => left.x - right.x);
-  const reps = resolveBandBoundaryRepValues(zoomBandBoundaries);
-  const result: number[] = [];
-  let anchorIndex = 0;
+  const normalizedAnchors = [...anchors]
+    .filter((anchor): anchor is ToneCurveAnchor => Number.isFinite(anchor.x) && Number.isFinite(anchor.y))
+    .sort((left: ToneCurveAnchor, right: ToneCurveAnchor) => left.x - right.x)
+    .map((anchor) => ({
+      x: clampInRange(anchor.x, zoomBandBoundaries[0] ?? 0, zoomBandBoundaries.at(-1) ?? 11),
+      y: clampInRange(anchor.y, TOLERANCE_MIN, TOLERANCE_MAX),
+    }));
 
-  for (const rep of reps) {
-    while (
-      anchorIndex + 1 < sortedAnchors.length
-      && (sortedAnchors[anchorIndex + 1]?.x ?? Number.NEGATIVE_INFINITY) <= rep
-    ) {
-      anchorIndex += 1;
+  if (normalizedAnchors.length === 0) {
+    return Array.from({ length: bandCount }, () => fallback);
+  }
+  if (normalizedAnchors.length === 1) {
+    return Array.from({ length: bandCount }, () => clampTolerance(normalizedAnchors[0]?.y ?? fallback, fallback));
+  }
+
+  const result: number[] = [];
+  const anchorCount = zoomBandBoundaries.length;
+
+  for (let index = 0; index < anchorCount; index += 1) {
+    const anchor = normalizedAnchors[index];
+    if (anchor === undefined) {
+      result.push(fallback);
+      continue;
     }
-    const anchor = sortedAnchors[Math.min(anchorIndex, sortedAnchors.length - 1)];
-    const value = typeof anchor?.y === 'number' ? anchor.y : fallback;
-    result.push(clampTolerance(value, fallback));
+    result.push(clampTolerance(anchor.y, fallback));
   }
 
   return result;

--- a/plugins/shape-plugin/src/ui/components/build-config/TransformConfigSection.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/TransformConfigSection.tsx
@@ -41,23 +41,65 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
   const { t } = useTranslation();
   const { baseTransformConfig, update } = useTransformConfigSection({ config, onChange });
   const hoverCardSx = getBuildConfigHoverCardSx(disabled);
-  const clampSliderValue = (value: number) => Math.min(2, Math.max(0, value));
+  const clampRetryCount = (value: number): number => Math.min(10, Math.max(0, Math.round(value)));
   const resolveSliderNumber = (value: number | number[]) => (Array.isArray(value) ? value[0] ?? 0 : value);
+  const retryCountMarks = [
+    0, 2, 4, 6, 8, 10,
+  ].map((value) => ({ value, label: String(value) }));
 
   const simplifyAlgorithm = baseTransformConfig.simplifyAlgorithm ?? 'topojson';
-  const simplifyRetryStep = typeof baseTransformConfig.retryToleranceStep === 'number'
-    ? clampSliderValue(baseTransformConfig.retryToleranceStep)
-    : 0.5;
+  const simplifyRetryCount = typeof baseTransformConfig.retryCount === 'number'
+    && Number.isFinite(baseTransformConfig.retryCount)
+    ? clampRetryCount(baseTransformConfig.retryCount)
+    : 4;
   const preserveTopology = baseTransformConfig.preserveTopology ?? true;
   const executionLogLevel = baseTransformConfig.executionLogLevel ?? 'summary';
   const toleranceFallback = 0.1;
-  const toleranceByBandAnchors = buildToneCurveAnchorsFromToleranceByBand(
-    baseTransformConfig.toleranceByBand,
-    baseTransformConfig.zoomBandBoundaries,
-    toleranceFallback
-  );
+  const toneCurveDefaultAnchorValues = [8, 6, 3, 1] as const;
+  const toneCurveRetrySecondDefaultAnchorValues = [9, 7, 4, 2] as const;
+  const toneCurveLineStyles = [
+    {
+      lineColor: '#0b5ed7',
+      anchorPointColor: '#0b5ed7',
+      lineWidth: 2,
+    },
+    {
+      lineColor: '#ef4444',
+      anchorPointColor: '#ef4444',
+      lineWidth: 2,
+      lineDashArray: '6 4',
+    },
+  ] as const;
+  const boundaryCount = baseTransformConfig.zoomBandBoundaries.length;
+  const hasCompleteToleranceByBand = (baseTransformConfig.toleranceByBand?.length ?? 0) === boundaryCount;
+  const resolvedToneCurveAnchors = hasCompleteToleranceByBand
+    ? buildToneCurveAnchorsFromToleranceByBand(
+      baseTransformConfig.toleranceByBand,
+      baseTransformConfig.zoomBandBoundaries,
+      toleranceFallback,
+      toneCurveDefaultAnchorValues,
+    )
+    : buildToneCurveAnchorsFromToleranceByBand(
+      undefined,
+      baseTransformConfig.zoomBandBoundaries,
+      toleranceFallback,
+      toneCurveDefaultAnchorValues,
+    );
+  const hasCompleteRetryToleranceByBand = (baseTransformConfig.retryToleranceByBand?.length ?? 0) === boundaryCount;
+  const resolvedToneCurveRetrySecondAnchors = hasCompleteRetryToleranceByBand
+    ? buildToneCurveAnchorsFromToleranceByBand(
+      baseTransformConfig.retryToleranceByBand,
+      baseTransformConfig.zoomBandBoundaries,
+      toleranceFallback,
+      toneCurveRetrySecondDefaultAnchorValues,
+    )
+    : buildToneCurveAnchorsFromToleranceByBand(
+      undefined,
+      baseTransformConfig.zoomBandBoundaries,
+      toleranceFallback,
+      toneCurveRetrySecondDefaultAnchorValues,
+    );
   const xMarks = baseTransformConfig.zoomBandBoundaries.map((value) => ({ value, label: String(value) }));
-  const toneCurveDefaultAnchors = toleranceByBandAnchors;
 
   const updateTransformConfig = (partial: Partial<ShapeBuildConfig['transformConfig']>) => (
     update({
@@ -149,11 +191,32 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
                   width={500}
                   height={180}
                   xRange={[baseTransformConfig.zoomBandBoundaries[0] ?? 1, baseTransformConfig.zoomBandBoundaries.at(-1) ?? 11]}
-                  yRange={[0, 2]}
+                  yRange={[0, 12]}
+                  lineStyles={toneCurveLineStyles}
                   xMarks={xMarks}
-                  xFixedValues={toneCurveDefaultAnchors.map((anchor) => anchor.x)}
-                  yFixedValues={toneCurveDefaultAnchors.map((anchor) => anchor.y)}
-                  ySnapStep={0.01}
+                  anchors={resolvedToneCurveAnchors}
+                  xFixedValues={resolvedToneCurveAnchors.map((anchor) => anchor.x)}
+                  allowAnchorCountChange={false}
+                  xSnapStep={0.1}
+                  ySnapStep={0.1}
+                  overlaySeries={[
+                    {
+                      anchors: resolvedToneCurveRetrySecondAnchors,
+                      xFixedValues: resolvedToneCurveRetrySecondAnchors.map((anchor) => anchor.x),
+                      yFixedValues: resolvedToneCurveRetrySecondAnchors.map((anchor) => anchor.y),
+                      allowAnchorCountChange: false,
+                      editable: true,
+                      onChange: (overlayAnchors) => {
+                        if (disabled) return;
+                        const next = buildToleranceByBandFromToneCurveAnchors(
+                          overlayAnchors,
+                          baseTransformConfig.zoomBandBoundaries,
+                          toleranceFallback,
+                        );
+                        updateTransformConfig({ retryToleranceByBand: next });
+                      },
+                    },
+                  ]}
                   onChange={(anchors) => {
                     if (disabled) return;
                     const next = buildToleranceByBandFromToneCurveAnchors(
@@ -168,20 +231,21 @@ export const TransformConfigSection: React.FC<Props> = ({ config, onChange, disa
 
               <Stack spacing={0.5}>
                 <Typography variant="body2" color="text.secondary">
-                  {t('processing.transform.retryToleranceStep.label', 'Retry tolerance step')}
+                  {t('processing.transform.retryToleranceStep.label', 'Retry count')}
                 </Typography>
-                <Stack direction="row" spacing={2} alignItems="center">
+                <Stack direction="row" spacing={2} alignItems="center" sx={{ paddingTop: '32px' }}>
                   <Slider
                     sx={{ flex: 1 }}
-                    value={simplifyRetryStep}
+                    value={simplifyRetryCount}
                     min={0}
-                    max={2}
-                    step={0.01}
+                    max={10}
+                    step={1}
+                    marks={retryCountMarks}
                     disabled={disabled}
-                    valueLabelDisplay="auto"
+                    valueLabelDisplay="on"
                     onChange={(_event, value) => {
-                      const next = clampSliderValue(resolveSliderNumber(value));
-                      updateTransformConfig({ retryToleranceStep: next });
+                      const next = clampRetryCount(resolveSliderNumber(value));
+                      updateTransformConfig({ retryCount: next });
                     }}
                   />
                 </Stack>


### PR DESCRIPTION
## Summary
- Restore omitted Step4 simplify retry UI updates:
  - Replace single retryToleranceStep slider with Retry count slider (0..10, integer, marks 0/2/4/6/8/10, always-visible value).
  - Add second tolerance curve overlay (red dashed) in ToneCurveEditor.
  - Remove always-on anchor-count label text from ToneCurveEditor UI.
- Update defaults and types for new config fields:
  -  and  in transform config schema/defaults.
  - adjust tone curve anchor conversion helpers.
- Update simplify retry core helper to follow retry-step requirement using second tolerance value and retry count.

## Notes
- This PR addresses previously omitted changes from the retry simplification work (TypeError fix and Step4 UI updates).
