### PR TITLE
docs(shape4): define tolerance bisection spec and execution plan

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #675 / `codex/docs/shape4/tolerance-bisection-spec-plan-675` / start: 2026-03-02 10:27 JST
 - #670 / `codex/fix/shape/step5-elapsed-time-consistency-670` / start: 2026-03-02 01:02 JST
 - #668 / `codex/fix/shape/step5-build-control-card-header-menu-668` / start: 2026-03-02 00:40 JST
 - #663 / `codex/fix/shape/tileemit-default-extent-buffer-663` / start: 2026-03-01 16:22 JST
@@ -150,6 +151,8 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- update: 2026-03-02 10:40 JST #675 Shape4 Geometry tolerance 新方式の文書化を実施。`docs/spec/shape4-geometry-tolerance-bisection-spec.md` に仕様（`t_base` 2分法、`multiplier/minRatio/maxRatio`、ToneCurveEditor 3線化、失敗時挙動、段階移行）を記載し、`plans/shape4-geometry-tolerance-bisection-execplan.md` に実装マイルストーンと検証手順を定義。確認: `test -f docs/spec/shape4-geometry-tolerance-bisection-spec.md` exit 0、`test -f plans/shape4-geometry-tolerance-bisection-execplan.md` exit 0、`rg -n \"t_base|2分法|multiplier|minRatio|maxRatio|ToneCurveEditor|0.0..2.0|6553\" docs/spec/shape4-geometry-tolerance-bisection-spec.md plans/shape4-geometry-tolerance-bisection-execplan.md` exit 0。
+- start: 2026-03-02 10:27 JST #675 を起票（https://github.com/kubohiroya/hierarchidb/issues/675）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/docs/shape4/tolerance-bisection-spec-plan-675` を作成し、Shape4 の tolerance 新方式（`t_base` 2分法 + `multiplier/min/max`）仕様/作業計画ドキュメント整備に着手。
 - update: 2026-03-02 01:09 JST #670 実行中ステージ elapsed が停止する原因は stage map への live elapsed 合成不足と total elapsed の `max(stageSum, sessionElapsed)` 算出にあった。`useShapeBuildStepProgressState` で live 値を stage map に反映し、実行中 total elapsed を stage 合算へ統一。`useShapeBuildProgressPanelControllerBaseStateDataCore` で実行中ステージの表示に `summary.stageElapsedMs` を使用。検証: `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts` すべて exit 0。参考として `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` は既存失敗5件で exit 1（本件外）。
 - start: 2026-03-02 01:02 JST #670 を起票（https://github.com/kubohiroya/hierarchidb/issues/670）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape/step5-elapsed-time-consistency-670` を `main` 起点で作成し、Step5 のステージ経過時間停止・`-` 表示崩れ・BuildControl 合計時間不整合の修正に着手。
 - update: 2026-03-02 00:57 JST #668 追加要件対応として Build Control Card 内の「アイコン Build Controls ▼」を撤去し、同じメニュー機能を含む「アイコン Build Session ▼」をカード左脇（カード外）へ移設。原因は Build Session 操作ヘッダをカード内に混在させていたため視覚構造が不明瞭だったこと。発生範囲は `packages/components/src/BuildControlCard.tsx`（ヘッダ/メニュー撤去）、`packages/components/src/BuildStepPanel.tsx`（左脇 Build Session ヘッダ＋メニュー新設）、`plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelViewModel.ts`（ラベル `Build Session` へ更新）、`plugins/shape-plugin/src/ui/__tests__/components/build-progress/ShapeBuildProgressPanel.unit.test.tsx`（表示文言更新）。検証: `pnpm -w turbo run typecheck --filter @hierarchidb/components --filter @hierarchidb/shape-plugin` exit 0、`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/ShapeBuildProgressPanel.unit.test.tsx` exit 0。

