### PR TITLE
fix(shape): sync step5 task chip state with preview window close

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #599 / `codex/fix/shape/step5-chip-window-sync-599` / start: 2026-02-28 10:14 JST
 - #597 / `codex/fix/shape/step6-preview-max-update-depth` / start: 2026-02-28 10:00 JST
 - #589 / `codex/fix/shape/step5-rebuild-fetch-preview` / start: 2026-02-28 08:06 JST
 - #576 / `codex/chore/plugin-registry-ignore-generated-dir` / start: 2026-02-27 20:53 JST
@@ -125,6 +126,11 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- start: 2026-02-28 10:14 JST #599 を起票（https://github.com/kubohiroya/hierarchidb/issues/599）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape/step5-chip-window-sync-599` を作成して着手。
+- update: 2026-02-28 10:21 JST #599 原因は `TaskItemCardListCard` が `selectedDetail` をローカル保持しており、Geometry Preview Floating Window の `onClose`（×ボタン）で親のウィンドウ開閉状態だけが閉じても `selectedDetail` が残存すること。発生範囲は `plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/TaskItemCardListCard.tsx` の Chip選択状態と Floating Window 表示状態の同期経路。
+- update: 2026-02-28 10:21 JST #599 修正として `TaskItemCardListCard.tsx` に open→closed 遷移検知 (`wasDetailFloatingWindowOpenRef` + `useEffect`) を追加し、遷移時に `selectedDetail` / `hoveredDetail` をクリアして Chip のトグル見た目を強制同期。適用範囲は同ファイルのみ。回帰防止として `plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` に「×で閉じた後に再表示しても前回選択Chipが残らない」テストを追加。
+- blocked: 2026-02-28 10:21 JST #599 `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は差分外既知エラー `plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemCard.tsx:86` (`stageIcon` 未使用, TS6133) により exit 2。
+- done: 2026-02-28 10:21 JST #599 検証: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` exit 0、`pnpm -w turbo run build --filter @hierarchidb/shape-plugin --only` exit 0。
 - blocked: 2026-02-28 10:02 JST #597 `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --only` は差分外既知失敗（`src/ui/components/build-progress/TaskItemCard/TaskItemCard.tsx:86` の `stageIcon` 未使用 TS6133）で exit 2。`pnpm -w turbo run test --filter @hierarchidb/shape-plugin --only` も差分外既知の複数失敗（既存ユニットテスト群）で exit 1。
 - update: 2026-02-28 10:02 JST #597 原因は `plugins/shape-plugin/src/ui/components/preview/ShapePreviewStepView.tsx` で `selectedRows={new Set(selectedFeatureIds)}` を毎レンダー生成し、`packages/ui/data-grid/src/TanstackDataGrid.tsx` の `selectedRows` 同期 `useEffect` が毎回 `setInternalSelectedRows` を実行して再レンダーが連鎖したこと。発生範囲は Shape Step6 Preview の metadata list（DataGrid）表示経路。修正方法は `selectedFeatureIdSet` を `React.useMemo` で安定化し `selectedRows` に渡す変更。適用範囲は `ShapePreviewStepView.tsx` のみ。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin --only` は exit 0。
 - start: 2026-02-28 10:00 JST #597 を起票（https://github.com/kubohiroya/hierarchidb/issues/597）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape/step6-preview-max-update-depth` を作成して着手。

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
@@ -5,7 +5,7 @@ import { createStore } from 'jotai/vanilla';
 import type { ShapeBuildTaskSummary } from '../../../atoms/shapeBuildProgressAtoms';
 import { TaskItemCardListCard } from '../../../components/build-progress/TaskItemCardListCard/TaskItemCardListCard';
 import type { TaskOutcomeSummaryBuilder } from '../../../components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders';
