### PR TITLE
fix(app): guard build session queue entry updates

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #621 / `codex/fix/app/build-session-queue-update-depth-621` / start: 2026-02-28 17:05 JST
 - #618 / `codex/feat/shape/vt-stage-visualization-and-fixes` / start: 2026-02-28 14:10 JST
 - #615 / `codex/refactor/shape/step5-task-detail-use-shared-floating-window-615` / start: 2026-02-28 13:45 JST
 - #613 / `codex/fix/shape/ingest-main-diff-613` / start: 2026-02-28 12:55 JST
@@ -131,6 +132,7 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- start: 2026-02-28 17:05 JST #621 を起票（https://github.com/kubohiroya/hierarchidb/issues/621）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/app/build-session-queue-update-depth-621` を作成して着手。
 - start: 2026-02-28 14:10 JST #618 を起票（https://github.com/kubohiroya/hierarchidb/issues/618）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/feat/shape/vt-stage-visualization-and-fixes` を作成して着手。
 - start: 2026-02-28 13:45 JST #615 を起票（https://github.com/kubohiroya/hierarchidb/issues/615）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/refactor/shape/step5-task-detail-use-shared-floating-window-615` を `origin/main` 起点で作成して着手。
 - start: 2026-02-28 12:28 JST #611 を起票（https://github.com/kubohiroya/hierarchidb/issues/611）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/build/ts2307-shape-tests-611` を作成し、worktree `/Users/hiroya/WebstormProjects/hierarchidb-codex-611` で着手。

--- a/app/src/components/hooks/useBuildSessionListQueue.ts
+++ b/app/src/components/hooks/useBuildSessionListQueue.ts
@@ -297,10 +297,20 @@ export function useBuildSessionListQueue({
     }) satisfies BuildSessionQueueEntry),
     [rows]
   );
+  const entriesSignature = useMemo(
+    () => rows.map(createQueueRowSignature).join('||'),
+    [rows]
+  );
+  const lastEntriesSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
-    onEntriesChange?.(entries);
-  }, [entries, onEntriesChange]);
+    if (!onEntriesChange) return;
+    if (lastEntriesSignatureRef.current === entriesSignature) {
+      return;
+    }
+    lastEntriesSignatureRef.current = entriesSignature;
+    onEntriesChange(entries);
+  }, [entries, entriesSignature, onEntriesChange]);
 
   const startTopSession = useCallback(async (nodeId: NodeId) => {
     if (autoStartingNodeRef.current === nodeId) {


### PR DESCRIPTION
## Summary\n- guard Build Session queue entry notifications to avoid repeated updates\n- prevent Maximum update depth loop via stable entries signature\n\n## Testing\n- pnpm -w turbo run typecheck --filter @hierarchidb/app (fails: @hierarchidb/plugin-registry/derivations missing)\n\nRefs #621