--- a/docs/spec/shape4-geometry-tolerance-bisection-spec.md
+++ b/docs/spec/shape4-geometry-tolerance-bisection-spec.md
@@ -1,0 +1,178 @@
+# Shape4 Geometry Tolerance 新方式仕様（t_base 2分法 + multiplier/min/max）
+
+## 目的
+
+Shape4 の Geometry ステージで、従来の「tolerance を増分で段階的に上げる再試行」を置き換える。新方式は Source ステージで既に保持している頂点統計を利用し、`turf.simplify` の基準 tolerance（`t_base`）を 2 分法で求める。これにより、巨大国と小国の複雑性差を吸収しつつ、頂点上限（`6553`）を満たすための試行回数を削減する。
+
+## 背景と課題
+
+現行方式は `retryToleranceByBand` と `retryCount` に依存し、オーバーしたフィーチャーごとに tolerance を増やしながら再簡略化する。これは次の課題を持つ。
+
+- 元ポリゴン複雑性が極端に異なるデータセットで、必要試行回数が読みにくい。
+- 「どの tolerance を目標にするか」が事前に定義されず、失敗条件が相対的になりやすい。
+- UI 設定が「初期値・増分・回数」に分かれており、調整意図が読み取りづらい。
+
+## 適用対象
+
+- 対象ステージ: Shape4 Geometry（`createTransformByBandHandler` 経路）
+- 対象アルゴリズム: `turf.simplify` を使う geojson simplify 系処理
+- 頂点制約: 1 フィーチャーあたり `6553` 以下（現行制約を維持）
+
+## 用語定義
+
+- `vertexLimit`: システム上限頂点数。既定 `6553`。
+- `maxSourcePolygonVertices`: Source ステージ統計から得る「1 ポリゴン頂点数最大値」。
+- `t_base`: 最大頂点ポリゴンを `vertexLimit` 以下にする最小 tolerance。
+- `multiplier`: `t_base` に掛ける係数（中心値）。
+- `minRatio` / `maxRatio`: `t_base` 比の下限・上限。
+- `t_final`: 実際に簡略化へ渡す tolerance。
+
+## 方式概要
+
+1. Source ステージ統計（sessions 保存済み）から、最大頂点ポリゴンを代表サンプルとして選ぶ。  
+2. 代表サンプルに対して `turf.simplify` を適用し、`maxVertices <= 6553` を満たす最小 tolerance を 2 分法で探索する。  
+3. 得られた `t_base` を基準に、自治体レベル × ズームの設定 `multiplier/minRatio/maxRatio` を適用する。  
+4. 各フィーチャーの複雑性に応じて `t_base` より小さい初期推定値を生成し、必要な場合のみ少回数の補正探索を行う。  
+
+## 2 分法探索仕様
+
+### 入力
+
+- `polygon`: 最大頂点ポリゴン（Source 統計で選定）
+- `vertexLimit`: 6553
+- `toleranceLow`: 0
+- `toleranceHigh`: 初期上限（推奨 `t_baseUpperStart = 1.0`）
+- `eps`: 収束閾値（推奨 `1e-7`）
+- `maxIterations`: 反復上限（推奨 24）
+
+### 上限拡張
+
+`toleranceHigh` で条件を満たさない場合は、`toleranceHigh *= 2` で段階拡張する。上限 `toleranceHighCap`（推奨 12.0）に達しても満たせない場合は探索失敗とし、従来失敗ハンドリングへ移行する。
+
+### 判定関数
+
+`f(t) = simplify(polygon, t).vertexCount - vertexLimit`
+
+- `f(t) <= 0` なら条件達成
+- `f(t) > 0` なら未達
+
+### 収束
+
+- ループごとに `mid = (low + high) / 2` を評価
+- `f(mid) <= 0` なら `high = mid`
+- `f(mid) > 0` なら `low = mid`
+- `|high - low| < eps` または `iteration == maxIterations` で終了
+- 終了値 `t_base = high`
+
+## tolerance 決定式
+
+### 正規化レンジ
+
+`multiplier`, `minRatio`, `maxRatio` はすべて `0.0..2.0` の範囲で定義する。
+
+### 制約
+
+- `0.0 <= minRatio <= maxRatio <= 2.0`
+- `multiplier` も `0.0..2.0` にクランプ
+
+### 実効値
+
+`candidate = t_base * multiplier`  
+`t_final = clamp(candidate, t_base * minRatio, t_base * maxRatio)`
+
+## 複雑性ベース初期推定（後段最適化）
+
+各フィーチャーの頂点数 `v` と、代表サンプル頂点数 `v_max` から比率を作る。
+
+- `r = clamp(log(v) / log(v_max), 0, 1)`
+- `t_est = t_base * (r ^ gamma)`（推奨 `gamma=1.4` 初期）
+
+`r` が小さい（小規模形状）ほど低い tolerance で開始し、上限超過時のみ少回数の補正探索を行う。
+
+## 設定モデル（新旧）
+
+### 新モデル（主系）
+
+- `simplifyToleranceByAdminLevel.<admin>.multiplierByBand[]`
+- `simplifyToleranceByAdminLevel.<admin>.minRatioByBand[]`
+- `simplifyToleranceByAdminLevel.<admin>.maxRatioByBand[]`
+- `simplifyToleranceByAdminLevel.<admin>.usePrevious`
+- `geometryConfig.toleranceSearchMaxIterations`（全体共通）
+
+### 旧モデル（移行期間）
+
+- `toleranceByBand`
+- `retryToleranceByBand`
+- `retryCount`
+
+旧モデルは読み取り互換のみ残し、内部評価は新モデル優先とする。互換期間終了後に削除する。
+
+## UI 仕様（ToneCurveEditor）
+
+- 線 1（青実線）: `multiplier`
+- 線 2（灰点線）: `minRatio`
+- 線 3（赤点線）: `maxRatio`
+
+UI ルール:
+
+- 値域は `0.0..2.0` 固定
+- 常に `minRatio <= multiplier <= maxRatio` を維持（ドラッグ時自動クランプ）
+- Admin0 変更は既存仕様どおりベース `geometryConfig` へ同期
+- 旧設定読み込み時は `multiplier` へ寄せ、`minRatio/maxRatio` は安全デフォルトで補完
+
+## デフォルト値方針
+
+初期デフォルト（共通）:
+
+- `multiplier = 1.0`
+- `minRatio = 0.0`
+- `maxRatio = 2.0`
+- `toleranceSearchMaxIterations = 24`
+
+運用初期はズーム帯で `multiplier` のみ段階補正し、`min/max` は安全ガードとして広めに維持する。
+
+## 失敗時挙動
+
+次の場合は `geometry failed` を返す。
+
+- `t_base` 探索で上限拡張後も `vertexLimit` を満たせない
+- 補正探索の上限反復で `vertexLimit` 未達
+- simplify 処理自体が例外終了
+
+エラーメッセージには最低限以下を含める。
+
+- `vertexLimit`
+- `baseTolerance`（`t_base`）
+- `finalTolerance`
+- `attempts`
+- `maxVertices`
+
+## 観測性（ログ・メタデータ）
+
+Geometry 結果メタデータに次を保存する。
+
+- `baseTolerance`
+- `effectiveTolerance`
+- `multiplier/minRatio/maxRatio`
+- `vertexLimit`
+- `searchIterations`
+- `searchOutcome`（`converged` / `failed`）
+
+## 段階移行方針
+
+1. 新方式を feature toggle（既定 ON/OFF は Issue で明示）で導入  
+2. 旧設定を読み取り互換で保持しつつ UI では `deprecated` 表示  
+3. 安定確認後、旧 `retryToleranceByBand/retryCount` を撤去  
+4. 互換削除時に migration note を残す  
+
+## 受け入れ基準（仕様レベル）
+
+- `t_base` の探索手順と停止条件が明文化されている。
+- `multiplier/minRatio/maxRatio` の定義と計算式が一意である。
+- ToneCurveEditor の 3 線 UI 仕様と制約が定義されている。
+- 旧方式からの移行・ロールバック方針が記載されている。
+
+## 非目標
+
+- 本仕様書では実装コード変更を行わない。
+- 本仕様書では DB マイグレーション実装詳細を固定しない（実装計画で確定）。

