### PR TITLE
fix(plugin-dialog): centralize dialog-safe menu and popover

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #604 / `codex/fix/plugin-dialog-safe-menu-popover-604` / start: 2026-02-28 10:38 JST
 - #601 / `codex/fix/plugin-registry-build-owned-generation-601` / start: 2026-02-28 10:28 JST
 - #597 / `codex/fix/shape/step6-preview-max-update-depth` / start: 2026-02-28 10:00 JST
 - #589 / `codex/fix/shape/step5-rebuild-fetch-preview` / start: 2026-02-28 08:06 JST
@@ -126,6 +127,10 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- done: 2026-02-28 10:45 JST #604 検証: `pnpm -w turbo run build --filter @hierarchidb/ui-dialog --filter @hierarchidb/components --filter @hierarchidb/plugin-ui-host --filter @hierarchidb/shape-plugin --filter @hierarchidb/location-plugin --filter @hierarchidb/resolver-plugin --only --output-logs errors-only` exit 0。`HIERARCHIDB_E2E=1 node_modules/.bin/playwright test e2e/shape/plugin-dialog-caret.spec.ts --project=chromium` exit 0（1 passed）。
+- blocked: 2026-02-28 10:45 JST #604 `pnpm -w turbo run typecheck --filter @hierarchidb/ui-dialog --filter @hierarchidb/components --filter @hierarchidb/plugin-ui-host --filter @hierarchidb/shape-plugin --filter @hierarchidb/location-plugin --filter @hierarchidb/resolver-plugin --only --output-logs errors-only` は差分外既知依存欠落（`@hierarchidb/ui-dialog` で `@hierarchidb/tree-api` 解決不可 TS2307）により exit 2。
+- update: 2026-02-28 10:45 JST #604 原因は PluginDialog 内に散在する `Menu/Popover` ごとのフォーカス復元設定が局所実装で漏れやすく、新規 UI 追加時にキャレット回帰が再発していたこと。発生範囲は `plugin-ui-host`（Stepper/Footer）、`components`（BuildControlCard/BuildStepStagePanel/共通メニュー）、`shape-plugin`（overlay Popover）、および dialog 内利用可能な plugin UI（location/resolver のメニュー）。修正として `@hierarchidb/ui-dialog` に `DialogSafeMenu` / `DialogSafePopover` を新設し、対象箇所の `Menu/Popover` を共通ラッパーへ置換。さらに `eslint.config.js` に `packages/components`・`packages/plugin-ui-host`・`plugins/**/src/ui` で生の `Menu/Popover` import を禁止するガードを追加。適用範囲は上記 UI コンポーネント群と lint 設定。
+- start: 2026-02-28 10:38 JST #604 を起票（https://github.com/kubohiroya/hierarchidb/issues/604）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。専用 worktree `/Users/hiroya/WebstormProjects/hierarchidb-codex-604` とブランチ `codex/fix/plugin-dialog-safe-menu-popover-604` を `origin/main` 起点で作成して着手。
 - done: 2026-02-28 10:32 JST #601 検証: `pnpm -w turbo run build --filter @hierarchidb/plugin-registry` exit 0、`pnpm --filter @hierarchidb/app build` exit 0。`app build` で `generate-plugin-registry` ログが出ないことを確認。
 - update: 2026-02-28 10:32 JST #601 原因は `packages/tools/build-scripts/src/gen-plugin-registry.ts` が import 時にも実行される条件式（`import.meta.url === pathToFileURL(fileURLToPath(import.meta.url)).href`）になっており、`app/vite.config.ts` から関数 import しただけで再生成が走っていたこと。発生範囲は `app build` と `vite config load` 経路。修正として 1) `@hierarchidb/plugin-registry` の build 前段で `tools:gen-plugin-registry` を実行し責務を集約 2) `app/package.json` build から直接再生成を削除 3) `app/vite.config.ts` で generator plugin を `command === 'serve'` 限定化 4) `gen-plugin-registry.ts` の entry 判定を `process.argv[1]` ベースへ修正。適用範囲は `packages/plugin-registry/package.json`, `app/package.json`, `app/vite.config.ts`, `packages/tools/build-scripts/src/gen-plugin-registry.ts`。
 - start: 2026-02-28 10:28 JST #601 を起票（https://github.com/kubohiroya/hierarchidb/issues/601）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/plugin-registry-build-owned-generation-601` を作成して着手。

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -184,4 +184,30 @@ export default [// Ignore _obsolate_common stage artifacts across the monorepo
     }],
   },
 },
