### PR TITLE
fix(shape): tweak vt fit button position and size

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #628 / `codex/fix/shape/vt-fit-button-tweak-628` / start: 2026-02-28 17:28 JST
 - #623 / `codex/fix/app/plugin-registry-derivations-623` / start: 2026-02-28 17:15 JST
 - #621 / `codex/fix/app/build-session-queue-update-depth-621` / start: 2026-02-28 17:05 JST
 - #618 / `codex/feat/shape/vt-stage-visualization-and-fixes` / start: 2026-02-28 14:10 JST
@@ -134,6 +135,7 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- start: 2026-02-28 17:28 JST #628 を起票（https://github.com/kubohiroya/hierarchidb/issues/628）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape/vt-fit-button-tweak-628` を作成して着手。
 - start: 2026-02-28 17:15 JST #623 を起票（https://github.com/kubohiroya/hierarchidb/issues/623）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/app/plugin-registry-derivations-623` を作成して着手。
 - start: 2026-02-28 17:05 JST #621 を起票（https://github.com/kubohiroya/hierarchidb/issues/621）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/app/build-session-queue-update-depth-621` を作成して着手。
 - start: 2026-02-28 14:10 JST #618 を起票（https://github.com/kubohiroya/hierarchidb/issues/618）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/feat/shape/vt-stage-visualization-and-fixes` を作成して着手。

--- a/plugins/shape-plugin/src/ui/components/build-progress/vt/VtGeometryPreviewMap.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/vt/VtGeometryPreviewMap.tsx
@@ -242,15 +242,15 @@ export const VtGeometryPreviewMap = ({
         onClick={handleFitClick}
         sx={{
           position: 'absolute',
-          top: 62,
-          right: 10,
+          top: 72,
+          right: 20,
           zIndex: 1200,
           bgcolor: 'common.white',
           border: '1px solid',
           borderColor: 'divider',
           boxShadow: 1,
-          width: 20,
-          height: 20,
+          width: 28,
+          height: 28,
           p: 0,
           borderRadius: '4px',
           color: 'grey.600',
@@ -258,7 +258,7 @@ export const VtGeometryPreviewMap = ({
             bgcolor: 'grey.50',
           },
           '& svg': {
-            fontSize: 12,
+            fontSize: 16,
           },
         }}
       >


### PR DESCRIPTION
## Summary\n- move VT Geometry Preview fit button 10px left/down\n- increase fit button size by 8px (with icon scaling)\n\n## Testing\n- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin\n\nRefs #628