--- a/plans/shape4-geometry-tolerance-bisection-execplan.md
+++ b/plans/shape4-geometry-tolerance-bisection-execplan.md
@@ -1,0 +1,141 @@
+# Shape4 Geometry tolerance 再設計を `t_base` 基準へ移行する
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+`PLANS.md` はリポジトリルートに存在し、本計画はその要件に従って維持する。
+
+## Purpose / Big Picture
+
+この変更が完了すると、Shape4 Geometry の頂点上限対策は「増分再試行中心」から「`t_base`（2分法探索）中心」に変わる。利用者は自治体レベルとズームレベルごとに `multiplier/min/max` を調整するだけで、データ複雑性に応じた tolerance が自動推定される。巨大国と小国が混在するケースでも、失敗までの試行回数を減らしつつ `6553` 上限を満たしやすくなる。動作確認は、同一データセットで新旧方式の試行回数・失敗率・最終頂点数を比較して行う。
+
+## Progress
+
+- [x] (2026-03-02 10:40 JST) 新方式仕様書 `docs/spec/shape4-geometry-tolerance-bisection-spec.md` を作成し、アルゴリズム・UI・移行方針を固定した。
+- [ ] 既存実装の責務分解（profile 解決、retry 実行、UI 設定保存）を整理し、置換順を確定する。
+- [ ] `simplifyProfile` と geometry 設定型に `multiplier/minRatio/maxRatio` を追加し、互換読込を実装する。
+- [ ] `createTransformByBandHandler` の retry 方式を `t_base` 探索 + 少回数補正へ置換する。
+- [ ] ToneCurveEditor を 3 線（青=multiplier、灰=min、赤=max）へ変更し、`0.0..2.0` 制約を実装する。
+- [ ] 新旧比較テスト（unit + integration）を追加し、試行回数削減と頂点上限遵守を検証する。
+- [ ] 旧 `retryToleranceByBand/retryCount` の deprecate 手順を適用し、撤去条件を満たしたら削除する。
+
+## Surprises & Discoveries
+
+- Observation: 現行の頂点上限失敗は `retryToleranceSecond` からの指数増加でフィーチャー単位に進むため、データ分布が偏ると試行回数が急増しやすい。
+  Evidence: `packages/vt-orchestrator/src/transform/createTransformByBandHandler/transformByBandRetrySimplify.ts` の `nextToleranceValue` 計算と `execute.ts` の feature ループ。
+
+- Observation: UI 設定は既に admin level 単位のタブ構造と `ToneCurveEditor` を持っており、パラメータ意味を差し替えるだけで 3 線化できる。
+  Evidence: `plugins/shape-plugin/src/ui/components/build-config/SimplifyToleranceByAdminLevelCard.tsx` が `toleranceByBand` と `retryToleranceByBand` の 2 系列を同時編集している。
+
+## Decision Log
+
+- Decision: `t_base` は Source 統計の最大頂点ポリゴンを代表サンプルにして 2 分法で算出する。
+  Rationale: 「最悪ケースを先に抑える」ことで上限超過の再試行を大幅に減らせるため。
+  Date/Author: 2026-03-02 / Codex
+
+- Decision: 新 UI は `multiplier/minRatio/maxRatio` の 3 線で統一し、値域を `0.0..2.0` に固定する。
+  Rationale: 旧「初期値・増分・回数」より意味が明確で、`t_final = clamp(t_base * multiplier, t_base * min, t_base * max)` を直接表現できるため。
+  Date/Author: 2026-03-02 / Codex
+
+- Decision: 旧設定は即時削除せず、互換読込を経て段階撤去する。
+  Rationale: 既存保存データとの互換性と運用リスクを確保するため。
+  Date/Author: 2026-03-02 / Codex
+
+## Outcomes & Retrospective
+
+- 2026-03-02 時点では設計・計画段階。実装は未着手。
+- 今回の成果は、実装時に迷いが出やすい「探索式」「UI 意味」「互換方針」を先に固定した点。
+- 次の節目は Milestone 1（設定型と profile 解決の実装）完了時に更新する。
+
+## Context and Orientation
+
+現行の Geometry tolerance 処理は `packages/vt-orchestrator/src/transform/createTransformByBandHandler/execute.ts` を中心に構成される。admin level ごとの tolerance 設定は `helpers/simplifyProfile.ts` が解決し、フィーチャーごとの頂点超過時は `transformByBandRetrySimplify.ts` で再簡略化を繰り返す。UI は `plugins/shape-plugin/src/ui/components/build-config/SimplifyToleranceByAdminLevelCard.tsx` で `ToneCurveEditor` を使い、実質 2 系列（通常 tolerance と retry tolerance）を編集する。
+
+本計画でいう `t_base` は「最大頂点ポリゴンを 6553 以下にする最小 tolerance」を意味する。`multiplier/minRatio/maxRatio` は `t_base` 比の調整値で、最終 tolerance は `clamp` で決定する。ここでの `clamp` は「下限未満なら下限へ、上限超過なら上限へ丸める」処理を指す。
+
+## Plan of Work
+
+最初に設定モデルを更新する。`simplifyProfile` と関連型へ `multiplierByBand/minRatioByBand/maxRatioByBand` を追加し、既存 `toleranceByBand/retryToleranceByBand/retryCount` は互換入力としてのみ扱う。次に Geometry 実行系を置換し、最大頂点ポリゴンから `t_base` を2分法で求める処理を追加する。`t_base` はバンド単位の基準として計算し、個別フィーチャーには複雑性ベース初期推定から少回数補正をかける。
+
+続いて UI を更新し、ToneCurveEditor を 3 線構成へ変更する。ドラッグ制約として `min <= multiplier <= max` と `0.0..2.0` を常時維持する。最後にテストを拡充し、新旧比較で「上限達成率」「試行回数」「失敗時メッセージ」を検証する。互換期間中は旧項目を読み取り可能に保ち、設定保存は新形式を優先する。
+
+## Milestones
+
+### Milestone 1: 設定契約の再定義
+
+`packages/gis-sdk` と `packages/vt-orchestrator` の設定型を更新し、`multiplier/minRatio/maxRatio` を正式項目にする。完了時点で、既存設定を読み込んでもクラッシュせず、新形式へ正規化できる状態にする。
+
+### Milestone 2: `t_base` 探索と Geometry 実行置換
+
+`execute.ts` の頂点超過ハンドリングを再構成し、2 分法探索で求めた `t_base` を基準に処理する。完了時点で、指数的再試行依存を外し、ログへ `baseTolerance` と探索反復情報が残るようにする。
+
+### Milestone 3: ToneCurveEditor 3 線化
+
+`SimplifyToleranceByAdminLevelCard.tsx` を 3 系列編集へ置換し、既存 2 系列 UI を廃止する。完了時点で admin×zoom の調整が `multiplier/min/max` で一貫し、保存データが新形式に統一される。
+
+### Milestone 4: 検証・互換・撤去
+
+新旧比較テストを通して品質と性能を確認し、Issue に結果を記録する。条件が満たされ次第、`retryToleranceByBand/retryCount` を最終撤去する。
+
+## Concrete Steps
+
+作業ディレクトリ: `/Users/hiroya/WebstormProjects/hierarchidb`
+
+1. 既存コード調査
+   - `rg -n "retryToleranceByBand|retryCount|MAX_RETRY_ATTEMPTS|DEFAULT_RETRY_VERTEX_LIMIT" packages/vt-orchestrator/src plugins/shape-plugin/src`
+
+2. 設定型の更新と互換正規化
+   - 変更対象:
+     - `packages/vt-orchestrator/src/transform/createTransformByBandHandler/helpers/simplifyProfile.ts`
+     - `packages/vt-orchestrator/src/types/_BuildConfig.ts`
+     - `plugins/shape-plugin/src/common/types/build.ts`（必要時）
+
+3. `t_base` 探索の実装
+   - 変更対象:
+     - `packages/vt-orchestrator/src/transform/createTransformByBandHandler/execute.ts`
+     - 必要なら `helpers/` へ `bisectionTolerance.ts` 追加
+
+4. UI 3 線化
+   - 変更対象:
+     - `plugins/shape-plugin/src/ui/components/build-config/SimplifyToleranceByAdminLevelCard.tsx`
+     - `plugins/shape-plugin/src/ui/locales/{ja,en}.json`
+
+5. テスト追加
+   - 変更対象候補:
+     - `packages/vt-orchestrator/src/transform/__tests__/...`
+     - `plugins/shape-plugin/src/ui/__tests__/...`
+
+6. 検証
+   - `pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin`
+   - `pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin`
+   - `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin`
+
+## Validation and Acceptance
+
+受け入れは次の観測で判断する。
+
+- 同じ入力データで、旧方式より平均試行回数が減少する。
+- 失敗ケースでもエラーに `baseTolerance/finalTolerance/vertexLimit` が含まれる。
+- UI が 3 線表示になり、`min <= multiplier <= max` 制約が常時成立する。
+- 既存保存データを読み込んでも設定画面が壊れず、新形式へ保存し直せる。
+
+## Idempotence and Recovery
+
+この移行は段階適用する。各マイルストーンごとにコミットし、問題があれば直前コミットへ revert して旧方式に戻せる。互換期間は旧設定の読み取りを維持するため、途中で再実行してもデータ破壊は発生しない。重大障害時は新方式の feature toggle を OFF にして即時切戻し可能な状態を維持する。
+
+## Artifacts and Notes
+
+実装時には Issue #675 に以下を記録する。
+
+- 新旧比較の試行回数・失敗率サマリ
+- `pnpm` 検証コマンドの exit code
+- 互換期間中に残す項目と削除予定時期
+
+## Interfaces and Dependencies
+
+主要依存は既存の `@hierarchidb/vt-orchestrator`, `@hierarchidb/gis-sdk`, `@hierarchidb/ui-tone-curve-editor` で、新規外部ライブラリは追加しない。最終的に必要なインターフェースは次の通り。
+
+- `resolveSimplifyToleranceProfile(...)` が `multiplier/minRatio/maxRatio` を返せること。
+- Geometry 実行が `t_base` 探索結果を受け取り、`t_final` を算出できること。
+- UI から admin×zoom ごとの 3 系列を保存・復元できること。
+
+Change log: 2026-03-02 初版作成。新方式仕様と実装順を固定するために追加。


### PR DESCRIPTION
## Summary
- add Shape4 Geometry tolerance redesign spec (`t_base` bisection + `multiplier/minRatio/maxRatio`)
- add implementation ExecPlan with milestones and validation path
- update TASKS hub (`Doing` + operations log) for issue #675

## Verification
- `test -f docs/spec/shape4-geometry-tolerance-bisection-spec.md`
- `test -f plans/shape4-geometry-tolerance-bisection-execplan.md`
- `rg -n "t_base|2分法|multiplier|minRatio|maxRatio|ToneCurveEditor|0.0..2.0|6553" docs/spec/shape4-geometry-tolerance-bisection-spec.md plans/shape4-geometry-tolerance-bisection-execplan.md`

Refs #675
