### PR TITLE
refactor(shape-plugin): reuse @hierarchidb/ui-floating-window in step5 detail preview

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #615 / `codex/refactor/shape/step5-task-detail-use-shared-floating-window-615` / start: 2026-02-28 13:45 JST
 - #613 / `codex/fix/shape/ingest-main-diff-613` / start: 2026-02-28 12:55 JST
 - #611 / `codex/fix/build/ts2307-shape-tests-611` / start: 2026-02-28 12:28 JST
 - #604 / `codex/fix/plugin-dialog-safe-menu-popover-604` / start: 2026-02-28 10:38 JST
@@ -129,6 +130,7 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- start: 2026-02-28 13:45 JST #615 を起票（https://github.com/kubohiroya/hierarchidb/issues/615）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/refactor/shape/step5-task-detail-use-shared-floating-window-615` を `origin/main` 起点で作成して着手。
 - start: 2026-02-28 12:28 JST #611 を起票（https://github.com/kubohiroya/hierarchidb/issues/611）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/build/ts2307-shape-tests-611` を作成し、worktree `/Users/hiroya/WebstormProjects/hierarchidb-codex-611` で着手。
 - start: 2026-02-28 12:55 JST #613 を起票（https://github.com/kubohiroya/hierarchidb/issues/613）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape/ingest-main-diff-613` を作成して着手。
 - update: 2026-02-28 13:23 JST #613 検証: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` exit 0。依存更新のため `pnpm install` 実行（exit 0）。

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
@@ -421,8 +421,8 @@ describe('TaskItemCardListCard', () => {
     fireEvent.click(chips[0]);
     expect(screen.getByText('URL: https://example.com/jp/close-sync.geojson')).toBeTruthy();
 
-    const closeButtons = view.container.querySelectorAll('[aria-label="Close preview"]');
-    const closeButton = closeButtons[0] as HTMLElement | undefined;
+    const titleBarButtons = Array.from(document.querySelectorAll('.floating-window .title-bar button')) as HTMLElement[];
+    const closeButton = titleBarButtons.at(-1);
     expect(closeButton).toBeTruthy();
     fireEvent.click(closeButton as HTMLElement);
     fireEvent.click(screen.getByRole('button', { name: 'Reopen preview' }));

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailSnackbar.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailSnackbar.tsx
@@ -3,13 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
   IconButton,
-  Paper,
   Stack,
   Typography,
   useTheme,
 } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
-import CloseIcon from '@mui/icons-material/Close';
 import LayersIcon from '@mui/icons-material/Layers';
 import { useAtomValue } from 'jotai';
 import type { Feature, FeatureCollection } from 'geojson';
@@ -22,6 +20,7 @@ import type { NodeId } from '@hierarchidb/core-types';
 import type { ShapeFetchCache } from '@hierarchidb/shape-api';
 import { shapeQueryAPIImpl } from '~/services/build/ShapeBuildAPIClient';
 import type { DataSourceName } from '~/common/types';
+import { FloatingWindow, type WindowState } from '@hierarchidb/ui-floating-window';
 import {
   buildRawDataDataSourceCacheKey,
   readRawDataDataSourceBuffer,
@@ -1039,7 +1038,7 @@ const TaskDetailContent = ({
   );
 };
 
-type TaskItemDetailFloatingWindowProps = {
+type TaskItemDetailWindowProps = {
   open: boolean;
   detail: TaskDetailSelection | null;
   onClose: () => void;
@@ -1048,16 +1047,14 @@ type TaskItemDetailFloatingWindowProps = {
   onRequestBringToFront?: () => void;
 };
 
-type ResizeDirection = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
-
-export const TaskItemDetailFloatingWindow = ({
+export const TaskItemDetailWindow = ({
   open,
   detail,
   onClose,
   zIndex,
   stageId,
   onRequestBringToFront,
-}: TaskItemDetailFloatingWindowProps) => {
+}: TaskItemDetailWindowProps) => {
   const theme = useTheme();
   const stages = useAtomValue(buildStagesAtom);
   const activeDetail = detail;
@@ -1075,19 +1072,14 @@ export const TaskItemDetailFloatingWindow = ({
   const [preview, setPreview] = useState<PreviewData | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [fetchStageMaxima, setFetchStageMaxima] = useState<FetchStageMaxima | null>(null);
-  const [position, setPosition] = useState<{ x: number; y: number }>({ x: 8, y: 8 });
-  const [windowSize, setWindowSize] = useState<{ width: number; height: number }>({ width: 580, height: 420 });
-  const [resizeActive, setResizeActive] = useState(false);
-  const dragStateRef = useRef<{ startClientX: number; startClientY: number; startX: number; startY: number } | null>(null);
-  const resizeStateRef = useRef<{
-    direction: ResizeDirection;
-    startClientX: number;
-    startClientY: number;
-    startX: number;
-    startY: number;
-    startWidth: number;
-    startHeight: number;
-  } | null>(null);
+  const [windowState, setWindowState] = useState<WindowState>({
+    position: { x: 8, y: 8 },
+    size: { width: 580, height: 420 },
+    isMinimized: false,
+    isFullscreen: false,
+    isVisible: true,
+    zIndex: 1000 + zIndex,
+  });
 
   useEffect(() => {
     if (!activeDetail) {
@@ -1160,63 +1152,16 @@ export const TaskItemDetailFloatingWindow = ({
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, [onClose, open]);
-
   useEffect(() => {
-    if (!open) return;
-    const handleWindowMouseMove = (event: MouseEvent) => {
-      const dragging = dragStateRef.current;
-      const resizing = resizeStateRef.current;
-      if (dragging) {
-        const nextX = dragging.startX + (event.clientX - dragging.startClientX);
-        const nextY = dragging.startY + (event.clientY - dragging.startClientY);
-        setPosition({
-          x: Math.max(0, Math.round(nextX)),
-          y: Math.max(0, Math.round(nextY)),
-        });
-      }
-      if (resizing) {
-        const minWidth = 420;
-        const minHeight = 280;
-        const deltaX = event.clientX - resizing.startClientX;
-        const deltaY = event.clientY - resizing.startClientY;
-        let nextX = resizing.startX;
-        let nextY = resizing.startY;
-        let nextWidth = resizing.startWidth;
-        let nextHeight = resizing.startHeight;
-
-        if (resizing.direction.includes('e')) {
-          nextWidth = Math.max(minWidth, Math.round(resizing.startWidth + deltaX));
-        }
-        if (resizing.direction.includes('s')) {
-          nextHeight = Math.max(minHeight, Math.round(resizing.startHeight + deltaY));
-        }
-        if (resizing.direction.includes('w')) {
-          const candidateWidth = Math.max(minWidth, Math.round(resizing.startWidth - deltaX));
-          nextX = Math.max(0, Math.round(resizing.startX + (resizing.startWidth - candidateWidth)));
-          nextWidth = candidateWidth;
-        }
-        if (resizing.direction.includes('n')) {
-          const candidateHeight = Math.max(minHeight, Math.round(resizing.startHeight - deltaY));
-          nextY = Math.max(0, Math.round(resizing.startY + (resizing.startHeight - candidateHeight)));
-          nextHeight = candidateHeight;
-        }
-
-        setPosition({ x: nextX, y: nextY });
-        setWindowSize({ width: nextWidth, height: nextHeight });
-      }
-    };
-    const handleWindowMouseUp = () => {
-      dragStateRef.current = null;
-      resizeStateRef.current = null;
-      setResizeActive(false);
-    };
-    window.addEventListener('mousemove', handleWindowMouseMove);
-    window.addEventListener('mouseup', handleWindowMouseUp);
-    return () => {
-      window.removeEventListener('mousemove', handleWindowMouseMove);
-      window.removeEventListener('mouseup', handleWindowMouseUp);
-    };
-  }, [open]);
+    setWindowState((prev) => {
+      const nextZIndex = 1000 + zIndex;
+      if (prev.zIndex === nextZIndex) return prev;
+      return {
+        ...prev,
+        zIndex: nextZIndex,
+      };
+    });
+  }, [zIndex]);
 
   const resultColor = useMemo(() => {
     if (!summary) return theme.palette.info.main;
@@ -1287,7 +1232,7 @@ export const TaskItemDetailFloatingWindow = ({
     overlays,
     sizeAccentColor: theme.palette.success.main,
     fetchStageMaxima,
-    previewBoxHeight: Math.max(140, Math.floor(windowSize.height * 0.45)),
+    previewBoxHeight: Math.max(140, Math.floor(windowState.size.height * 0.45)),
     withDownloadButton: true,
     onDownload: handleDownload,
   }) : (
@@ -1307,107 +1252,31 @@ export const TaskItemDetailFloatingWindow = ({
     </Box>
   );
 
+  const handleWindowStateChange = useCallback((nextState: WindowState) => {
+    setWindowState(nextState);
+  }, []);
   if (!open) return null;
   const stageLabel = effectiveStageId === 'fetch'
     ? 'Fetch'
     : (effectiveStageId === 'transform' ? 'Transform' : (effectiveStageId === 'vt' ? 'VT' : effectiveStageId));
   const stageIcon = stageIconMap.get(effectiveStageId) ?? <LayersIcon fontSize="small" />;
-
-  const handleTitleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    dragStateRef.current = {
-      startClientX: event.clientX,
-      startClientY: event.clientY,
-      startX: position.x,
-      startY: position.y,
-    };
-  };
-  const handleResizeMouseDown = (event: React.MouseEvent<HTMLDivElement>, direction: ResizeDirection) => {
-    event.preventDefault();
-    event.stopPropagation();
-    resizeStateRef.current = {
-      direction,
-      startClientX: event.clientX,
-      startClientY: event.clientY,
-      startX: position.x,
-      startY: position.y,
-      startWidth: windowSize.width,
-      startHeight: windowSize.height,
-    };
-    setResizeActive(true);
-  };
+  const windowTitle = `Geometry Preview: ${stageLabel}`;
 
   return (
-    <Paper
-      elevation={8}
-      onMouseDown={() => onRequestBringToFront?.()}
-      sx={{
-        position: 'fixed',
-        top: position.y,
-        left: position.x,
-        zIndex: (zTheme) => zTheme.zIndex.modal + zIndex,
-        background: 'background.paper',
-        border: '1px solid',
-        borderColor: 'divider',
-        width: windowSize.width,
-        minWidth: 420,
-        minHeight: 280,
-        height: windowSize.height,
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-      }}
+    <FloatingWindow
+      title={windowTitle}
+      titleIcon={stageIcon}
+      initialState={windowState}
+      onStateChange={handleWindowStateChange}
+      onClose={onClose}
+      onRequestFocus={onRequestBringToFront}
+      resizable
+      minWidth={420}
+      minHeight={280}
     >
-      <Box
-        onMouseDown={handleTitleMouseDown}
-        sx={{
-          px: 1,
-          py: 0.5,
-          cursor: 'move',
-          userSelect: 'none',
-          borderBottom: '1px solid',
-          borderColor: 'divider',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          bgcolor: 'background.default',
-        }}
-      >
-        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
-          <Box sx={{ display: 'inline-flex', alignItems: 'center', color: 'text.secondary' }}>
-            {stageIcon}
-          </Box>
-          <Typography variant="caption" sx={{ fontWeight: 700 }}>
-            {`Geometry Preview: ${stageLabel}`}
-          </Typography>
-        </Box>
-        <IconButton size="small" aria-label="Close preview" onClick={onClose}>
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </Box>
       <Box sx={{ position: 'relative', flex: 1, minHeight: 0 }}>
         {content}
       </Box>
-      <Box onMouseDown={(event) => handleResizeMouseDown(event, 'e')} sx={{ position: 'absolute', top: 8, bottom: 8, right: -3, width: 8, cursor: 'ew-resize' }} />
-      <Box onMouseDown={(event) => handleResizeMouseDown(event, 'w')} sx={{ position: 'absolute', top: 8, bottom: 8, left: -3, width: 8, cursor: 'ew-resize' }} />
-      <Box onMouseDown={(event) => handleResizeMouseDown(event, 's')} sx={{ position: 'absolute', left: 8, right: 8, bottom: -3, height: 8, cursor: 'ns-resize' }} />
-      <Box onMouseDown={(event) => handleResizeMouseDown(event, 'n')} sx={{ position: 'absolute', left: 8, right: 8, top: -3, height: 8, cursor: 'ns-resize' }} />
-      <Box
-        onMouseDown={(event) => handleResizeMouseDown(event, 'se')}
-        sx={{
-          position: 'absolute',
-          right: -2,
-          bottom: -2,
-          width: 12,
-          height: 12,
-          cursor: 'nwse-resize',
-          background: resizeActive ? 'action.selected' : 'transparent',
-          borderTopLeftRadius: 2,
-        }}
-      />
-      <Box onMouseDown={(event) => handleResizeMouseDown(event, 'sw')} sx={{ position: 'absolute', left: -2, bottom: -2, width: 12, height: 12, cursor: 'nesw-resize' }} />
-      <Box onMouseDown={(event) => handleResizeMouseDown(event, 'ne')} sx={{ position: 'absolute', right: -2, top: -2, width: 12, height: 12, cursor: 'nesw-resize' }} />
-      <Box onMouseDown={(event) => handleResizeMouseDown(event, 'nw')} sx={{ position: 'absolute', left: -2, top: -2, width: 12, height: 12, cursor: 'nwse-resize' }} />
-    </Paper>
+    </FloatingWindow>
   );
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/TaskItemCardListCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/TaskItemCardListCard.tsx
@@ -18,7 +18,7 @@ import {
   buildTransformTaskOutcomeSummary,
 } from '~/ui/components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders';
 import {
-  TaskItemDetailFloatingWindow,
+  TaskItemDetailWindow,
   type TaskDetailSelection,
 } from '~/ui/components/build-progress/TaskItemCard/TaskItemDetailSnackbar';
 
@@ -185,7 +185,7 @@ export const TaskItemCardListCard = forwardRef<HTMLDivElement|null, TaskItemCard
           })}
         </Box>
       )}
-      <TaskItemDetailFloatingWindow
+      <TaskItemDetailWindow
         open={isDetailFloatingWindowOpen}
         detail={selectedDetail ?? hoveredDetail}
         onClose={onCloseDetailFloatingWindow ?? (() => {})}


### PR DESCRIPTION
## Summary
- Replace step5 task detail window frame implementation with `@hierarchidb/ui-floating-window`.
- Remove custom drag/resize frame logic from `TaskItemDetailSnackbar.tsx`.
- Keep existing preview content logic and stage/title behavior.
- Update unit test to close the portal-rendered floating window via title bar controls.

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --only` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` (exit 0)

## Rollback
- Revert this PR commit to restore the previous custom frame implementation.

Refs #615