+{
+  files: [
+    'packages/plugin-ui-host/src/**/*.{ts,tsx}',
+    'packages/components/src/**/*.{ts,tsx}',
+    'plugins/**/src/ui/**/*.{ts,tsx}',
+  ],
+  rules: {
+    'no-restricted-imports': ['error', {
+      paths: [
+        {
+          name: '@mui/material',
+          importNames: ['Menu', 'Popover'],
+          message: 'Use DialogSafeMenu / DialogSafePopover from @hierarchidb/ui-dialog for dialog-safe focus behavior.',
+        },
+        {
+          name: '@mui/material/Menu',
+          message: 'Use DialogSafeMenu from @hierarchidb/ui-dialog for dialog-safe focus behavior.',
+        },
+        {
+          name: '@mui/material/Popover',
+          message: 'Use DialogSafePopover from @hierarchidb/ui-dialog for dialog-safe focus behavior.',
+        },
+      ],
+    }],
+  },
+},
 ];

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,6 +50,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "11.14.0",
     "@hierarchidb/core-types": "workspace:*",
+    "@hierarchidb/ui-dialog": "workspace:*",
     "@hierarchidb/ui-lru-splitview": "workspace:*"
   },
   "keywords": [],
@@ -65,6 +66,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "11.14.0",
     "@hierarchidb/core-types": "workspace:*",
+    "@hierarchidb/ui-dialog": "workspace:*",
     "@hierarchidb/ui-lru-splitview": "workspace:*"
   }
 }

--- a/packages/components/src/BuildControlCard.tsx
+++ b/packages/components/src/BuildControlCard.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, CircularProgress, IconButton, Menu, MenuItem, Stack, Typography } from '@mui/material';
+import { DialogSafeMenu } from '@hierarchidb/ui-dialog';
+import { Box, Button, CircularProgress, IconButton, MenuItem, Stack, Typography } from '@mui/material';
 import {
   useCallback,
   useEffect,
@@ -184,11 +185,10 @@ export const BuildControlCard: React.FC<BuildControlCardProps> = ({
             <ArrowDropDownIcon fontSize="small" />
           </IconButton>
         ) : null}
-        <Menu
+        <DialogSafeMenu
           anchorEl={menuAnchorEl}
           open={isMenuOpen}
           onClose={handleMenuClose}
-          disableRestoreFocus
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
@@ -201,7 +201,7 @@ export const BuildControlCard: React.FC<BuildControlCardProps> = ({
               {item.label}
             </MenuItem>
           ))}
