### PR TITLE
fix(shape-plugin): resolve invalid ui-build-sessions import path

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #567 / `codex/fix/shape-plugin-build-sessions-import-567` / start: 2026-02-26 17:30 JST
 - #560 / `codex/feat/shape/admin-level-simplify-tolerance-560` / start: 2026-02-25 23:40 JST
 - #559 / `codex/feat/ui/plugin-dialog-stepper-context-menu-559` / start: 2026-02-25 23:16 JST
 - #513 / `fix/shape/initial-build-progress-stability` / start: 2026-02-22 10:40 JST
@@ -118,6 +119,9 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- update: 2026-02-26 17:44 JST #567 原因は `plugins/shape-plugin/src/ui/components/build-progress/*` に `../../../../../../packages/ui/build-sessions` への不正相対importが残っていたこと。発生範囲は build-progress 関連 7 ファイル。修正として全参照を `@hierarchidb/ui-build-sessions` へ統一し、`plugins/shape-plugin/package.json` の `turbo.pipeline.build.dependsOn` に `@hierarchidb/ui-build-sessions#build` を追加して依存順を保証。適用範囲は shape-plugin の当該 import と turbo 設定のみ。
+- blocked: 2026-02-26 17:45 JST #567 `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --only --output-logs errors-only` は差分外既知ブロッカー（多数の TS2307/TS7006）で exit 2。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin --only --output-logs errors-only` は exit 0（本件の import 解決エラー再発なし）。
+- start: 2026-02-26 17:30 JST #567 を起票（https://github.com/kubohiroya/hierarchidb/issues/567）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape-plugin-build-sessions-import-567` を作成して着手。
 - update: 2026-02-25 23:48 JST #560 Step4 に `SimplifyToleranceByAdminLevelCard`（Admin 0/1/2/3+ Tabs、Admin1+ の「前のタブの値を参照して利用」スイッチ/「前のタブの値をコピーして適用」ボタン）を実装し、`ShapeBuildConfig` 型（`TransformConfig.simplifyToleranceByAdminLevel`）・`DEFAULT_BUILD_CONFIG`・`shapeCreatePresets` を拡張。Step5 Transform は `@hierarchidb/vt-orchestrator` の `resolveSimplifyToleranceProfile` で地物 `adminLevel` ごとに tolerance/retryTolerance/retryCount を解決して適用するよう更新。
 - blocked: 2026-02-25 23:48 JST #560 `pnpm -w turbo run typecheck --filter @hierarchidb/gis-sdk --filter @hierarchidb/shape-api --filter @hierarchidb/shape-plugin --filter @hierarchidb/vt-orchestrator --only --output-logs errors-only` は差分外既知ブロッカー `packages/gis-sdk/src/ephemeral/EphemeralDB.ts:87`（TS2352）で exit 2。差分検証は `--only` で `@hierarchidb/shape-plugin` / `@hierarchidb/vt-orchestrator` を個別実行し exit 0 を確認。
 - start: 2026-02-25 23:40 JST #560 を起票（https://github.com/kubohiroya/hierarchidb/issues/560）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/feat/shape/admin-level-simplify-tolerance-560` を作成して着手。

--- a/plugins/shape-plugin/package.json
+++ b/plugins/shape-plugin/package.json
@@ -263,6 +263,7 @@
       "build": {
         "dependsOn": [
           "@hierarchidb/plugin-base#build",
+          "@hierarchidb/ui-build-sessions#build",
           "@hierarchidb/ui-tone-curve-editor#build",
           "@hierarchidb/vt-orchestrator#build"
         ]

--- a/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressRuntimeHelpers.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressRuntimeHelpers.ts
@@ -1,4 +1,4 @@
-import { computePercentage, type TaskCountSummary } from '../../../../../../packages/ui/build-sessions';
+import { computePercentage, type TaskCountSummary } from '@hierarchidb/ui-build-sessions';
 import type { BuildProgress } from './shapeBuildProgressMapping.js';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
 import type { StageCountInfo } from './shapeBuildProgressSummaryCountHelpers.js';

--- a/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressSummaryComputation.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressSummaryComputation.ts
@@ -6,7 +6,7 @@ import {
   useBuildTaskProgress,
   type TaskCountSummary,
   type TaskLike,
-} from '../../../../../../packages/ui/build-sessions';
+} from '@hierarchidb/ui-build-sessions';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
 import type { BuildTaskSummary } from '@hierarchidb/build-api';
 import type { TaskStage } from '@hierarchidb/build-api';

--- a/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressSummaryComputationHelpers.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressSummaryComputationHelpers.ts
@@ -1,4 +1,4 @@
-export type { TaskCountSummary } from '../../../../../../packages/ui/build-sessions';
+export type { TaskCountSummary } from '@hierarchidb/ui-build-sessions';
 export type { BuildStatus } from '@hierarchidb/components/build-status';
 export type { StageCountInfo } from './shapeBuildProgressSummaryCountHelpers.js';
 export {

--- a/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressSummaryCountHelpers.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildProgressSummaryCountHelpers.ts
@@ -1,4 +1,4 @@
-import type { TaskCountSummary } from '../../../../../../packages/ui/build-sessions';
+import type { TaskCountSummary } from '@hierarchidb/ui-build-sessions';
 import type { BuildProgress } from './shapeBuildProgressMapping.js';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
 import type { BuildStage } from '@hierarchidb/components/build-stage';

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgress/useBuildProgress.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgress/useBuildProgress.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { NodeType } from '@hierarchidb/core-types';
 import type { BuildUnifiedProgressInfo } from '@hierarchidb/build-api';
-import { usePluginBuildProgress } from '../../../../../../../packages/ui/build-sessions';
+import { usePluginBuildProgress } from '@hierarchidb/ui-build-sessions';
 import {
   toShapeProgress,
   toShapeStatus,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildLabels/useShapeBuildLabels.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildLabels/useShapeBuildLabels.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { BuildStage } from '@hierarchidb/components/build-stage';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
-import type { TaskCountSummary } from '../../../../../../../packages/ui/build-sessions';
+import type { TaskCountSummary } from '@hierarchidb/ui-build-sessions';
 import type { BuildProgress, BuildProgressStatus } from '~/ui/components/build-progress/shapeBuildProgressMapping';
 import { formatTaskDisplayMessage } from '~/ui/components/build-progress/taskDisplayText';
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts
@@ -5,7 +5,7 @@ import {
   replaceSnapshotAndPreserveNonIncomingStages,
 } from './useShapeBuildTaskSync.comparison.utils.js';
 import type { ShapeBuildTaskSummary } from '~/ui/atoms/shapeBuildProgressAtoms';
-import { upsertTaskInOrder } from '../../../../../../../packages/ui/build-sessions';
+import { upsertTaskInOrder } from '@hierarchidb/ui-build-sessions';
 import { useShapeBuildTaskSyncState } from './useShapeBuildTaskSync.state.js';
 import type { SyncResult, SyncSchedulingArgs } from './useShapeBuildTaskSync.types.js';
 


### PR DESCRIPTION
## Summary
- replace invalid relative imports to `packages/ui/build-sessions` with workspace import `@hierarchidb/ui-build-sessions`
- add missing turbo build dependency `@hierarchidb/ui-build-sessions#build` in `@hierarchidb/shape-plugin`
- update TASKS operation log for #567 (cause/scope/fix/verification)

## Verification
- `pnpm -w turbo run build --filter @hierarchidb/shape-plugin --only --output-logs errors-only` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --only --output-logs errors-only` (exit 2, existing unrelated TS2307/TS7006 blockers)

Refs #567
