### PR TITLE
fix(shape): stabilize build progress sync

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #611 / `codex/fix/build/ts2307-shape-tests-611` / start: 2026-02-28 12:28 JST
 - #604 / `codex/fix/plugin-dialog-safe-menu-popover-604` / start: 2026-02-28 10:38 JST
 - #601 / `codex/fix/plugin-registry-build-owned-generation-601` / start: 2026-02-28 10:28 JST
 - #597 / `codex/fix/shape/step6-preview-max-update-depth` / start: 2026-02-28 10:00 JST
@@ -127,6 +128,9 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- start: 2026-02-28 12:28 JST #611 を起票（https://github.com/kubohiroya/hierarchidb/issues/611）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/build/ts2307-shape-tests-611` を作成し、worktree `/Users/hiroya/WebstormProjects/hierarchidb-codex-611` で着手。
+- update: 2026-02-28 12:50 JST #611 `@hierarchidb/ui-dialog` の d.ts に残っていた `~/headless/types` 参照を相対 import に修正し、TS2307 を解消。
+- done: 2026-02-28 12:50 JST #611 検証: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` exit 0。
 - done: 2026-02-28 10:45 JST #604 検証: `pnpm -w turbo run build --filter @hierarchidb/ui-dialog --filter @hierarchidb/components --filter @hierarchidb/plugin-ui-host --filter @hierarchidb/shape-plugin --filter @hierarchidb/location-plugin --filter @hierarchidb/resolver-plugin --only --output-logs errors-only` exit 0。`HIERARCHIDB_E2E=1 node_modules/.bin/playwright test e2e/shape/plugin-dialog-caret.spec.ts --project=chromium` exit 0（1 passed）。
 - blocked: 2026-02-28 10:45 JST #604 `pnpm -w turbo run typecheck --filter @hierarchidb/ui-dialog --filter @hierarchidb/components --filter @hierarchidb/plugin-ui-host --filter @hierarchidb/shape-plugin --filter @hierarchidb/location-plugin --filter @hierarchidb/resolver-plugin --only --output-logs errors-only` は差分外既知依存欠落（`@hierarchidb/ui-dialog` で `@hierarchidb/tree-api` 解決不可 TS2307）により exit 2。
 - update: 2026-02-28 10:45 JST #604 原因は PluginDialog 内に散在する `Menu/Popover` ごとのフォーカス復元設定が局所実装で漏れやすく、新規 UI 追加時にキャレット回帰が再発していたこと。発生範囲は `plugin-ui-host`（Stepper/Footer）、`components`（BuildControlCard/BuildStepStagePanel/共通メニュー）、`shape-plugin`（overlay Popover）、および dialog 内利用可能な plugin UI（location/resolver のメニュー）。修正として `@hierarchidb/ui-dialog` に `DialogSafeMenu` / `DialogSafePopover` を新設し、対象箇所の `Menu/Popover` を共通ラッパーへ置換。さらに `eslint.config.js` に `packages/components`・`packages/plugin-ui-host`・`plugins/**/src/ui` で生の `Menu/Popover` import を禁止するガードを追加。適用範囲は上記 UI コンポーネント群と lint 設定。

--- a/packages/ui/dialog/package.json
+++ b/packages/ui/dialog/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "test": "vitest --passWithNoTests",

--- a/packages/ui/dialog/src/hooks/useDialogContext.ts
+++ b/packages/ui/dialog/src/hooks/useDialogContext.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import type { HeadlessDialogContextValue } from '~/headless/types';
+import type { HeadlessDialogContextValue } from '../headless/types';
 
 const PluginDialogContext = createContext<HeadlessDialogContextValue<any> | null>(null);
 