-import { createElement } from 'react';
+import { createElement, useState } from 'react';
 import { NodeId } from "@hierarchidb/core-types";
 
 vi.mock('../../../i18n.js', () => ({
@@ -345,5 +345,87 @@ describe('TaskItemCardListCard', () => {
       fireEvent.click(chip);
     }
     expect(onOpenDetailFloatingWindow).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears selected chip when floating window is closed from close button', () => {
+    const tasks: ShapeBuildTaskSummary[] = [
+      {
+        taskId: 'fetch-task-close-sync-1',
+        nodeId: 'node-1' as NodeId,
+        stage: 'fetch',
+        taskType: 'fetch',
+        status: 'completed',
+        progress: 100,
+        metadata: {
+          fetchDetail: {
+            countryCode: 'JP',
+            countryName: 'Japan',
+            adminLevel: 0,
+            url: 'https://example.com/jp/close-sync.geojson',
+            features: { input: 100, output: 50 },
+            polygons: { input: 100, output: 50 },
+          },
+        },
+      } as ShapeBuildTaskSummary,
+      {
+        taskId: 'fetch-task-close-sync-2',
+        nodeId: 'node-1' as NodeId,
+        stage: 'fetch',
+        taskType: 'fetch',
+        status: 'completed',
+        progress: 100,
+        metadata: {
+          fetchDetail: {
+            countryCode: 'US',
+            countryName: 'United States',
+            adminLevel: 0,
+            url: 'https://example.com/us/close-sync.geojson',
+            features: { input: 200, output: 100 },
+            polygons: { input: 200, output: 100 },
+          },
+        },
+      } as ShapeBuildTaskSummary,
+    ];
+    const store = createStore();
+
+    const Harness = () => {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>Reopen preview</button>
+          <TaskItemCardListCard
+            stageId="fetch"
+            tasks={tasks}
+            stageValue={0}
+            resolveStatusLabel={() => 'Completed'}
+            resolveStatusColor={() => 'success'}
+            resolveTaskTitle={(task) => task.taskId}
+            virtualize={false}
+            isDetailFloatingWindowOpen={open}
+            onCloseDetailFloatingWindow={() => setOpen(false)}
+          />
+        </>
+      );
+    };
+
+    render(
+      <Provider store={store}>
+        <Harness />
+      </Provider>
+    );
+
+    const chips = screen.getAllByText('Completed')
+      .map((element) => element.closest('.MuiChip-root'))
+      .filter(Boolean) as HTMLElement[];
+    expect(chips.length).toBe(2);
+
+    fireEvent.click(chips[0]);
+    expect(screen.getByText('URL: https://example.com/jp/close-sync.geojson')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('Close preview'));
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen preview' }));
+    fireEvent.mouseEnter(chips[1]);
+
+    expect(screen.getByText('URL: https://example.com/us/close-sync.geojson')).toBeTruthy();
   });
 });

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/TaskItemCardListCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/TaskItemCardListCard.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactNode, forwardRef, useCallback, useMemo, useState } from 'react';
+import { type CSSProperties, type ReactNode, forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box } from '@mui/material';
 import type { ShapeBuildTaskSummary } from '~/ui/atoms/shapeBuildProgressAtoms';
 
@@ -63,6 +63,7 @@ export const TaskItemCardListCard = forwardRef<HTMLDivElement|null, TaskItemCard
 }: TaskItemCardListCardProps, ref) => {
   const [hoveredDetail, setHoveredDetail] = useState<TaskDetailSelection | null>(null);
   const [selectedDetail, setSelectedDetail] = useState<TaskDetailSelection | null>(null);
+  const wasDetailFloatingWindowOpenRef = useRef(isDetailFloatingWindowOpen);
   const { t } = useTranslation();
   const stages = useShapeBuildStages({ t: (key, fallback): string => String(t(key, fallback ?? key)) });
   const stageIconById = useMemo(() => {
@@ -71,6 +72,14 @@ export const TaskItemCardListCard = forwardRef<HTMLDivElement|null, TaskItemCard
   const resolveStageIcon = useCallback((taskStageId: string): ReactNode | null => (
     stageIconById.get(taskStageId) ?? null
   ), [stageIconById]);
+  useEffect(() => {
+    const wasOpen = wasDetailFloatingWindowOpenRef.current;
+    if (wasOpen && !isDetailFloatingWindowOpen) {
+      setSelectedDetail(null);
+      setHoveredDetail(null);
+    }
+    wasDetailFloatingWindowOpenRef.current = isDetailFloatingWindowOpen;
+  }, [isDetailFloatingWindowOpen]);
   const {
     orderedTasks,
     shouldVirtualize,


### PR DESCRIPTION
## Summary
- Fix incomplete state sync between Step5 `TaskItemCard` status Chip toggle style and Geometry Preview Floating Window visibility.
- Clear selected/hovered task detail when the preview floating window transitions from open to closed.
- Add a regression test that reproduces close-button (`×`) behavior and verifies chip/preview sync after reopen.

## Cause
- `TaskItemCardListCard` kept `selectedDetail` locally even after floating window close, so chip selected style remained active while window was closed.

## Changes
- `TaskItemCardListCard.tsx`
  - Added open→closed transition detection via `useRef` + `useEffect`.
  - Clears `selectedDetail` and `hoveredDetail` when preview window closes.
- `TaskItemCardListCard.unit.test.tsx`
  - Added regression test for close-button sync behavior.

## Verification
- `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` (exit 0)
- `pnpm -w turbo run build --filter @hierarchidb/shape-plugin --only` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` (exit 2, known unrelated blocker: `TaskItemCard.tsx:86` TS6133 unused `stageIcon`)

Refs #599
