### PR TITLE
fix(shape): stabilize build task sync

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #613 / `codex/fix/shape/ingest-main-diff-613` / start: 2026-02-28 12:55 JST
 - #611 / `codex/fix/build/ts2307-shape-tests-611` / start: 2026-02-28 12:28 JST
 - #604 / `codex/fix/plugin-dialog-safe-menu-popover-604` / start: 2026-02-28 10:38 JST
 - #601 / `codex/fix/plugin-registry-build-owned-generation-601` / start: 2026-02-28 10:28 JST
@@ -129,6 +130,8 @@
 
 ## 今日の運用ログ
 - start: 2026-02-28 12:28 JST #611 を起票（https://github.com/kubohiroya/hierarchidb/issues/611）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/build/ts2307-shape-tests-611` を作成し、worktree `/Users/hiroya/WebstormProjects/hierarchidb-codex-611` で着手。
+- start: 2026-02-28 12:55 JST #613 を起票（https://github.com/kubohiroya/hierarchidb/issues/613）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape/ingest-main-diff-613` を作成して着手。
+- update: 2026-02-28 13:23 JST #613 検証: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` exit 0。依存更新のため `pnpm install` 実行（exit 0）。
 - update: 2026-02-28 12:50 JST #611 `@hierarchidb/ui-dialog` の d.ts に残っていた `~/headless/types` 参照を相対 import に修正し、TS2307 を解消。
 - done: 2026-02-28 12:50 JST #611 検証: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` exit 0。
 - done: 2026-02-28 10:45 JST #604 検証: `pnpm -w turbo run build --filter @hierarchidb/ui-dialog --filter @hierarchidb/components --filter @hierarchidb/plugin-ui-host --filter @hierarchidb/shape-plugin --filter @hierarchidb/location-plugin --filter @hierarchidb/resolver-plugin --only --output-logs errors-only` exit 0。`HIERARCHIDB_E2E=1 node_modules/.bin/playwright test e2e/shape/plugin-dialog-caret.spec.ts --project=chromium` exit 0（1 passed）。

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,7 +39,9 @@
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@hierarchidb/ui-dialog": "workspace:*"
+  },
   "peerDependencies": {
     "@mui/icons-material": "^7.3.6",
     "@mui/material": "^7.3.6",

--- a/plugins/shape-plugin/src/__tests__/unit/shapePipelineFetchStageSection.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/shapePipelineFetchStageSection.unit.test.ts
@@ -9,6 +9,7 @@ import * as shapeFetchStageModule from '../../services/vt/shapeFetchStage';
 import {
   listTasksByStageAndStatus,
   putTasks,
+  updateTask,
   VtTaskQueueDb,
 } from '@hierarchidb/vt-orchestrator';
 
@@ -193,5 +194,51 @@ describe('runShapeFetchStageSection', () => {
     expect(queued).toHaveLength(1);
     expect(queued[0]?.message ?? null).toBeNull();
     expect(queued[0]?.errorMessage ?? null).toBeNull();
+  });
+
+  it('retries queued drain once on fresh runs before finalizing pending tasks', async () => {
+    db = createDb();
+    await putTasks(db, [createQueuedFetchTask('fetch-queued-drain-1')]);
+
+    const runShapeFetchStageSpy = vi
+      .spyOn(shapeFetchStageModule, 'runShapeFetchStage')
+      .mockImplementationOnce(async () => {})
+      .mockImplementationOnce(async () => {
+        await updateTask(db!, 'fetch-queued-drain-1', {
+          status: 'completed',
+          progress: 100,
+          completedAt: Date.now(),
+          message: 'completed on recovery pass',
+          errorMessage: undefined,
+        });
+      });
+
+    try {
+      const stopAfterStage = await runShapeFetchStageSection({
+        nodeId: NODE_ID,
+        dataSource: 'geoboundaries',
+        buildConfig: DEFAULT_BUILD_CONFIG,
+        taskQueue: db,
+        resumeExistingTasks: false,
+        failureHandling: 'continue',
+        buildContinuationPolicy: 'finish_all_stages',
+        pipelineRunId: 'test-run-fresh-pending-drain',
+      });
+      expect(stopAfterStage).toBe(false);
+      expect(runShapeFetchStageSpy).toHaveBeenCalledTimes(2);
+      expect(runShapeFetchStageSpy.mock.calls[0]?.[0]?.resumeExistingTasks).toBe(false);
+      expect(runShapeFetchStageSpy.mock.calls[1]?.[0]?.resumeExistingTasks).toBe(true);
+    } finally {
+      runShapeFetchStageSpy.mockRestore();
+    }
+
+    const [failed, completed, queued] = await Promise.all([
+      listTasksByStageAndStatus(db, NODE_ID, 'fetch', 'failed'),
+      listTasksByStageAndStatus(db, NODE_ID, 'fetch', 'completed'),
+      listTasksByStageAndStatus(db, NODE_ID, 'fetch', 'queued'),
+    ]);
+    expect(failed).toHaveLength(0);
+    expect(completed).toHaveLength(1);
+    expect(queued).toHaveLength(0);
   });
 });

