### PR TITLE
fix(shape): keep queued fetch tasks on resume

### DIFF
--- a/plugins/shape-plugin/src/__tests__/unit/shapePipelineFetchStageSection.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/shapePipelineFetchStageSection.unit.test.ts
@@ -53,6 +53,17 @@ const createAuthPendingFetchTask = (taskId: string): TaskQueueRecord => ({
   updatedAt: Date.now(),
 });
 
+const createQueuedFetchTask = (taskId: string): TaskQueueRecord => ({
+  taskId,
+  nodeId: NODE_ID,
+  stage: 'fetch',
+  index: 0,
+  status: 'queued',
+  progress: 0,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+});
+
 describe('runShapeFetchStageSection', () => {
   let db: VtTaskQueueDb | null = null;
 
@@ -148,5 +159,39 @@ describe('runShapeFetchStageSection', () => {
     ]);
     expect(failed).toHaveLength(0);
     expect(queued).toHaveLength(1);
+  });
+
+  it('keeps queued fetch tasks as queued during resume runs instead of marking them failed', async () => {
+    db = createDb();
+    await putTasks(db, [createQueuedFetchTask('fetch-queued-1')]);
+
+    const runShapeFetchStageSpy = vi
+      .spyOn(shapeFetchStageModule, 'runShapeFetchStage')
+      .mockResolvedValue(undefined);
+
+    try {
+      const stopAfterStage = await runShapeFetchStageSection({
+        nodeId: NODE_ID,
+        dataSource: 'geoboundaries',
+        buildConfig: DEFAULT_BUILD_CONFIG,
+        taskQueue: db,
+        resumeExistingTasks: true,
+        failureHandling: 'continue',
+        buildContinuationPolicy: 'finish_all_stages',
+        pipelineRunId: 'test-run-resume-pending',
+      });
+      expect(stopAfterStage).toBe(false);
+    } finally {
+      runShapeFetchStageSpy.mockRestore();
+    }
+
+    const [failed, queued] = await Promise.all([
+      listTasksByStageAndStatus(db, NODE_ID, 'fetch', 'failed'),
+      listTasksByStageAndStatus(db, NODE_ID, 'fetch', 'queued'),
+    ]);
+    expect(failed).toHaveLength(0);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.message ?? null).toBeNull();
+    expect(queued[0]?.errorMessage ?? null).toBeNull();
   });
 });

--- a/plugins/shape-plugin/src/services/vt/shapePipelineFetchStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineFetchStage.ts
@@ -83,6 +83,18 @@ export const runShapeFetchStageSection = async (params: ShapeFetchStageParams): 
     runId: params.pipelineRunId ?? null,
     counts: stageCounts,
   }));
+  if (params.resumeExistingTasks && (stageCounts.queued > 0 || stageCounts.running > 0)) {
+    await resetStageRunningTasks(params.taskQueue, params.nodeId, 'fetch');
+    stageCounts = await summarizeStageCounts(params.taskQueue, params.nodeId, 'fetch');
+    if (stageCounts.queued > 0 || stageCounts.running > 0) {
+      console.warn('[ShapeFetch][PipelineDiagnostics] fetch stage left pending tasks during resume; keep queued for next retry', JSON.stringify({
+        nodeId: params.nodeId,
+        runId: params.pipelineRunId ?? null,
+        counts: stageCounts,
+      }));
+    }
+  }
+  const shouldFinalizePending = !params.resumeExistingTasks || (stageCounts.queued === 0 && stageCounts.running === 0);
   const finalizedPending = await finalizePendingStageTasks(
     params.taskQueue,
     params.nodeId,
@@ -90,6 +102,9 @@ export const runShapeFetchStageSection = async (params: ShapeFetchStageParams): 
     'aborted: fetch stage completed with pending tasks',
     '[ShapeFetch][PipelineDiagnostics] fetch stage finalized pending tasks',
     params.pipelineRunId,
+    {
+      markFailed: shouldFinalizePending,
+    },
   );
   if (finalizedPending.authPending > 0) {
     throw new FetchStageAuthPendingError();

--- a/plugins/shape-plugin/src/services/vt/shapePipelineStageHelpers.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineStageHelpers.ts
@@ -116,6 +116,9 @@ export const finalizePendingStageTasks = async (
   errorMessage: string,
   logLabel: string,
   pipelineRunId?: string,
+  options?: {
+    markFailed?: boolean;
+  },
 ): Promise<{ queued: number; running: number; authPending: number }> => {
   const [queuedTasks, runningTasks] = await Promise.all([
     listTasksByStageAndStatus(taskQueue, nodeId, stage, 'queued'),
@@ -132,23 +135,27 @@ export const finalizePendingStageTasks = async (
     return authState === 'required';
   });
   const finalizeTargets = pendingTasks.filter((task) => !authPendingTasks.includes(task));
+  const shouldMarkFailed = options?.markFailed ?? true;
   const now = Date.now();
-  await Promise.all(
-    finalizeTargets.map((task) => (
-      updateTask(taskQueue, task.taskId, {
-        status: 'failed',
-        message: errorMessage,
-        errorMessage,
-        completedAt: now,
-      })
-    )),
-  );
+  if (shouldMarkFailed) {
+    await Promise.all(
+      finalizeTargets.map((task) => (
+        updateTask(taskQueue, task.taskId, {
+          status: 'failed',
+          message: errorMessage,
+          errorMessage,
+          completedAt: now,
+        })
+      )),
+    );
+  }
   console.warn(logLabel, JSON.stringify({
     nodeId,
     runId: pipelineRunId ?? null,
     queued: finalizeTargets.filter((task) => task.status === 'queued').length,
     running: finalizeTargets.filter((task) => task.status === 'running').length,
     authPending: authPendingTasks.length,
+    markFailed: shouldMarkFailed,
   }));
   return {
     queued: finalizeTargets.filter((task) => task.status === 'queued').length,


### PR DESCRIPTION
## Summary
- avoid force-failing queued/running fetch tasks during resume runs
- add markFailed option to pending finalization helper
- add regression unit test for queued-task preservation on resume

## Verification
- pnpm install --frozen-lockfile
- pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/shapePipelineFetchStageSection.unit.test.ts
- pnpm -w turbo run build --filter @hierarchidb/shape-plugin --only

Closes #590