-        </Menu>
+        </DialogSafeMenu>
       </Stack>
       {details && details.length > 0 ? (
         <Stack direction="row" spacing={2} alignItems="center" sx={{ whiteSpace: 'nowrap' }}>

--- a/packages/components/src/BuildStepStagePanel.tsx
+++ b/packages/components/src/BuildStepStagePanel.tsx
@@ -7,7 +7,8 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { Box, Chip, CircularProgress, IconButton, LinearProgress, Menu, MenuItem, Skeleton, Stack, Typography, useTheme } from '@mui/material';
+import { DialogSafeMenu } from '@hierarchidb/ui-dialog';
+import { Box, Chip, CircularProgress, IconButton, LinearProgress, MenuItem, Skeleton, Stack, Typography, useTheme } from '@mui/material';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import TaskAltIcon from '@mui/icons-material/TaskAlt';
@@ -282,11 +283,10 @@ const BuildStepStagePanelCore: FC<BuildStepStageSummaryPanelProps> = ({
                 >
                   <ArrowDropDownIcon fontSize="small" />
                 </IconButton>
-                <Menu
+                <DialogSafeMenu
                   anchorEl={menuAnchorEl}
                   open={isMenuOpen}
                   onClose={handleMenuClose}
-                  disableRestoreFocus
                   anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                   transformOrigin={{ vertical: 'top', horizontal: 'right' }}
                 >
@@ -299,7 +299,7 @@ const BuildStepStagePanelCore: FC<BuildStepStageSummaryPanelProps> = ({
                       {item.label}
                     </MenuItem>
                   ))}
-                </Menu>
+                </DialogSafeMenu>
               </>
             ) : null}
           </Stack>

--- a/packages/components/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/components/src/DropdownMenu/DropdownMenu.tsx
@@ -17,7 +17,8 @@
  * - DropdownMenuItemType: Menu item configuration type
  */
 
-import { Box, ListItemIcon, ListItemText, Menu, MenuItem } from '@mui/material';
+import { DialogSafeMenu } from '@hierarchidb/ui-dialog';
+import { Box, ListItemIcon, ListItemText, MenuItem } from '@mui/material';
 import { type MouseEvent, type ReactElement, type ReactNode, useCallback, useState } from 'react';
 import type { DropdownMenuItemType } from './DropdownMenuItemType.js';
 
@@ -58,7 +59,7 @@ export const DropdownMenu = ({
       <Box style={{ marginTop: '-1.775px' }} onClick={handleMenuOpenButtonClick}>
         {children}
       </Box>
-      <Menu id={id + '-menu'} anchorEl={anchorElem} open={open} onClose={() => setAnchorElem(null)}>
+      <DialogSafeMenu id={id + '-menu'} anchorEl={anchorElem} open={open} onClose={() => setAnchorElem(null)}>
         {items.map((item: DropdownMenuItemType | null, index: number) =>
           item ? (
             <MenuItem
@@ -84,7 +85,7 @@ export const DropdownMenu = ({
             <MenuItem key={index} divider />
           ),
         )}
-      </Menu>
+      </DialogSafeMenu>
     </>
   );
 };

--- a/packages/components/src/MenuListItemButton/MenuListItemLinkButton.tsx
+++ b/packages/components/src/MenuListItemButton/MenuListItemLinkButton.tsx
@@ -1,4 +1,5 @@
-import { IconButton, ListItemIcon, ListItemText, Menu, MenuItem, SpeedDialIcon } from '@mui/material';
+import { DialogSafeMenu } from '@hierarchidb/ui-dialog';
+import { IconButton, ListItemIcon, ListItemText, MenuItem, SpeedDialIcon } from '@mui/material';
 import { type CSSProperties, type MouseEvent, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { Link, useLocation } from '@tanstack/react-router';
 
@@ -46,7 +47,7 @@ export const MenuListItemLinkButton = ({
       >
         <SpeedDialIcon />
       </IconButton>
-      <Menu id={id + '-menu'} anchorEl={anchorElem} open={open} onClose={() => setAnchorElem(null)}>
+      <DialogSafeMenu id={id + '-menu'} anchorEl={anchorElem} open={open} onClose={() => setAnchorElem(null)}>
         {items.map((item: MenuItemLinkType | null, index: number) =>
           item ? (
             <MenuItem
@@ -63,7 +64,7 @@ export const MenuListItemLinkButton = ({
             <MenuItem key={index} divider />
           ),
         )}
-      </Menu>
+      </DialogSafeMenu>
     </>
   );
 };

--- a/packages/components/src/StyledMenu/StyledMenu.tsx
+++ b/packages/components/src/StyledMenu/StyledMenu.tsx
@@ -1,9 +1,10 @@
 import { alpha, styled } from '@mui/material/styles';
-import Menu, { type MenuProps } from '@mui/material/Menu';
+import { DialogSafeMenu } from '@hierarchidb/ui-dialog';
+import { type MenuProps } from '@mui/material';
 import type { StyledComponent } from '@emotion/styled';
 
 export const StyledMenu: StyledComponent<MenuProps> = styled((props: MenuProps) => (
-  <Menu
+  <DialogSafeMenu
     elevation={0}
     anchorOrigin={{
       vertical: 'bottom',

--- a/packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx
+++ b/packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx
@@ -6,7 +6,7 @@
  * controller layer.
  */
 
-import { getDialogSurfaceColor } from '@hierarchidb/ui-dialog';
+import { DialogSafeMenu, getDialogSurfaceColor } from '@hierarchidb/ui-dialog';
 import CheckIcon from '@mui/icons-material/Check';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
@@ -16,7 +16,7 @@ import ConstructionIcon from '@mui/icons-material/Construction';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import OpenInNewOffIcon from '@mui/icons-material/OpenInNewOff';
 import type { ButtonProps } from '@mui/material';
-import { Box, Button, CircularProgress, ListItemIcon, ListItemText, Menu, MenuItem, Stack, Tooltip } from '@mui/material';
+import { Box, Button, CircularProgress, ListItemIcon, ListItemText, MenuItem, Stack, Tooltip } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 import { useLocation } from '@tanstack/react-router';
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
@@ -478,10 +478,9 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
           </Stack>
         </Stack>
       </Box>
-      <Menu
+      <DialogSafeMenu
         open={Boolean(contextMenuState)}
         onClose={closeContextMenu}
-        disableRestoreFocus
         anchorReference="anchorPosition"
         anchorPosition={
           contextMenuState
@@ -507,7 +506,7 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
           </ListItemIcon>
           <ListItemText>Copy Link URL</ListItemText>
         </MenuItem>
-      </Menu>
+      </DialogSafeMenu>
     </>
   );
 };

--- a/packages/plugin-ui-host/src/headless/components/PluginDialogStepper.tsx
+++ b/packages/plugin-ui-host/src/headless/components/PluginDialogStepper.tsx
@@ -1,7 +1,7 @@
+import { DialogSafeMenu } from '@hierarchidb/ui-dialog';
 import {
   ListItemIcon,
   ListItemText,
-  Menu,
   MenuItem,
   Stack,
   Step,
@@ -228,10 +228,9 @@ export const PluginDialogStepper: React.FC<PluginDialogStepperProps> = ({
           );
         })}
       </Stepper>
-      <Menu
+      <DialogSafeMenu
         open={Boolean(contextMenuState)}
         onClose={closeContextMenu}
-        disableRestoreFocus
         anchorReference="anchorPosition"
         anchorPosition={
           contextMenuState
@@ -257,7 +256,7 @@ export const PluginDialogStepper: React.FC<PluginDialogStepperProps> = ({
           </ListItemIcon>
           <ListItemText>Copy Link URL</ListItemText>
         </MenuItem>
-      </Menu>
+      </DialogSafeMenu>
     </>
   );
 };

--- a/packages/ui/dialog/src/components/DialogSafeMenu.tsx
+++ b/packages/ui/dialog/src/components/DialogSafeMenu.tsx
@@ -1,0 +1,8 @@
+import Menu, { type MenuProps } from '@mui/material/Menu';
+import type { JSX } from 'react';
+
+export const DialogSafeMenu = (props: MenuProps): JSX.Element => {
+  const { disableRestoreFocus = true, ...rest } = props;
+  return <Menu {...rest} disableRestoreFocus={disableRestoreFocus} />;
+};
+

--- a/packages/ui/dialog/src/components/DialogSafePopover.tsx
+++ b/packages/ui/dialog/src/components/DialogSafePopover.tsx
@@ -1,0 +1,8 @@
+import Popover, { type PopoverProps } from '@mui/material/Popover';
+import type { JSX } from 'react';
+
+export const DialogSafePopover = (props: PopoverProps): JSX.Element => {
+  const { disableRestoreFocus = true, ...rest } = props;
+  return <Popover {...rest} disableRestoreFocus={disableRestoreFocus} />;
+};
+

--- a/packages/ui/dialog/src/index.ts
+++ b/packages/ui/dialog/src/index.ts
@@ -3,6 +3,8 @@ export * from './components/CommonDialog.js';
 export * from './components/CommonDialogTitle.js';
 export * from './components/CommonDialogActions.js';
 export * from './components/UnsavedChangesDialog.js';
+export * from './components/DialogSafeMenu.js';
+export * from './components/DialogSafePopover.js';
 export * from './types/PluginDialog.types.js';
 export * from './headless/AbstractDialog.js';
 export * from './headless/PluginDialogContent.js';

--- a/plugins/location-plugin/src/ui/components/batch/LocationMapPreview.tsx
+++ b/plugins/location-plugin/src/ui/components/batch/LocationMapPreview.tsx
@@ -2,6 +2,7 @@
   * Location Map Preview Component
    */
 
+import { DialogSafeMenu } from '@hierarchidb/ui-dialog';
 import {
   Box,
   Button,
@@ -10,7 +11,6 @@ import {
   DialogContent,
   DialogTitle,
   Fab,
-  Menu,
   MenuItem,
   MenuList,
   Paper,
@@ -368,7 +368,7 @@ export const LocationMapPreview: React.FC<LocationMapPreviewProps> = ({
 
       {/*
 */}
-      <Menu
+      <DialogSafeMenu
         anchorEl={settingsAnchor}
         open={Boolean(settingsAnchor)}
         onClose={() => setSettingsAnchor(null)}
@@ -383,7 +383,7 @@ export const LocationMapPreview: React.FC<LocationMapPreviewProps> = ({
             {translations.mapPreview.menuAnalytics}
           </MenuItem>
         </MenuList>
-      </Menu>
+      </DialogSafeMenu>
 
       {/*
 */}

--- a/plugins/resolver-plugin/src/ui/components/ResolverPanel.tsx
+++ b/plugins/resolver-plugin/src/ui/components/ResolverPanel.tsx
@@ -11,11 +11,11 @@ import {
   List,
   ListItem,
   ListItemText,
-  Menu,
   MenuItem,
   Paper,
   Typography,
 } from '@mui/material';
+import { DialogSafeMenu } from '@hierarchidb/ui-dialog';
 import Grid from '@mui/material/Grid';
 import {
   Cached as CachedIcon,
@@ -319,7 +319,7 @@ export const ResolverPanel: React.FC<ResolverPanelProps> = ({
       )}
 
       {/* Context Menu */}
-      <Menu
+      <DialogSafeMenu
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleMenuClose}
@@ -361,7 +361,7 @@ export const ResolverPanel: React.FC<ResolverPanelProps> = ({
           <DeleteIcon sx={{ mr: 1 }} fontSize="small" color="error" />
           Delete
         </MenuItem>
-      </Menu>
+      </DialogSafeMenu>
     </Box>
   );
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/ShapeBuildProgressPanelControllerOverlayDialogsView.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/ShapeBuildProgressPanelControllerOverlayDialogsView.tsx
@@ -1,5 +1,6 @@
+import { DialogSafePopover } from '@hierarchidb/ui-dialog';
 import { type ReactNode } from 'react';
-import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Snackbar, Alert, Popover, Typography } from '@mui/material';
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Snackbar, Alert, Typography } from '@mui/material';
 import { DownloadRetryControls, WorkerNumberConfigCard } from '@hierarchidb/ui-accordion-config';
 import { TreeTableSearchInput } from '@hierarchidb/ui-search-input';
 import type { ShapeBuildProgressPanelControllerBaseResult } from '~/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/base/useShapeBuildProgressPanelControllerBaseState';
@@ -236,7 +237,7 @@ export const ShapeBuildProgressPanelOverlayFooter = ({
   handleStartWarningConfirm,
 }: FooterArgs): ReactNode => (
   <>
-    <Popover
+    <DialogSafePopover
       open={Boolean(fetchRetryEditorAnchor)}
       anchorEl={fetchRetryEditorAnchor}
       onClose={closeFetchRetryEditor}
@@ -246,8 +247,8 @@ export const ShapeBuildProgressPanelOverlayFooter = ({
       <Box sx={{ p: 2, width: 820, maxWidth: 'calc(100vw - 24px)' }}>
         {fetchRetryEditorCard}
       </Box>
-    </Popover>
-    <Popover
+    </DialogSafePopover>
+    <DialogSafePopover
       open={Boolean(concurrencyEditorAnchor && concurrencyEditorStageId)}
       anchorEl={concurrencyEditorAnchor}
       onClose={closeConcurrencyEditor}
@@ -257,7 +258,7 @@ export const ShapeBuildProgressPanelOverlayFooter = ({
       <Box sx={{ p: 2, width: 360, maxWidth: 'calc(100vw - 24px)' }}>
         {concurrencyEditorCard}
       </Box>
-    </Popover>
+    </DialogSafePopover>
     <Snackbar
       open={isBuildStartupPending && !startupNoticeDismissed}
       onClose={(_event, reason) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,6 +705,9 @@ importers:
       '@hierarchidb/core-types':
         specifier: workspace:*
         version: link:../core-types
+      '@hierarchidb/ui-dialog':
+        specifier: workspace:*
+        version: link:../ui/dialog
       '@hierarchidb/ui-lru-splitview':
         specifier: workspace:*
         version: link:../ui/lru-splitview


### PR DESCRIPTION
## Summary
- add `DialogSafeMenu` and `DialogSafePopover` to `@hierarchidb/ui-dialog`
- migrate PluginDialog-related menu/popover usages to shared dialog-safe wrappers
  - `plugin-ui-host` stepper/footer context menus
  - `components` build-stage/build-control menus and shared menu components
  - `shape-plugin` overlay popovers
  - `location-plugin` and `resolver-plugin` UI menus used in dialog contexts
- add ESLint guard to forbid direct `Menu`/`Popover` imports in dialog-related UI paths

## Why
Menu/Popover focus-restore settings were scattered per component, so new menu UI repeatedly reintroduced caret-loss regressions in PluginDialog text inputs. This change centralizes behavior and adds a lint guard to prevent drift.

## Verification
- `pnpm install --no-frozen-lockfile` (lockfile updated because `@hierarchidb/components` now depends on `@hierarchidb/ui-dialog`)
- `pnpm -w turbo run build --filter @hierarchidb/ui-dialog --filter @hierarchidb/components --filter @hierarchidb/plugin-ui-host --filter @hierarchidb/shape-plugin --filter @hierarchidb/location-plugin --filter @hierarchidb/resolver-plugin --only --output-logs errors-only` (exit 0)
- `pnpm eslint packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx packages/plugin-ui-host/src/headless/components/PluginDialogStepper.tsx packages/components/src/BuildControlCard.tsx packages/components/src/BuildStepStagePanel.tsx packages/components/src/MenuListItemButton/MenuListItemLinkButton.tsx packages/components/src/DropdownMenu/DropdownMenu.tsx packages/components/src/StyledMenu/StyledMenu.tsx plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/ShapeBuildProgressPanelControllerOverlayDialogsView.tsx plugins/location-plugin/src/ui/components/batch/LocationMapPreview.tsx plugins/resolver-plugin/src/ui/components/ResolverPanel.tsx packages/ui/dialog/src/components/DialogSafeMenu.tsx packages/ui/dialog/src/components/DialogSafePopover.tsx` (exit 0)
- `HIERARCHIDB_E2E=1 node_modules/.bin/playwright test e2e/shape/plugin-dialog-caret.spec.ts --project=chromium` (exit 0, 1 passed)

### Known blocked check (pre-existing)
- `pnpm -w turbo run typecheck --filter @hierarchidb/ui-dialog --filter @hierarchidb/components --filter @hierarchidb/plugin-ui-host --filter @hierarchidb/shape-plugin --filter @hierarchidb/location-plugin --filter @hierarchidb/resolver-plugin --only --output-logs errors-only`
  - failed with existing dependency-resolution issue in `@hierarchidb/ui-dialog` (`@hierarchidb/tree-api` TS2307)

## Rollback
- Revert this PR commit to restore direct `Menu/Popover` usage and remove lint guard.

Closes #604