--- a/plugins/shape-plugin/src/services/vt/shapePipelineFetchStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineFetchStage.ts
@@ -47,7 +47,7 @@ export const runShapeFetchStageSection = async (params: ShapeFetchStageParams): 
   if (params.resumeExistingTasks) {
     await markStageTasksRecycled(params.taskQueue, params.nodeId, 'fetch');
   }
-  try {
+  const runFetchPass = async (resumeExistingTasks: boolean): Promise<void> => {
     await runShapeFetchStage({
       nodeId: params.nodeId,
       dataSource: params.dataSource,
@@ -56,11 +56,14 @@ export const runShapeFetchStageSection = async (params: ShapeFetchStageParams): 
       buildConfig: params.buildConfig,
       taskQueue: params.taskQueue,
       waitIfPaused: params.waitIfPaused,
-      resumeExistingTasks: params.resumeExistingTasks,
+      resumeExistingTasks,
       abortController: fetchAbortController,
       failureHandling: params.failureHandling,
       onTasksEnqueued: params.onTasksEnqueued,
     });
+  };
+  try {
+    await runFetchPass(params.resumeExistingTasks);
   } catch (error) {
     const baseMessage = error instanceof Error ? error.message : String(error);
     const failedTaskId = error && typeof error === 'object'
@@ -78,11 +81,21 @@ export const runShapeFetchStageSection = async (params: ShapeFetchStageParams): 
     throw error;
   }
   let stageCounts = await summarizeStageCounts(params.taskQueue, params.nodeId, 'fetch');
-  console.warn('[ShapeTransform][PipelineDiagnostics] stage fetch completed', JSON.stringify({
+  console.warn('[ShapeFetch][PipelineDiagnostics] stage fetch completed', JSON.stringify({
     nodeId: params.nodeId,
     runId: params.pipelineRunId ?? null,
     counts: stageCounts,
   }));
+  if (!params.resumeExistingTasks && (stageCounts.queued > 0 || stageCounts.running > 0)) {
+    console.warn('[ShapeFetch][PipelineDiagnostics] fetch stage left pending tasks on fresh run; retrying queued drain once', JSON.stringify({
+      nodeId: params.nodeId,
+      runId: params.pipelineRunId ?? null,
+      counts: stageCounts,
+    }));
+    await resetStageRunningTasks(params.taskQueue, params.nodeId, 'fetch');
+    await runFetchPass(true);
+    stageCounts = await summarizeStageCounts(params.taskQueue, params.nodeId, 'fetch');
+  }
   if (params.resumeExistingTasks && (stageCounts.queued > 0 || stageCounts.running > 0)) {
     await resetStageRunningTasks(params.taskQueue, params.nodeId, 'fetch');
     stageCounts = await summarizeStageCounts(params.taskQueue, params.nodeId, 'fetch');

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSnapshotProgressState.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSnapshotProgressState.unit.test.tsx
@@ -4,6 +4,7 @@ import type { BuildTaskUpdateEvent } from '@hierarchidb/build-api';
 import { useShapeBuildTaskSnapshotProgressState } from '../../../components/build-progress/useShapeBuildTaskSnapshotProgressState/useShapeBuildTaskSnapshotProgressState';
 import type { NodeId } from '@hierarchidb/core-types';
 import { getDefaultStore } from 'jotai';
+import { resolveTaskMetadataMessage } from '~/common/utils/taskMessages';
 import {
   tasksAtom,
   tasksErrorAtom,
@@ -1390,7 +1391,8 @@ describe('useShapeBuildTaskSnapshotProgressState', () => {
 
     await waitFor(() => {
       expect(result.current.tasks).toHaveLength(1);
-      expect(result.current.tasks[0]?.message).toBe(
+      const message = resolveTaskMetadataMessage(result.current.tasks[0]?.metadata);
+      expect(message).toBe(
         'tiles 12/40 | vt parent input z=6 x=15 y=23 intersects(features=9, geojsonBytes=2316360)',
       );
     });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx
@@ -307,40 +307,46 @@ describe('useShapeBuildTaskSnapshotProgressState', () => {
   });
 
   it('accepts task updates for unknown taskId', async () => {
-    const { result } = renderHook(() => useShapeBuildTaskSnapshotProgressState('node-progress' as NodeId));
-    await waitFor(() => {
-      expect(subscribeMock).toHaveBeenCalled();
-    });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { result } = renderHook(() => useShapeBuildTaskSnapshotProgressState('node-progress' as NodeId));
+      await waitFor(() => {
+        expect(subscribeMock).toHaveBeenCalled();
+      });
 
-    emitEvent('node-progress', {
-      type: 'snapshot',
-      nodeId: 'node-progress' as NodeId,
-      tasks: [
-        makeTaskSummary('node-progress:fetch:0', { status: 'running', progress: 20, index: 1 }),
-        makeTaskSummary('node-progress:fetch:1', { status: 'running', progress: 10, index: 2 }),
-      ],
-    });
+      emitEvent('node-progress', {
+        type: 'snapshot',
+        nodeId: 'node-progress' as NodeId,
+        tasks: [
+          makeTaskSummary('node-progress:fetch:0', { status: 'running', progress: 20, index: 1 }),
+          makeTaskSummary('node-progress:fetch:1', { status: 'running', progress: 10, index: 2 }),
+        ],
+      });
 
-    await waitFor(() => {
-      expect(result.current.tasks).toHaveLength(2);
-      expect(result.current.tasks[0]?.status).toBe('running');
-      expect(result.current.tasks[0]?.progress).toBe(20);
-    });
+      await waitFor(() => {
+        expect(result.current.tasks).toHaveLength(2);
+        expect(result.current.tasks[0]?.status).toBe('running');
+        expect(result.current.tasks[0]?.progress).toBe(20);
+      });
 
-    emitEvent('node-progress', {
-      type: 'update',
-      nodeId: 'node-progress' as NodeId,
-      task: makeTaskSummary('node-progress:fetch:unknown', {
-        status: 'running',
-        progress: 50,
-        message: 'invalid',
-        index: 0,
-      }),
-    });
+      emitEvent('node-progress', {
+        type: 'update',
+        nodeId: 'node-progress' as NodeId,
+        task: makeTaskSummary('node-progress:fetch:unknown', {
+          status: 'running',
+          progress: 50,
+          message: 'invalid',
+          index: 0,
+        }),
+      });
 
-    await waitFor(() => {
-      expect(result.current.tasks).toHaveLength(3);
-    });
+      await waitFor(() => {
+        expect(result.current.tasks).toHaveLength(3);
+      });
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it('keeps update target semantics for known tasks', async () => {

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.comparison.utils.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.comparison.utils.ts
@@ -37,9 +37,16 @@ const areMetadataEquivalentForView = (
   return leftKeys.every((key) => Object.hasOwn(right, key) && right[key] === left[key]);
 };
 
-const resolveTaskMetadataText = (task: ShapeBuildTaskSummary): string => (
-  resolveTaskMetadataMessage(task.metadata)?.trim() ?? ''
-);
+const resolveTaskMetadataText = (task: ShapeBuildTaskSummary): string => {
+  const metadataMessage = resolveTaskMetadataMessage(task.metadata)?.trim();
+  if (metadataMessage) return metadataMessage;
+  const rawMessage = (task as { message?: unknown }).message;
+  if (typeof rawMessage === 'string') {
+    const trimmed = rawMessage.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return '';
+};
 
 const normalizeTaskMetadata = (
   metadata: Record<string, unknown> | undefined,
@@ -320,7 +327,8 @@ export const replaceSnapshotAndPreserveCurrentTasksByStage = (
 
 export const resolveTaskSummaryFromRaw = (task: RawTaskSummary): ShapeBuildTaskSummary => {
   const stage = resolveTaskStage(task);
-  const normalizedMetadata = normalizeTaskMetadata(task.metadata, undefined);
+  const rawMessage = (task as { message?: unknown }).message;
+  const normalizedMetadata = normalizeTaskMetadata(task.metadata, rawMessage);
   const progress = resolveProgressValue(task.progress);
   const metadataMessage = resolveTaskMetadataMessage(normalizedMetadata) ?? '';
   const resolvedStatus = resolveTaskDisplayStatus(task.status, progress, task.display, metadataMessage);

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.handlers.events.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.handlers.events.ts
@@ -96,7 +96,7 @@ export const useShapeBuildTaskSyncEventHandlers = ({
     if (!previous && tasksMapRef.current.size > 0) {
       const message = `[ShapeBuildTaskSync] unknown taskId: ${resolved.taskId}`;
       if (isDev) {
-        console.error(message, {
+        console.debug(`${message} (accepted as late update)`, {
           nodeId: sessionNodeId,
           task: resolved,
           currentTasks: Array.from(tasksMapRef.current.keys()),

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.resolver.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.resolver.ts
@@ -14,9 +14,16 @@ import {
 } from './useShapeBuildTaskSync.comparison.utils.js';
 import { isTaskSkipped, resolveTaskMetadataMessage } from '~/common/utils/taskMessages';
 
-const resolveTaskMetadataText = (task: ReturnType<typeof resolveTaskSummaryFromRaw>): string => (
-  resolveTaskMetadataMessage(task.metadata)?.trim() ?? ''
-);
+const resolveTaskMetadataText = (task: ReturnType<typeof resolveTaskSummaryFromRaw>): string => {
+  const metadataMessage = resolveTaskMetadataMessage(task.metadata)?.trim();
+  if (metadataMessage) return metadataMessage;
+  const rawMessage = (task as { message?: unknown }).message;
+  if (typeof rawMessage === 'string') {
+    const trimmed = rawMessage.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return '';
+};
 
 type ResolverDeps = {
   sessionNodeId: string | null;

--- a/plugins/shape-plugin/src/worker/api/api-internal-execution-core.ts
+++ b/plugins/shape-plugin/src/worker/api/api-internal-execution-core.ts
@@ -69,7 +69,6 @@ const {
   getShapeEntityHandler,
   activePipelines,
   activePipelineRuns,
-  seedTaskQueueFromBuildTasks,
   isStopReason,
 } = shapeBuildRuntimeExecutionMetrics;
 
@@ -598,6 +597,10 @@ const startBuildSessionInternal = async (
       'config-invalidation',
       async () => applyConfigInvalidation(nodeForSession, null, mergedRuntimeConfig),
     );
+    await executeStartupStep(
+      'clear-build-task-history',
+      async () => clearBuildTasksByStage(nodeForSession, ['fetch', 'transform', 'vt']),
+    );
     let existingTaskCount = await executeStartupStep(
       'count-existing-tasks',
       async () => taskQueue.tasks.where('nodeId').equals(nodeForSession).count(),
@@ -613,15 +616,6 @@ const startBuildSessionInternal = async (
         {
           existingTaskCount,
           previousSessionStatus: previousSession?.status ?? null,
-        },
-      );
-    }
-    if (existingTaskCount === 0) {
-      await executeStartupStep(
-        'seed-task-queue',
-        async () => {
-          await seedTaskQueueFromBuildTasks(nodeForSession);
-          existingTaskCount = await taskQueue.tasks.where('nodeId').equals(nodeForSession).count();
         },
       );
     }
@@ -987,19 +981,14 @@ const invokeShapeBuildCommand = async (
         clearActivePipelineRuntimeState(nodeId);
       }
     });
+    await executeResumeStep(
+      'clear-build-task-history',
+      async () => clearBuildTasksByStage(nodeId, ['fetch', 'transform', 'vt']),
+    );
     let existingTaskCount = await executeResumeStep(
       'count-existing-tasks',
       async () => taskQueue.tasks.where('nodeId').equals(nodeId).count(),
     );
-    if (existingTaskCount === 0) {
-      await executeResumeStep(
-        'seed-task-queue',
-        async () => {
-          await seedTaskQueueFromBuildTasks(nodeId);
-          existingTaskCount = await taskQueue.tasks.where('nodeId').equals(nodeId).count();
-        },
-      );
-    }
     if (activePipelines.has(pipelineKey)) {
       await emitProgressSnapshot(nodeId, 'resumeBuildSession ignored: pipeline already active');
       return;
@@ -1099,15 +1088,6 @@ const invokeShapeBuildCommand = async (
       'count-existing-tasks-after-invalidation',
       async () => taskQueue.tasks.where('nodeId').equals(nodeId).count(),
     );
-    if (existingTaskCount === 0) {
-      await executeResumeStep(
-        'seed-task-queue-after-invalidation',
-        async () => {
-          await seedTaskQueueFromBuildTasks(nodeId);
-          existingTaskCount = await taskQueue.tasks.where('nodeId').equals(nodeId).count();
-        },
-      );
-    }
     const existingFetchTaskCount = await executeResumeStep(
       'count-existing-fetch-tasks-after-invalidation',
       async () => taskQueue.tasks.where('[nodeId+stage]').equals([nodeId, 'fetch']).count(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,6 +695,10 @@ importers:
         version: 5.8.2
 
   packages/components:
+    dependencies:
+      '@hierarchidb/ui-dialog':
+        specifier: workspace:*
+        version: link:../ui/dialog
     devDependencies:
       '@emotion/react':
         specifier: 11.14.0
@@ -705,9 +709,6 @@ importers:
       '@hierarchidb/core-types':
         specifier: workspace:*
         version: link:../core-types
-      '@hierarchidb/ui-dialog':
-        specifier: workspace:*
-        version: link:../ui/dialog
       '@hierarchidb/ui-lru-splitview':
         specifier: workspace:*
         version: link:../ui/lru-splitview


### PR DESCRIPTION
## Summary\n- normalize build task metadata by carrying message into metadata so skip/phase/summary logic stays consistent\n- add fetch-stage retry drain for queued/running tasks on fresh start\n- reset build task history on start/resume to avoid stale progress and accept late updates\n- ensure components resolves @hierarchidb/ui-dialog in tests by adding dependency\n\n## Testing\n- pnpm -w turbo run test --filter @hierarchidb/shape-plugin\n- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin\n\nRefs #613