### PR TITLE
fix(shape): stabilize task summary sync and enrich fetch failure logs

### DIFF
--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildStep/useShapeBuildStepAtomSync/useShapeBuildStepAtomSyncEffects.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildStep/useShapeBuildStepAtomSync/useShapeBuildStepAtomSyncEffects.ts
@@ -3,7 +3,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import type { AuthProviderType } from '@hierarchidb/ui-auth';
 import type { BuildStatus } from '@hierarchidb/components/build-status';
 import type { TaskProgressAuthState, TaskProgressControls, TaskProgressSummary } from '~/ui/atoms/shapeBuildProgressAtoms';
-import { shallowEqualRecord } from '~/ui/components/build-progress/shapeBuildStepAtomSyncEquality';
+import { shallowEqualRecord, shallowEqualTaskProgressSummary } from '~/ui/components/build-progress/shapeBuildStepAtomSyncEquality';
 
 type StageTotalMap = Record<
   string,
@@ -111,7 +111,7 @@ export const useShapeBuildStepAtomSyncAtomEffects = ({
       stageRemainingMs,
       stageTotals,
     };
-    if (shallowEqualRecord(summaryRef.current, nextSummary)) return;
+    if (shallowEqualTaskProgressSummary(summaryRef.current, nextSummary)) return;
     summaryRef.current = nextSummary;
     setSummary(nextSummary);
   }, [

--- a/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildStepAtomSyncEquality.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/shapeBuildStepAtomSyncEquality.ts
@@ -6,3 +6,82 @@ export const shallowEqualRecord = <T extends Record<string, unknown> | null | un
   if (aKeys.length !== bKeys.length) return false;
   return aKeys.every((key) => (a as Record<string, unknown>)[key] === (b as Record<string, unknown>)[key]);
 };
+
+const shallowEqualNumberRecord = (
+  a: Record<string, number> | null | undefined,
+  b: Record<string, number> | null | undefined,
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => a[key] === b[key]);
+};
+
+type StageTotals = Record<string, {
+  total: number;
+  completed: number;
+  failed: number;
+  skipped: number;
+}>;
+
+const shallowEqualStageTotals = (a: StageTotals | null | undefined, b: StageTotals | null | undefined): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => {
+    const left = a[key];
+    const right = b[key];
+    if (!left || !right) return false;
+    return left.total === right.total
+      && left.completed === right.completed
+      && left.failed === right.failed
+      && left.skipped === right.skipped;
+  });
+};
+
+type TaskProgressSummaryLike = {
+  stageLabel: string;
+  taskLabel: string;
+  taskUnitLabel: string;
+  overallProgress: number;
+  completed: number;
+  total: number;
+  failed: number;
+  skipped: number;
+  buildStatus: string;
+  hasProgressData: boolean;
+  timingStageId?: string | null;
+  completedStageElapsedMs: Record<string, number>;
+  totalElapsedMs: number;
+  stageElapsedMs: number;
+  stageRemainingMs: number | null;
+  stageTotals: StageTotals;
+};
+
+export const shallowEqualTaskProgressSummary = (
+  a: TaskProgressSummaryLike | null | undefined,
+  b: TaskProgressSummaryLike | null | undefined,
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.stageLabel === b.stageLabel
+    && a.taskLabel === b.taskLabel
+    && a.taskUnitLabel === b.taskUnitLabel
+    && a.overallProgress === b.overallProgress
+    && a.completed === b.completed
+    && a.total === b.total
+    && a.failed === b.failed
+    && a.skipped === b.skipped
+    && a.buildStatus === b.buildStatus
+    && a.hasProgressData === b.hasProgressData
+    && a.timingStageId === b.timingStageId
+    && a.totalElapsedMs === b.totalElapsedMs
+    && a.stageElapsedMs === b.stageElapsedMs
+    && a.stageRemainingMs === b.stageRemainingMs
+    && shallowEqualNumberRecord(a.completedStageElapsedMs, b.completedStageElapsedMs)
+    && shallowEqualStageTotals(a.stageTotals, b.stageTotals);
+};

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSnapshotProgressState/useShapeBuildTaskSnapshotProgressState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSnapshotProgressState/useShapeBuildTaskSnapshotProgressState.ts
@@ -410,7 +410,10 @@ export function useShapeBuildTaskSnapshotProgressState(
       if (task.status !== 'failed') return;
       if (reported.has(task.taskId)) return;
       reported.add(task.taskId);
-      const message = resolveTaskMetadataMessage(task.metadata) ?? 'Task failed';
+      const message = resolveTaskMetadataMessage(task.metadata)
+        ?? task.errorMessage
+        ?? task.message
+        ?? 'Task failed';
       const geometryDetails = parseGeometrySimplifyError(message);
       if (geometryDetails) {
         console.warn('[ShapeBuildStep] task failed:geometrySimplify', {


### PR DESCRIPTION
## Summary\n- Stabilize TaskProgressSummary sync to avoid redundant updates (deep compare for elapsed/stage totals).\n- Include errorMessage/message fallback when logging failed fetch tasks.\n\n## Testing\n- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin (exit 2: unrelated @hierarchidb/components -> @hierarchidb/ui-dialog TS2307)\n- pnpm -w turbo run test --filter @hierarchidb/shape-plugin (exit 1: existing failures in useShapeBuildTaskSnapshotProgressState.unit.test.tsx and others)\n- pnpm -w turbo run build --filter @hierarchidb/shape-plugin (exit 0, warnings present)\n\nRefs #608