--- a/packages/vt-orchestrator/src/compareTaskOrder.ts
+++ b/packages/vt-orchestrator/src/compareTaskOrder.ts
@@ -343,6 +343,7 @@ export async function runStageTasks<TInput = unknown, TOutput = unknown>(
         await updateTask(db, task.taskId, {
           status: nextStatus,
           progress: result.progress ?? 100,
+          message: result.message,
           metadata: result.metadata,
           outputData: result.outputData,
           errorMessage: result.errorMessage,

--- a/plugins/shape-plugin/package.json
+++ b/plugins/shape-plugin/package.json
@@ -161,6 +161,7 @@
     "@hierarchidb/ui-lru-splitview": "workspace:*",
     "@hierarchidb/ui-map": "workspace:*",
     "@hierarchidb/ui-memory": "workspace:*",
+    "@hierarchidb/ui-monitoring": "workspace:*",
     "@hierarchidb/ui-plugin-basic-info": "workspace:*",
     "@hierarchidb/ui-search-input": "workspace:*",
     "@hierarchidb/ui-stacked-barchart": "workspace:*",

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/ShapeBuildProgressPanel.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/ShapeBuildProgressPanel.unit.test.tsx
@@ -109,6 +109,23 @@ describe('ShapeBuildProgressPanel', () => {
     store.set(tasksByStageAtom, { transform: [failedTask] });
     store.set(taskProgressSummaryAtom, {
       stageLabel: 'Transform',
+      taskLabel: 'Running',
+      taskUnitLabel: 'Tasks',
+      overallProgress: 50,
+      completed: 0,
+      total: 1,
+      failed: 0,
+      skipped: 0,
+      buildStatus: 'running',
+      hasProgressData: true,
+      timingStageId: null,
+      completedStageElapsedMs: {},
+      totalElapsedMs: 0,
+      stageElapsedMs: 0,
+      stageRemainingMs: null,
+    });
+    const failedSummary = {
+      stageLabel: 'Transform',
       taskLabel: 'Failed',
       taskUnitLabel: 'Tasks',
       overallProgress: 50,
@@ -123,7 +140,7 @@ describe('ShapeBuildProgressPanel', () => {
       totalElapsedMs: 0,
       stageElapsedMs: 0,
       stageRemainingMs: null,
-    });
+    };
 
     const view = render(
       <Provider store={store}>
@@ -132,6 +149,7 @@ describe('ShapeBuildProgressPanel', () => {
     );
 
     await within(view.container).findByText('Build controls');
+    store.set(taskProgressSummaryAtom, failedSummary);
     await waitFor(() => {
       expect(document.body.textContent).toContain('transform failed: max vertices per feature exceeded');
     });

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
@@ -41,7 +41,7 @@ describe('TaskItemCardListCard', () => {
     ];
     const store = createStore();
 
-    render(
+    const view = render(
       <Provider store={store}>
         <TaskItemCardListCard
           stageId="fetch"
@@ -75,7 +75,7 @@ describe('TaskItemCardListCard', () => {
     ];
     const store = createStore();
 
-    render(
+    const view = render(
       <Provider store={store}>
         <TaskItemCardListCard
           stageId="transform"
@@ -119,7 +119,7 @@ describe('TaskItemCardListCard', () => {
     ];
     const store = createStore();
 
-    render(
+    const view = render(
       <Provider store={store}>
         <TaskItemCardListCard
           stageId="fetch"
@@ -134,8 +134,10 @@ describe('TaskItemCardListCard', () => {
     );
 
     expect(screen.queryByText('N/A')).toBeNull();
-    expect(screen.getByText(/Completed|Fetched data/)).toBeTruthy();
-    expect(screen.getByText(/Failed:/)).toBeTruthy();
+    const summaries = screen.getAllByTestId('task-inline-summary')
+      .map((element) => element.textContent ?? '');
+    expect(summaries.some((text) => /Completed|Fetched data/.test(text))).toBe(true);
+    expect(summaries.some((text) => /Failed:/.test(text))).toBe(true);
   });
 
   it('accepts injected summary builder for fetch stage', () => {
@@ -157,7 +159,7 @@ describe('TaskItemCardListCard', () => {
       detailLines: ['Injected fetch detail'],
     });
 
-    render(
+    const view = render(
       <Provider store={store}>
         <TaskItemCardListCard
           stageId="fetch"
@@ -198,7 +200,7 @@ describe('TaskItemCardListCard', () => {
     ];
     const store = createStore();
 
-    render(
+    const view = render(
       <Provider store={store}>
         <TaskItemCardListCard
           stageId="fetch"
@@ -213,11 +215,14 @@ describe('TaskItemCardListCard', () => {
       </Provider>
     );
 
-    const chip = screen.getByText('Completed').closest('.MuiChip-root');
-    expect(chip).toBeTruthy();
-    if (chip) {
-      fireEvent.mouseEnter(chip);
-    }
+    const chips = Array.from(new Set(
+      screen.getAllByText('Completed')
+        .map((element) => element.closest('.MuiChip-root'))
+        .filter((element): element is HTMLElement => Boolean(element))
+        .filter((element) => element.closest('[data-task-id]')),
+    ));
+    expect(chips.length).toBe(1);
+    fireEvent.mouseEnter(chips[0]);
 
     expect(screen.getByText('URL: https://example.com/jp/adm0.geojson')).toBeTruthy();
     expect(screen.getByText('Features')).toBeTruthy();
@@ -267,7 +272,7 @@ describe('TaskItemCardListCard', () => {
     ];
     const store = createStore();
 
-    render(
+    const view = render(
       <Provider store={store}>
         <TaskItemCardListCard
           stageId="fetch"
@@ -282,9 +287,7 @@ describe('TaskItemCardListCard', () => {
       </Provider>
     );
 
-    const chips = screen.getAllByText('Completed')
-      .map((element) => element.closest('.MuiChip-root'))
-      .filter(Boolean) as HTMLElement[];
+    const chips = Array.from(view.container.querySelectorAll('[data-task-id] .MuiChip-root'));
     expect(chips.length).toBe(2);
 
     fireEvent.mouseEnter(chips[0]);
@@ -323,7 +326,7 @@ describe('TaskItemCardListCard', () => {
     const store = createStore();
     const onOpenDetailFloatingWindow = vi.fn();
 
-    render(
+    const view = render(
       <Provider store={store}>
         <TaskItemCardListCard
           stageId="fetch"
@@ -339,11 +342,9 @@ describe('TaskItemCardListCard', () => {
       </Provider>
     );
 
-    const chip = screen.getByText('Completed').closest('.MuiChip-root');
-    expect(chip).toBeTruthy();
-    if (chip) {
-      fireEvent.click(chip);
-    }
+    const chips = Array.from(view.container.querySelectorAll('[data-task-id] .MuiChip-root'));
+    expect(chips.length).toBe(1);
+    fireEvent.click(chips[0]);
     expect(onOpenDetailFloatingWindow).toHaveBeenCalledTimes(1);
   });
 
@@ -408,21 +409,22 @@ describe('TaskItemCardListCard', () => {
       );
     };
 
-    render(
+    const view = render(
       <Provider store={store}>
         <Harness />
       </Provider>
     );
 
-    const chips = screen.getAllByText('Completed')
-      .map((element) => element.closest('.MuiChip-root'))
-      .filter(Boolean) as HTMLElement[];
+    const chips = Array.from(view.container.querySelectorAll('[data-task-id] .MuiChip-root'));
     expect(chips.length).toBe(2);
 
     fireEvent.click(chips[0]);
     expect(screen.getByText('URL: https://example.com/jp/close-sync.geojson')).toBeTruthy();
 
-    fireEvent.click(screen.getByLabelText('Close preview'));
+    const closeButtons = view.container.querySelectorAll('[aria-label="Close preview"]');
+    const closeButton = closeButtons[0] as HTMLElement | undefined;
+    expect(closeButton).toBeTruthy();
+    fireEvent.click(closeButton as HTMLElement);
     fireEvent.click(screen.getByRole('button', { name: 'Reopen preview' }));
     fireEvent.mouseEnter(chips[1]);
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/BuildProgressStageContent/BuildProgressStageContent.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/BuildProgressStageContent/BuildProgressStageContent.tsx
@@ -20,6 +20,7 @@ type BuildProgressStageContentProps = {
   }>;
   isTaskSummaryLoading: boolean;
   isTasksLoading: boolean;
+  isStartupPending: boolean;
   buildStatus: BuildStatus;
   resolveStatusLabel: (statusValue?: string, skipped?: boolean) => string;
   resolveStatusColor: (statusValue?: string, skipped?: boolean) => 'default' | 'success' | 'error' | 'warning' | 'info';
@@ -42,6 +43,7 @@ export const BuildProgressStageContent = ({
   paneProgress,
   isTaskSummaryLoading,
   isTasksLoading,
+  isStartupPending,
   buildStatus,
   resolveStatusLabel,
   resolveStatusColor,
@@ -62,6 +64,7 @@ export const BuildProgressStageContent = ({
     paneProgress,
     isTaskSummaryLoading,
     isTasksLoading,
+    isStartupPending,
     buildStatus,
     resolveStatusLabel,
     resolveStatusColor,

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/BuildProgressStageContent/useBuildProgressStageContentState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/BuildProgressStageContent/useBuildProgressStageContentState.ts
@@ -25,6 +25,7 @@ type BuildProgressStageContentStateArgs = {
   }>;
   isTaskSummaryLoading: boolean;
   isTasksLoading: boolean;
+  isStartupPending: boolean;
   buildStatus: BuildStatus;
   resolveStatusLabel: (statusValue?: string, skipped?: boolean) => string;
   resolveStatusColor: (
@@ -83,6 +84,7 @@ export const useBuildProgressStageContentState = ({
   paneProgress,
   isTaskSummaryLoading,
   isTasksLoading,
+  isStartupPending,
   buildStatus,
   resolveStatusLabel,
   resolveStatusColor,
@@ -153,7 +155,10 @@ export const useBuildProgressStageContentState = ({
   const stagePane = paneProgress?.find((entry) => entry.paneId === stage.id);
   const hasSummaryTasks = (stagePane?.taskCount ?? 0) > 0;
   const showSummarySkeleton = isTaskSummaryLoading && !hasTasks && !hasSummaryTasks;
-  const showTaskSkeleton = !hasTasks && !showSummarySkeleton && isTasksLoading;
+  const showTaskSkeleton = !hasTasks
+    && !showSummarySkeleton
+    && isTasksLoading
+    && (isBuildInProgressState || isStartupPending);
 
   const requestedTargetIndex = useMemo(() => {
     if (!scrollToTaskId) return null;

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/base/useShapeBuildProgressPanelControllerBaseState/useShapeBuildProgressPanelControllerBaseStateDataCore.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/base/useShapeBuildProgressPanelControllerBaseState/useShapeBuildProgressPanelControllerBaseStateDataCore.ts
@@ -212,6 +212,7 @@ export const useShapeBuildProgressPanelControllerBaseStateDataCore = ({
     || controls.startPending
     || startPendingHold;
   const isTaskSummaryLoadingForDisplay = isTaskSummaryLoading || isResetSessionLoading;
+  const isStartupPendingForDisplay = isBuildStartupPending || startPendingHold;
   const isControlMenuDisabled = isResetSessionLoading || summary.buildStatus === 'idle';
   const isStartButtonLoading = isResetSessionLoading
     ? false
@@ -616,6 +617,7 @@ export const useShapeBuildProgressPanelControllerBaseStateDataCore = ({
     startPendingHold,
     isTasksLoadingForDisplay,
     isTaskSummaryLoadingForDisplay,
+    isStartupPendingForDisplay,
     taskSearchText,
     setTaskSearchText,
     startupNoticeDismissed,

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/base/useShapeBuildProgressPanelControllerBaseState/useShapeBuildProgressPanelControllerBaseStateDataDisplay.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/base/useShapeBuildProgressPanelControllerBaseState/useShapeBuildProgressPanelControllerBaseStateDataDisplay.ts
@@ -73,6 +73,7 @@ type DisplayArgs = {
   startPendingHold: boolean;
   isTasksLoadingForDisplay: boolean;
   isTaskSummaryLoadingForDisplay: boolean;
+  isStartupPendingForDisplay: boolean;
   taskSearchText: string;
   setTaskSearchText: (next: string) => void;
   startupNoticeDismissed: boolean;
@@ -190,6 +191,7 @@ export const useShapeBuildProgressPanelControllerBaseStateDataDisplay = (args: D
     startPendingHold,
     isTasksLoadingForDisplay,
     isTaskSummaryLoadingForDisplay,
+    isStartupPendingForDisplay,
     taskSearchText,
     setTaskSearchText,
     startupNoticeDismissed,
@@ -293,6 +295,7 @@ export const useShapeBuildProgressPanelControllerBaseStateDataDisplay = (args: D
     isResetSessionLoading,
     isResetSessionPending,
     startPendingHold,
+    isStartupPendingForDisplay,
     isControlMenuDisabled,
     isStartButtonLoading,
     isBuildSessionStarted,

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/useShapeBuildProgressPanelControllerOverlaySections.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/useShapeBuildProgressPanelControllerOverlaySections.ts
@@ -29,6 +29,7 @@ export type StageContentArgs = {
   tasksByStageForDisplay: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['tasksByStageForDisplay'];
   isTasksLoadingForDisplay: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['isTasksLoadingForDisplay'];
   isTaskSummaryLoadingForDisplay: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['isTaskSummaryLoadingForDisplay'];
+  isStartupPendingForDisplay: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['isStartupPendingForDisplay'];
   summary: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['summary'];
   resolveStatusLabel: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['resolveStatusLabel'];
   resolveStatusColor: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['resolveStatusColor'];
@@ -63,6 +64,7 @@ const ShapeBuildProgressPanelStageContent = ({
   tasksByStageForDisplay,
   isTasksLoadingForDisplay,
   isTaskSummaryLoadingForDisplay,
+  isStartupPendingForDisplay,
   summary,
   resolveStatusLabel,
   resolveStatusColor,
@@ -83,6 +85,7 @@ const ShapeBuildProgressPanelStageContent = ({
     tasksByStageForDisplay,
     isTasksLoadingForDisplay,
     isTaskSummaryLoadingForDisplay,
+    isStartupPendingForDisplay,
     summary,
     resolveStatusLabel,
     resolveStatusColor,
@@ -105,6 +108,7 @@ export const useShapeBuildProgressPanelControllerOverlaySections = ({
   paneProgressForDisplay,
   isTasksLoadingForDisplay,
   isTaskSummaryLoadingForDisplay,
+  isStartupPendingForDisplay,
   resolveStatusLabel,
   resolveStatusColor,
   resolveTaskTitle,
@@ -136,6 +140,7 @@ export const useShapeBuildProgressPanelControllerOverlaySections = ({
       tasksByStageForDisplay,
       isTasksLoadingForDisplay,
       isTaskSummaryLoadingForDisplay,
+      isStartupPendingForDisplay,
       summary,
       resolveStatusLabel,
       resolveStatusColor,

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/useShapeBuildProgressPanelControllerOverlaySectionsView.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/useShapeBuildProgressPanelControllerOverlay/useShapeBuildProgressPanelControllerOverlaySectionsView.tsx
@@ -18,6 +18,7 @@ type StageContentArgs = {
   tasksByStageForDisplay: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['tasksByStageForDisplay'];
   isTasksLoadingForDisplay: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['isTasksLoadingForDisplay'];
   isTaskSummaryLoadingForDisplay: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['isTaskSummaryLoadingForDisplay'];
+  isStartupPendingForDisplay: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['isStartupPendingForDisplay'];
   summary: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['summary'];
   resolveStatusLabel: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['resolveStatusLabel'];
   resolveStatusColor: UseShapeBuildProgressPanelControllerOverlaySectionsArgs['resolveStatusColor'];
@@ -55,6 +56,7 @@ export const ShapeBuildProgressPanelOverlaySectionContent = ({
   tasksByStageForDisplay,
   isTasksLoadingForDisplay,
   isTaskSummaryLoadingForDisplay,
+  isStartupPendingForDisplay,
   summary,
   resolveStatusLabel,
   resolveStatusColor,
@@ -75,6 +77,7 @@ export const ShapeBuildProgressPanelOverlaySectionContent = ({
     paneProgress={paneProgress ?? []}
     isTasksLoading={isTasksLoadingForDisplay}
     isTaskSummaryLoading={isTaskSummaryLoadingForDisplay}
+    isStartupPending={isStartupPendingForDisplay}
     buildStatus={summary.buildStatus}
     resolveStatusLabel={resolveStatusLabel}
     resolveStatusColor={resolveStatusColor}

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemCard.tsx
@@ -139,7 +139,7 @@ export const TaskItemCard = ({
         <span aria-label={countryCode ?? 'country-flag'}>{flag}</span>
       </Box>
     )
-    : null;
+    : (stageIcon ?? null);
 
   return (
     <TaskItem

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/stage.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/stage.ts
@@ -1,4 +1,5 @@
 import type { TaskStage } from '@hierarchidb/build-api';
+import { resolveMostAdvancedStageId } from '~/ui/components/build-progress/stagePriority';
 
 export type StageLikeTask = {
   stage: TaskStage;
@@ -47,14 +48,5 @@ const resolveMostAdvancedRunningStage = (
   stageIds: Set<string>,
   stages: Array<{ id: string }>,
 ): string | null => {
-  const stageOrder = stages.map((stage) => stage.id);
-  for (let index = stageOrder.length - 1; index >= 0; index -= 1) {
-    const stage = stageOrder[index];
-    if (typeof stage !== 'string') {
-      continue;
-    }
-    if (!stageIds.has(stage)) continue;
-    return stage;
-  }
-  return null;
+  return resolveMostAdvancedStageId(stageIds, stages);
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/resolveReceivingTaskSnapshotDecision.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/resolveReceivingTaskSnapshotDecision.ts
@@ -119,9 +119,11 @@ export const resolveReceivingTaskSnapshotDecision = (
   }
 
   if (input.buildStatus === 'failed') {
+    const hasSessionProgressEvidence = typeof input.sessionProgressTotal === 'number'
+      && input.sessionProgressTotal > 0;
     // During resume/startup, build status can remain "failed" briefly while worker stage
     // has already moved into startup:*:start/finish. Avoid premature failure finalization.
-    if (isTransientStartupStage(input.sessionStageId) || input.hasProgressTaskSignal) {
+    if (isTransientStartupStage(input.sessionStageId) || input.hasProgressTaskSignal || hasSessionProgressEvidence) {
       return { kind: 'continue' };
     }
     return {

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSnapshotProgressState/useShapeBuildTaskSnapshotProgressState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSnapshotProgressState/useShapeBuildTaskSnapshotProgressState.ts
@@ -412,7 +412,6 @@ export function useShapeBuildTaskSnapshotProgressState(
       reported.add(task.taskId);
       const message = resolveTaskMetadataMessage(task.metadata)
         ?? task.errorMessage
-        ?? task.message
         ?? 'Task failed';
       const geometryDetails = parseGeometrySimplifyError(message);
       if (geometryDetails) {

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.comparison.utils.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.comparison.utils.ts
@@ -41,6 +41,24 @@ const resolveTaskMetadataText = (task: ShapeBuildTaskSummary): string => (
   resolveTaskMetadataMessage(task.metadata)?.trim() ?? ''
 );
 
+const normalizeTaskMetadata = (
+  metadata: Record<string, unknown> | undefined,
+  message: unknown,
+): Record<string, unknown> | undefined => {
+  if (typeof message !== 'string' || message.trim().length === 0) {
+    return metadata;
+  }
+  const trimmed = message.trim();
+  if (metadata && typeof metadata === 'object') {
+    const existing = typeof metadata.message === 'string' ? metadata.message.trim() : '';
+    if (existing.length > 0) {
+      return metadata;
+    }
+    return { ...metadata, message: trimmed };
+  }
+  return { message: trimmed };
+};
+
 export const areTasksEquivalentForView = (
   left: ShapeBuildTaskSummary,
   right: ShapeBuildTaskSummary,
@@ -211,10 +229,18 @@ const shouldPromoteCompletedMessage = (
   return false;
 };
 
+const isRetryableTerminalTask = (task: ShapeBuildTaskSummary): boolean => (
+  task.status === 'failed'
+  || isTaskSkipped(task.display, resolveTaskMetadataText(task))
+);
+
 export const shouldPreferNextTask = (
   current: ShapeBuildTaskSummary,
   next: ShapeBuildTaskSummary,
 ): boolean => {
+  if (isRetryableTerminalTask(current) && (next.status === 'queued' || next.status === 'running')) {
+    return true;
+  }
   if (isCompletedAtFullProgress(current) && isCompletedAtFullProgress(next)) {
     return shouldPromoteCompletedMessage(current, next);
   }
@@ -294,14 +320,16 @@ export const replaceSnapshotAndPreserveCurrentTasksByStage = (
 
 export const resolveTaskSummaryFromRaw = (task: RawTaskSummary): ShapeBuildTaskSummary => {
   const stage = resolveTaskStage(task);
+  const normalizedMetadata = normalizeTaskMetadata(task.metadata, undefined);
   const progress = resolveProgressValue(task.progress);
-  const metadataMessage = resolveTaskMetadataMessage(task.metadata) ?? '';
+  const metadataMessage = resolveTaskMetadataMessage(normalizedMetadata) ?? '';
   const resolvedStatus = resolveTaskDisplayStatus(task.status, progress, task.display, metadataMessage);
   return {
     ...task,
     stage,
     status: resolvedStatus,
     progress: resolveTaskProgress(resolvedStatus, task.display, metadataMessage, progress),
+    metadata: normalizedMetadata,
   };
 };
 
@@ -327,18 +355,7 @@ export const resolveTaskStage = (task: RawTaskSummary): TaskStage => {
     return taskIdStage;
   }
 
-  const fallbackStage = String(task.stage).toLowerCase();
-  if (fallbackStage.includes('fetch')) {
-    return 'fetch';
-  }
-  if (fallbackStage.includes('transform')) {
-    return 'transform';
-  }
-  if (fallbackStage.includes('vt')) {
-    return 'vt';
-  }
-
-  return 'fetch';
+  throw new Error('invalid task stage');
 };
 
 export const isTaskStage = (value: unknown): value is TaskStage => (

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.debug.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.debug.ts
@@ -108,7 +108,9 @@ export const logTaskUpdate100 = (task: ShapeBuildTaskSummary): void => {
   const indexValue = taskIdParts.length >= 4 ? taskIdParts[3] : taskIdParts[2];
   const resolvedCountry = countryIndex || 'unknown';
   const resolvedIndex = typeof indexValue === 'string' && indexValue.length > 0 ? indexValue : '0';
-  const resolvedMessage = resolveTaskMetadataMessage(task.metadata) || task.status;
+  const resolvedMessage = resolveTaskMetadataMessage(task.metadata)
+    || task.errorMessage
+    || task.status;
   console.log(
     `[TaskUpdate100] ${resolvedCountry}, ${resolvedIndex}, ${resolvedMessage}, ${task.status}`,
   );

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.resolver.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.resolver.ts
@@ -71,9 +71,10 @@ export const useShapeBuildTaskSyncResolver = ({
       if (parentInputSummary) {
         const parentInputMessage = buildVtParentInputSummaryMessage(parentInputSummary);
         const baseMessage = resolveTaskMetadataText(resolvedTask);
+        const mergedMessage = mergeTaskMessage(baseMessage, parentInputMessage);
         resolvedTask.metadata = {
           ...(resolvedTask.metadata ?? {}),
-          message: mergeTaskMessage(baseMessage, parentInputMessage),
+          message: mergedMessage,
         };
         if (isDev) {
           const logKey = `${resolvedTask.taskId}:${parentInputMessage}`;

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts
@@ -178,6 +178,13 @@ export const useShapeBuildTaskSyncScheduling = ({
       changed = changed || result.changed;
     });
 
+    tasksMapRef.current = new Map(nextList.map((task) => [task.taskId, task]));
+    completedTasksRef.current = new Map(
+      nextList
+        .filter((task) => isCompletedAtFullProgress(task))
+        .map((task) => [task.taskId, task]),
+    );
+
     return { nextList, changed };
   }, [
     bufferedSnapshotRef,

--- a/plugins/shape-plugin/src/ui/components/preview/internal/__tests__/adminLevel.test.ts
+++ b/plugins/shape-plugin/src/ui/components/preview/internal/__tests__/adminLevel.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { parseAdminLevelValue } from '../adminLevel';
 import { collectShapeLayerAdminLevels } from '../useShapePreviewStepUtils';
 import { parseSourceKey } from '../useShapePreviewStepUtils';
+
+vi.mock('@hierarchidb/ui-map', () => ({
+  formatAdminLevelLabel: (value?: number) => (
+    typeof value === 'number' && Number.isFinite(value) ? `ADM${value}` : 'Base'
+  ),
+}));
 
 describe('parseAdminLevelValue', () => {
   it('normalizes numeric and ADM-level values', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3911,9 +3911,6 @@ importers:
       '@hierarchidb/shape-store':
         specifier: workspace:*
         version: link:../../packages/shape-store
-      '@hierarchidb/ui-monitoring':
-        specifier: workspace:*
-        version: link:../../packages/ui/monitoring
       '@hierarchidb/util':
         specifier: workspace:*
         version: link:../../packages/util
@@ -4065,6 +4062,9 @@ importers:
       '@hierarchidb/ui-memory':
         specifier: workspace:*
         version: link:../../packages/ui/memory
+      '@hierarchidb/ui-monitoring':
+        specifier: workspace:*
+        version: link:../../packages/ui/monitoring
       '@hierarchidb/ui-plugin-basic-info':
         specifier: workspace:*
         version: link:../../packages/ui/plugin-basic-info


### PR DESCRIPTION
## Summary
- resolve TS2307 in ui-dialog d.ts by switching to relative headless types import
- keep build-progress skeletons during startup pending/hold transitions
- normalize task sync metadata message handling and clean up test selectors

## Testing
- pnpm -w turbo run test --filter @hierarchidb/shape-plugin
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin

Refs #611
