### PR TITLE
feat(shape): implement tolerance bisection pipeline

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,7 +38,7 @@
 ## Kanban
 
 ### Doing
-- #677 / `codex/docs/shape/step4-invalid-geometry-tileemit-warning-spec-677` / start: 2026-03-02 10:44 JST
+- #677 / `codex/feat/shape/tolerance-bisection-pipeline-677` / start: 2026-03-02 11:03 JST
 - #675 / `codex/docs/shape4/tolerance-bisection-spec-plan-675` / start: 2026-03-02 10:27 JST
 - #670 / `codex/fix/shape/step5-elapsed-time-consistency-670` / start: 2026-03-02 01:02 JST
 - #668 / `codex/fix/shape/step5-build-control-card-header-menu-668` / start: 2026-03-02 00:40 JST
@@ -152,7 +152,7 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
-- start: 2026-03-02 10:44 JST #677 を起票（https://github.com/kubohiroya/hierarchidb/issues/677）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/docs/shape/step4-invalid-geometry-tileemit-warning-spec-677` を作成して、Step4 Invalid geometry filtering の TileEmit 移設仕様と作業計画の文書化に着手。
+- start: 2026-03-02 11:03 JST #677 を再オープンし実装タスクへ再定義（https://github.com/kubohiroya/hierarchidb/issues/677）。Project `hierarchidb` の Status を `In Progress` に更新し、ブランチ `codex/feat/shape/tolerance-bisection-pipeline-677` を作成。#675（仕様/計画）は main 反映済みのため close し、#675→#677 の順で Shape ビルドパイプライン改修を一体運用で開始。
 - update: 2026-03-02 10:40 JST #675 Shape4 Geometry tolerance 新方式の文書化を実施。`docs/spec/shape4-geometry-tolerance-bisection-spec.md` に仕様（`t_base` 2分法、`multiplier/minRatio/maxRatio`、ToneCurveEditor 3線化、失敗時挙動、段階移行）を記載し、`plans/shape4-geometry-tolerance-bisection-execplan.md` に実装マイルストーンと検証手順を定義。確認: `test -f docs/spec/shape4-geometry-tolerance-bisection-spec.md` exit 0、`test -f plans/shape4-geometry-tolerance-bisection-execplan.md` exit 0、`rg -n \"t_base|2分法|multiplier|minRatio|maxRatio|ToneCurveEditor|0.0..2.0|6553\" docs/spec/shape4-geometry-tolerance-bisection-spec.md plans/shape4-geometry-tolerance-bisection-execplan.md` exit 0。
 - start: 2026-03-02 10:27 JST #675 を起票（https://github.com/kubohiroya/hierarchidb/issues/675）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/docs/shape4/tolerance-bisection-spec-plan-675` を作成し、Shape4 の tolerance 新方式（`t_base` 2分法 + `multiplier/min/max`）仕様/作業計画ドキュメント整備に着手。
 - update: 2026-03-02 01:09 JST #670 実行中ステージ elapsed が停止する原因は stage map への live elapsed 合成不足と total elapsed の `max(stageSum, sessionElapsed)` 算出にあった。`useShapeBuildStepProgressState` で live 値を stage map に反映し、実行中 total elapsed を stage 合算へ統一。`useShapeBuildProgressPanelControllerBaseStateDataCore` で実行中ステージの表示に `summary.stageElapsedMs` を使用。検証: `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/hooks/unit/useShapeBuildStep.elapsed.unit.test.ts` すべて exit 0。参考として `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` は既存失敗5件で exit 1（本件外）。

--- a/packages/gis-sdk/src/config.ts
+++ b/packages/gis-sdk/src/config.ts
@@ -121,9 +121,10 @@ export type SimplifyToleranceAdminLevelKey = 'admin0' | 'admin1' | 'admin2' | 'a
 
 export interface GeometrySimplifyAdminLevelProfile {
   usePrevious?: boolean;
-  toleranceByBand?: number[];
-  retryToleranceByBand?: number[];
-  retryCount?: number;
+  multiplierByBand?: number[];
+  minRatioByBand?: number[];
+  maxRatioByBand?: number[];
+  toleranceSearchMaxIterations?: number;
 }
 
 export type GeometrySimplifyToleranceByAdminLevelConfig = Record<
@@ -148,6 +149,10 @@ export interface GeometryConfig {
   toleranceByBand: number[];
   retryCount?: number;
   retryToleranceByBand?: number[];
+  toleranceMultiplierByBand?: number[];
+  toleranceMinRatioByBand?: number[];
+  toleranceMaxRatioByBand?: number[];
+  toleranceSearchMaxIterations?: number;
   simplifyToleranceByAdminLevel?: GeometrySimplifyToleranceByAdminLevelConfig;
   retryToleranceStep?: number;
   quantize?: number;

--- a/packages/shape-api/src/defaults.ts
+++ b/packages/shape-api/src/defaults.ts
@@ -3,6 +3,10 @@ import { DEFAULT_ZOOM_BAND_BOUNDARIES } from '@hierarchidb/util';
 const DEFAULT_TRANSFORM_TOLERANCE_BY_BAND = [0.1, 0.1, 0.1, 0.1];
 const DEFAULT_RETRY_TOLERANCE_BY_BAND = [3.5, 2.5, 1.5, 1];
 const DEFAULT_SIMPLIFY_RETRY_COUNT = 4;
+const DEFAULT_TOLERANCE_MULTIPLIER_BY_BAND = [1, 1, 1, 1];
+const DEFAULT_TOLERANCE_MIN_RATIO_BY_BAND = [0, 0, 0, 0];
+const DEFAULT_TOLERANCE_MAX_RATIO_BY_BAND = [2, 2, 2, 2];
+const DEFAULT_TOLERANCE_SEARCH_MAX_ITERATIONS = 24;
 
 export const DEFAULT_BUILD_CONFIG = {
   dataSourceName: 'geoboundaries',
@@ -46,30 +50,38 @@ export const DEFAULT_BUILD_CONFIG = {
     toleranceByBand: DEFAULT_TRANSFORM_TOLERANCE_BY_BAND,
     retryCount: DEFAULT_SIMPLIFY_RETRY_COUNT,
     retryToleranceByBand: DEFAULT_RETRY_TOLERANCE_BY_BAND,
+    toleranceMultiplierByBand: DEFAULT_TOLERANCE_MULTIPLIER_BY_BAND,
+    toleranceMinRatioByBand: DEFAULT_TOLERANCE_MIN_RATIO_BY_BAND,
+    toleranceMaxRatioByBand: DEFAULT_TOLERANCE_MAX_RATIO_BY_BAND,
+    toleranceSearchMaxIterations: DEFAULT_TOLERANCE_SEARCH_MAX_ITERATIONS,
     simplifyToleranceByAdminLevel: {
       admin0: {
         usePrevious: false,
-        toleranceByBand: DEFAULT_TRANSFORM_TOLERANCE_BY_BAND,
-        retryToleranceByBand: DEFAULT_RETRY_TOLERANCE_BY_BAND,
-        retryCount: DEFAULT_SIMPLIFY_RETRY_COUNT,
+        multiplierByBand: DEFAULT_TOLERANCE_MULTIPLIER_BY_BAND,
+        minRatioByBand: DEFAULT_TOLERANCE_MIN_RATIO_BY_BAND,
+        maxRatioByBand: DEFAULT_TOLERANCE_MAX_RATIO_BY_BAND,
+        toleranceSearchMaxIterations: DEFAULT_TOLERANCE_SEARCH_MAX_ITERATIONS,
       },
       admin1: {
         usePrevious: true,
-        toleranceByBand: DEFAULT_TRANSFORM_TOLERANCE_BY_BAND,
-        retryToleranceByBand: DEFAULT_RETRY_TOLERANCE_BY_BAND,
-        retryCount: DEFAULT_SIMPLIFY_RETRY_COUNT,
+        multiplierByBand: DEFAULT_TOLERANCE_MULTIPLIER_BY_BAND,
+        minRatioByBand: DEFAULT_TOLERANCE_MIN_RATIO_BY_BAND,
+        maxRatioByBand: DEFAULT_TOLERANCE_MAX_RATIO_BY_BAND,
+        toleranceSearchMaxIterations: DEFAULT_TOLERANCE_SEARCH_MAX_ITERATIONS,
       },
       admin2: {
         usePrevious: true,
-        toleranceByBand: DEFAULT_TRANSFORM_TOLERANCE_BY_BAND,
-        retryToleranceByBand: DEFAULT_RETRY_TOLERANCE_BY_BAND,
-        retryCount: DEFAULT_SIMPLIFY_RETRY_COUNT,
+        multiplierByBand: DEFAULT_TOLERANCE_MULTIPLIER_BY_BAND,
+        minRatioByBand: DEFAULT_TOLERANCE_MIN_RATIO_BY_BAND,
+        maxRatioByBand: DEFAULT_TOLERANCE_MAX_RATIO_BY_BAND,
+        toleranceSearchMaxIterations: DEFAULT_TOLERANCE_SEARCH_MAX_ITERATIONS,
       },
       admin3Plus: {
         usePrevious: true,
-        toleranceByBand: DEFAULT_TRANSFORM_TOLERANCE_BY_BAND,
-        retryToleranceByBand: DEFAULT_RETRY_TOLERANCE_BY_BAND,
-        retryCount: DEFAULT_SIMPLIFY_RETRY_COUNT,
+        multiplierByBand: DEFAULT_TOLERANCE_MULTIPLIER_BY_BAND,
+        minRatioByBand: DEFAULT_TOLERANCE_MIN_RATIO_BY_BAND,
+        maxRatioByBand: DEFAULT_TOLERANCE_MAX_RATIO_BY_BAND,
+        toleranceSearchMaxIterations: DEFAULT_TOLERANCE_SEARCH_MAX_ITERATIONS,
       },
     },
     retryToleranceStep: 0.02,

--- a/packages/vt-orchestrator/src/transform/__tests__/simplifyProfile.unit.test.ts
+++ b/packages/vt-orchestrator/src/transform/__tests__/simplifyProfile.unit.test.ts
@@ -22,9 +22,10 @@ const createBaseTransformConfig = (): GeometryConfig => ({
     elongatedShapeCorrectionFactor: 1.3,
   },
   deleteOnComplete: false,
-  toleranceByBand: [0.1, 0.2],
-  retryCount: 4,
-  retryToleranceByBand: [3, 2],
+  toleranceMultiplierByBand: [1, 1],
+  toleranceMinRatioByBand: [0, 0],
+  toleranceMaxRatioByBand: [2, 2],
+  toleranceSearchMaxIterations: 24,
   areaThreshold: 1,
   excludePolygonAreaCoefficient: 1,
   omitDetailsConfig: {
@@ -40,22 +41,23 @@ describe('resolveSimplifyToleranceProfile', () => {
 
     const profile = resolveSimplifyToleranceProfile(config, 2);
 
-    expect(profile.toleranceByBand).toEqual([0.1, 0.2]);
-    expect(profile.retryToleranceByBand).toEqual([3, 2]);
-    expect(profile.retryCount).toBe(4);
+    expect(profile.multiplierByBand).toEqual([1, 1]);
+    expect(profile.minRatioByBand).toEqual([0, 0]);
+    expect(profile.maxRatioByBand).toEqual([2, 2]);
+    expect(profile.toleranceSearchMaxIterations).toBe(24);
   });
 
   it('resolves admin 1 from admin0 when usePrevious is enabled', () => {
     const config = createBaseTransformConfig();
     config.simplifyToleranceByAdminLevel = {
       admin0: {
-        toleranceByBand: [0.25, 0.35],
-        retryToleranceByBand: [2.5, 2],
-        retryCount: 5,
+        multiplierByBand: [0.9, 1.1],
+        minRatioByBand: [0.2, 0.3],
+        maxRatioByBand: [1.6, 1.7],
+        toleranceSearchMaxIterations: 30,
       },
       admin1: {
         usePrevious: true,
-        toleranceByBand: [0.9, 0.9],
       },
       admin2: {
         usePrevious: true,
@@ -67,25 +69,24 @@ describe('resolveSimplifyToleranceProfile', () => {
 
     const profile = resolveSimplifyToleranceProfile(config, 1);
 
-    expect(profile.toleranceByBand).toEqual([0.25, 0.35]);
-    expect(profile.retryToleranceByBand).toEqual([2.5, 2]);
-    expect(profile.retryCount).toBe(5);
+    expect(profile.multiplierByBand).toEqual([0.9, 1.1]);
+    expect(profile.minRatioByBand).toEqual([0.2, 0.3]);
+    expect(profile.maxRatioByBand).toEqual([1.6, 1.7]);
+    expect(profile.toleranceSearchMaxIterations).toBe(30);
   });
 
   it('uses dedicated admin 2 profile when usePrevious is disabled', () => {
     const config = createBaseTransformConfig();
     config.simplifyToleranceByAdminLevel = {
-      admin0: {
-        toleranceByBand: [0.11, 0.21],
-      },
+      admin0: {},
       admin1: {
         usePrevious: true,
       },
       admin2: {
         usePrevious: false,
-        toleranceByBand: [0.31, 0.41],
-        retryToleranceByBand: [1.9, 1.7],
-        retryCount: 2,
+        multiplierByBand: [0.8, 0.7],
+        minRatioByBand: [0.1, 0.1],
+        maxRatioByBand: [1.4, 1.3],
       },
       admin3Plus: {
         usePrevious: true,
@@ -94,36 +95,33 @@ describe('resolveSimplifyToleranceProfile', () => {
 
     const profile = resolveSimplifyToleranceProfile(config, 2);
 
-    expect(profile.toleranceByBand).toEqual([0.31, 0.41]);
-    expect(profile.retryToleranceByBand).toEqual([1.9, 1.7]);
-    expect(profile.retryCount).toBe(2);
+    expect(profile.multiplierByBand).toEqual([0.8, 0.7]);
+    expect(profile.minRatioByBand).toEqual([0.1, 0.1]);
+    expect(profile.maxRatioByBand).toEqual([1.4, 1.3]);
   });
 
   it('maps admin level 3+ to admin3Plus profile', () => {
     const config = createBaseTransformConfig();
     config.simplifyToleranceByAdminLevel = {
-      admin0: {
-        toleranceByBand: [0.15, 0.25],
-      },
+      admin0: {},
       admin1: {
         usePrevious: true,
       },
       admin2: {
         usePrevious: false,
-        toleranceByBand: [0.35, 0.45],
       },
       admin3Plus: {
         usePrevious: false,
-        toleranceByBand: [0.55, 0.65],
-        retryToleranceByBand: [1.5, 1.4],
-        retryCount: 1,
+        multiplierByBand: [1.2, 1.1],
+        minRatioByBand: [0.4, 0.35],
+        maxRatioByBand: [1.9, 1.8],
       },
     };
 
     const profile = resolveSimplifyToleranceProfile(config, 5);
 
-    expect(profile.toleranceByBand).toEqual([0.55, 0.65]);
-    expect(profile.retryToleranceByBand).toEqual([1.5, 1.4]);
-    expect(profile.retryCount).toBe(1);
+    expect(profile.multiplierByBand).toEqual([1.2, 1.1]);
+    expect(profile.minRatioByBand).toEqual([0.4, 0.35]);
+    expect(profile.maxRatioByBand).toEqual([1.9, 1.8]);
   });
 });

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler/execute.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler/execute.ts
@@ -48,7 +48,9 @@ import {
 } from './helpers/runtime.js';
 import {
   countVertexLimitOverages,
+  findBaseToleranceByBisection,
   retrySimplifyFeatureWithinVertexLimit,
+  selectMaxVertexFeature,
 } from './transformByBandRetrySimplify.js';
 import { resolveSimplifyToleranceProfile } from './helpers/simplifyProfile.js';
 
@@ -264,8 +266,7 @@ export const createTransformByBandHandler = (
   let debugNodeId: NodeId | null = null;
   let debugSelectionLogged = false;
   let firstTaskLogged = false;
-  const DEFAULT_RETRY_TOLERANCE_OFFSET = 1;
-  const MAX_RETRY_ATTEMPTS = 10;
+  const MAX_TOLERANCE_SEARCH_ITERATIONS = 64;
   const debugResetAfterMs = 30000;
   const readHeapUsageRatio = (): number | null => {
     const performance = (globalThis as {
@@ -315,6 +316,13 @@ export const createTransformByBandHandler = (
       return `${Number.parseFloat(value.toFixed(6))}`;
     };
     let finalToleranceSummary: number | undefined;
+    let baseToleranceSummary: number | undefined;
+    let toleranceSearchIterationsSummary = 0;
+    let toleranceSearchConvergedSummary = false;
+    let toleranceMultiplierSummary: number | undefined;
+    let toleranceMinRatioSummary: number | undefined;
+    let toleranceMaxRatioSummary: number | undefined;
+    let vertexLimitSummary: number | undefined;
     const toResultMetadata = (
       status: 'completed' | 'failed' | 'skipped',
       effectiveTolerance: number,
@@ -330,6 +338,25 @@ export const createTransformByBandHandler = (
       }
       if (Number.isFinite(effectiveTolerance)) {
         metadata.effectiveTolerance = effectiveTolerance;
+      }
+      if (Number.isFinite(baseToleranceSummary)) {
+        metadata.baseTolerance = baseToleranceSummary;
+      }
+      if (Number.isFinite(toleranceSearchIterationsSummary)) {
+        metadata.toleranceSearchIterations = toleranceSearchIterationsSummary;
+      }
+      metadata.toleranceSearchConverged = toleranceSearchConvergedSummary;
+      if (Number.isFinite(toleranceMultiplierSummary)) {
+        metadata.toleranceMultiplier = toleranceMultiplierSummary;
+      }
+      if (Number.isFinite(toleranceMinRatioSummary)) {
+        metadata.toleranceMinRatio = toleranceMinRatioSummary;
+      }
+      if (Number.isFinite(toleranceMaxRatioSummary)) {
+        metadata.toleranceMaxRatio = toleranceMaxRatioSummary;
+      }
+      if (Number.isFinite(vertexLimitSummary)) {
+        metadata.vertexLimit = vertexLimitSummary;
       }
       if (Number.isFinite(retryAttempt) && retryAttempt >= 0) {
         metadata.retryAttempt = Math.max(0, Math.floor(retryAttempt));
@@ -443,44 +470,51 @@ export const createTransformByBandHandler = (
       };
     }
     const simplifyProfile = resolveSimplifyToleranceProfile(geometryConfig, input.adminLevel);
-    if (!Array.isArray(simplifyProfile.toleranceByBand) || simplifyProfile.toleranceByBand.length === 0) {
+    if (!Array.isArray(simplifyProfile.multiplierByBand) || simplifyProfile.multiplierByBand.length === 0) {
       const resultMetadata = await persistResultMetadata('failed');
       return {
         status: 'failed',
         ...resultMetadata,
-        errorMessage: 'geometry failed: simplify tolerance by band is missing',
+        errorMessage: 'geometry failed: tolerance multiplier profile is missing',
       };
     }
-    const toleranceByBand = simplifyProfile.toleranceByBand;
-    const retryToleranceByBand = Array.isArray(simplifyProfile.retryToleranceByBand)
-      ? simplifyProfile.retryToleranceByBand
-      : [];
-    const configuredRetryCount = simplifyProfile.retryCount;
-    const tolerance = resolveTransformTolerance(toleranceByBand, band.bandIndex, 0.1);
+    const fallbackTolerance = 0.1;
+    const toleranceSearchMaxIterations = simplifyProfile.toleranceSearchMaxIterations;
+    const clampRatioValue = (value: number, fallback: number): number => {
+      const candidate = Number.isFinite(value) ? value : fallback;
+      return Math.max(0, Math.min(2, candidate));
+    };
+    const rawMultiplier = resolveTransformTolerance(simplifyProfile.multiplierByBand, band.bandIndex, 1);
+    const rawMinRatio = resolveTransformTolerance(simplifyProfile.minRatioByBand, band.bandIndex, 0);
+    const rawMaxRatio = resolveTransformTolerance(simplifyProfile.maxRatioByBand, band.bandIndex, 2);
+    const resolvedMinRatio = clampRatioValue(Math.min(rawMinRatio, rawMaxRatio), 0);
+    const resolvedMaxRatio = clampRatioValue(Math.max(rawMinRatio, rawMaxRatio), 2);
+    const resolvedMultiplier = clampRatioValue(rawMultiplier, 1);
+    const resolveAppliedTolerance = (baseTolerance: number): number => {
+      const candidate = baseTolerance * resolvedMultiplier;
+      const minTolerance = baseTolerance * resolvedMinRatio;
+      const maxTolerance = baseTolerance * resolvedMaxRatio;
+      return Math.max(minTolerance, Math.min(maxTolerance, candidate));
+    };
+    let tolerance = fallbackTolerance;
     finalToleranceSummary = tolerance;
     updateFinalEffectiveTolerance(tolerance);
     const retryVertexLimit = resolveRetryVertexLimit(input.countryCode);
-    const bandTolerance = toleranceByBand[band.bandIndex];
-    if (bandTolerance === undefined || tolerance !== bandTolerance) {
-      console.info('[ShapeGeometry][Tolerance]', JSON.stringify({
-        nodeId: task.nodeId,
-        taskId,
-        sourceKey: input.sourceKey,
-        adminLevel: input.adminLevel,
-        bandIndex: input.bandIndex,
-        zTarget: band.zMax,
-        baseTolerance: bandTolerance,
-        appliedTolerance: tolerance,
-      }));
-    }
+    vertexLimitSummary = retryVertexLimit;
+    toleranceMultiplierSummary = resolvedMultiplier;
+    toleranceMinRatioSummary = resolvedMinRatio;
+    toleranceMaxRatioSummary = resolvedMaxRatio;
     emitTransformTrace(traceLogLevel, 'summary', 'task-config', {
       sessionId: String(task.nodeId),
       taskId,
       stage: 'geometry',
       simplifyAlgorithm,
       preserveTopology,
-      tolerance,
+      fallbackTolerance,
       fetchIntakeGuard: intakeGuardConfig,
+      toleranceMultiplier: resolvedMultiplier,
+      toleranceMinRatio: resolvedMinRatio,
+      toleranceMaxRatio: resolvedMaxRatio,
     });
 
     let workingCollection: FeatureCollection | null = null;
@@ -848,6 +882,64 @@ export const createTransformByBandHandler = (
           limit: memory.jsHeapSizeLimit ?? null,
         };
       };
+      const representativeFeature = selectMaxVertexFeature(inputCollection, countVerticesFromGeometry);
+      if (representativeFeature) {
+        const runBaseSimplifyAttempt = async (nextTolerance: number): Promise<Feature | null> => {
+          const retryCollection = await runStageWithLabel('simplify-only:base-search', () => (
+            simplifyOnlyCollection(
+              { type: 'FeatureCollection', features: [representativeFeature.feature] },
+              band.zMax,
+              nextTolerance,
+              geometryOps,
+            )
+          ));
+          const firstFeature = retryCollection.features[0];
+          return firstFeature ?? null;
+        };
+        const baseSearch = await findBaseToleranceByBisection({
+          feature: representativeFeature.feature,
+          retryVertexLimit,
+          maxIterations: toleranceSearchMaxIterations,
+          initialLow: 0,
+          initialHigh: Math.max(0.1, fallbackTolerance),
+          highCap: 12,
+          runSimplifyAttempt: runBaseSimplifyAttempt,
+          countVerticesFromGeometry,
+        });
+        baseToleranceSummary = baseSearch.tolerance;
+        toleranceSearchIterationsSummary = baseSearch.iterations;
+        toleranceSearchConvergedSummary = baseSearch.converged;
+        if (baseSearch.converged && Number.isFinite(baseSearch.tolerance)) {
+          tolerance = resolveAppliedTolerance(baseSearch.tolerance);
+        } else {
+          tolerance = fallbackTolerance;
+        }
+        finalToleranceSummary = tolerance;
+        updateFinalEffectiveTolerance(tolerance);
+        console.info('[ShapeGeometry][Tolerance]', JSON.stringify({
+          nodeId: task.nodeId,
+          taskId,
+          sourceKey: input.sourceKey,
+          adminLevel: input.adminLevel,
+          bandIndex: input.bandIndex,
+          zTarget: band.zMax,
+          baseTolerance: baseToleranceSummary,
+          appliedTolerance: tolerance,
+          fallbackTolerance,
+          multiplier: resolvedMultiplier,
+          minRatio: resolvedMinRatio,
+          maxRatio: resolvedMaxRatio,
+          searchIterations: baseSearch.iterations,
+          searchConverged: baseSearch.converged,
+          representativeVertexCount: representativeFeature.vertexCount,
+          representativeFeatureIndex: representativeFeature.featureIndex + 1,
+          representativeFinalVertexCount: baseSearch.finalVertexCount,
+        }));
+      } else {
+        tolerance = fallbackTolerance;
+        finalToleranceSummary = tolerance;
+        updateFinalEffectiveTolerance(tolerance);
+      }
       const summarizeVertexLimit = (collection: FeatureCollection | null): {
         featureCount: number;
         overLimitFeatureCount: number;
@@ -1197,13 +1289,8 @@ export const createTransformByBandHandler = (
       }
       if (!shouldDeferSimplifyToVt) {
         await updateTaskPhase(taskId, 'vertex-limit-retry:start', taskProgressRange.simplifyEnd);
-        const maxRetryAttempts = Math.min(MAX_RETRY_ATTEMPTS, configuredRetryCount);
-        const resolveRetryTolerance2 = (): number => {
-          const fallback = Math.min(12, tolerance + DEFAULT_RETRY_TOLERANCE_OFFSET);
-          const candidate = resolveTransformTolerance(retryToleranceByBand, band.bandIndex, fallback);
-          return Number.isFinite(candidate) ? candidate : fallback;
-        };
-        const retryTolerance2 = resolveRetryTolerance2();
+        const maxRetryAttempts = Math.max(1, Math.min(MAX_TOLERANCE_SEARCH_ITERATIONS, toleranceSearchMaxIterations));
+        const maxToleranceForRetry = Math.max(tolerance + 1e-9, (baseToleranceSummary ?? tolerance) * resolvedMaxRatio);
 
         const runRetrySimplifyAttempt = async (feature: Feature, nextToleranceValue: number): Promise<Feature | null> => {
           const retrySimplifyPromise = runStageWithLabel('simplify-only:retry', () => (
@@ -1251,11 +1338,12 @@ export const createTransformByBandHandler = (
                   feature,
                   baseTolerance: tolerance,
                   retryVertexLimit,
-                  retryToleranceSecond: retryTolerance2,
                   maxRetryAttempts,
-              featureIndex: featureIndex + 1,
-              featureTotal: adjustedSimplified.features.length,
-              runRetrySimplifyAttempt: (nextTolerance) => runRetrySimplifyAttempt(feature, nextTolerance),
+                  maxTolerance: maxToleranceForRetry,
+                  minTolerance: tolerance,
+                  featureIndex: featureIndex + 1,
+                  featureTotal: adjustedSimplified.features.length,
+                  runRetrySimplifyAttempt: (nextTolerance) => runRetrySimplifyAttempt(feature, nextTolerance),
               countVerticesFromGeometry,
               updateRetrySimplifyAttemptPhase: (params) => updateRetrySimplifyAttemptPhase(taskId, params),
             });
@@ -1370,7 +1458,7 @@ export const createTransformByBandHandler = (
             `retryAttemptsTotal=${retryAttemptsTotal}`,
             `retriedFeatures=${retryAttemptedFeatureCount}/${simplifiedFeatureCountForLimit}`,
             `maxRetriesPerFeature=${maxRetryAttemptsPerFeature}`,
-            `retryCount=${maxRetryAttempts}`,
+            `searchMaxIterations=${maxRetryAttempts}`,
             `finalToleranceRange=${formatToleranceForMessage(finalToleranceMinValue)}..${formatToleranceForMessage(finalToleranceMaxValue)}`,
           ].join(', ');
           if (vertexLimitRecords.length > 0) {

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler/helpers/simplifyProfile.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler/helpers/simplifyProfile.ts
@@ -1,9 +1,10 @@
 import type { GeometryConfig, GeometrySimplifyToleranceByAdminLevelConfig } from '@hierarchidb/gis-sdk';
 
 export type SimplifyToleranceProfile = {
-  toleranceByBand: number[];
-  retryToleranceByBand: number[];
-  retryCount: number;
+  multiplierByBand: number[];
+  minRatioByBand: number[];
+  maxRatioByBand: number[];
+  toleranceSearchMaxIterations: number;
 };
 
 type SimplifyAdminLevelKey = 'admin0' | 'admin1' | 'admin2' | 'admin3Plus';
@@ -22,14 +23,18 @@ const resolveProfileByKey = (
   key: SimplifyAdminLevelKey,
   previous: SimplifyToleranceProfile | null,
 ): SimplifyToleranceProfile => {
-  const fallbackRetryCount = typeof geometryConfig.retryCount === 'number' && Number.isFinite(geometryConfig.retryCount)
-    ? Math.max(0, Math.min(10, Math.round(geometryConfig.retryCount)))
-    : 4;
-  const fallbackToleranceByBand = Array.isArray(geometryConfig.toleranceByBand)
-    ? geometryConfig.toleranceByBand
+  const fallbackSearchIterations = typeof geometryConfig.toleranceSearchMaxIterations === 'number'
+    && Number.isFinite(geometryConfig.toleranceSearchMaxIterations)
+    ? Math.max(1, Math.min(64, Math.round(geometryConfig.toleranceSearchMaxIterations)))
+    : 24;
+  const fallbackMultiplierByBand = Array.isArray(geometryConfig.toleranceMultiplierByBand)
+    ? geometryConfig.toleranceMultiplierByBand
     : [];
-  const fallbackRetryToleranceByBand = Array.isArray(geometryConfig.retryToleranceByBand)
-    ? geometryConfig.retryToleranceByBand
+  const fallbackMinRatioByBand = Array.isArray(geometryConfig.toleranceMinRatioByBand)
+    ? geometryConfig.toleranceMinRatioByBand
+    : [];
+  const fallbackMaxRatioByBand = Array.isArray(geometryConfig.toleranceMaxRatioByBand)
+    ? geometryConfig.toleranceMaxRatioByBand
     : [];
 
   const raw = config?.[key];
@@ -38,20 +43,31 @@ const resolveProfileByKey = (
     return previous;
   }
 
-  const toleranceByBand = Array.isArray(raw?.toleranceByBand) && raw.toleranceByBand.length > 0
-    ? raw.toleranceByBand
-    : fallbackToleranceByBand;
-  const retryToleranceByBand = Array.isArray(raw?.retryToleranceByBand) && raw.retryToleranceByBand.length > 0
-    ? raw.retryToleranceByBand
-    : fallbackRetryToleranceByBand;
-  const retryCount = typeof raw?.retryCount === 'number' && Number.isFinite(raw.retryCount)
-    ? Math.max(0, Math.min(10, Math.round(raw.retryCount)))
-    : fallbackRetryCount;
+  const multiplierByBand = Array.isArray(raw?.multiplierByBand) && raw.multiplierByBand.length > 0
+    ? raw.multiplierByBand
+    : (fallbackMultiplierByBand.length > 0
+      ? fallbackMultiplierByBand
+      : []);
+  const minRatioByBand = Array.isArray(raw?.minRatioByBand) && raw.minRatioByBand.length > 0
+    ? raw.minRatioByBand
+    : (fallbackMinRatioByBand.length > 0
+      ? fallbackMinRatioByBand
+      : []);
+  const maxRatioByBand = Array.isArray(raw?.maxRatioByBand) && raw.maxRatioByBand.length > 0
+    ? raw.maxRatioByBand
+    : (fallbackMaxRatioByBand.length > 0
+      ? fallbackMaxRatioByBand
+      : []);
+  const toleranceSearchMaxIterations = typeof raw?.toleranceSearchMaxIterations === 'number'
+    && Number.isFinite(raw.toleranceSearchMaxIterations)
+    ? Math.max(1, Math.min(64, Math.round(raw.toleranceSearchMaxIterations)))
+    : fallbackSearchIterations;
 
   return {
-    toleranceByBand,
-    retryToleranceByBand,
-    retryCount,
+    multiplierByBand,
+    minRatioByBand,
+    maxRatioByBand,
+    toleranceSearchMaxIterations,
   };
 };
 

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler/transformByBandRetrySimplify.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler/transformByBandRetrySimplify.ts
@@ -25,14 +25,39 @@ export type RetryFeatureParams = {
   feature: Feature;
   baseTolerance: number;
   retryVertexLimit: number;
-  retryToleranceSecond: number;
   maxRetryAttempts: number;
+  maxTolerance: number;
+  minTolerance?: number;
+  toleranceEpsilon?: number;
   featureIndex: number;
   featureTotal: number;
   runRetrySimplifyAttempt: (tolerance: number) => Promise<Feature | null>;
   countVerticesFromGeometry: (geometry: Feature['geometry'] | null | undefined) => number;
   updateRetrySimplifyAttemptPhase: (params: UpdateRetryAttemptParams) => Promise<void>;
 };
+
+export type BaseToleranceSearchResult = {
+  tolerance: number;
+  converged: boolean;
+  iterations: number;
+  finalVertexCount: number;
+};
+
+export type BaseToleranceSearchParams = {
+  feature: Feature;
+  retryVertexLimit: number;
+  maxIterations: number;
+  initialLow?: number;
+  initialHigh?: number;
+  highCap?: number;
+  toleranceEpsilon?: number;
+  runSimplifyAttempt: (tolerance: number) => Promise<Feature | null>;
+  countVerticesFromGeometry: (geometry: Feature['geometry'] | null | undefined) => number;
+};
+
+const DEFAULT_BISECTION_EPSILON = 1e-7;
+const DEFAULT_INITIAL_HIGH = 1;
+const DEFAULT_MAX_HIGH = 12;
 
 export const countVertexLimitOverages = (
   collection: FeatureCollection,
@@ -54,6 +79,121 @@ export const countVertexLimitOverages = (
   };
 };
 
+export const selectMaxVertexFeature = (
+  collection: FeatureCollection,
+  countVerticesFromGeometry: (geometry: Feature['geometry'] | null | undefined) => number,
+): { feature: Feature; featureIndex: number; vertexCount: number } | null => {
+  let bestFeature: Feature | null = null;
+  let bestVertexCount = -1;
+  let bestIndex = -1;
+  for (const [featureIndex, feature] of collection.features.entries()) {
+    if (!feature?.geometry) continue;
+    const vertexCount = countVerticesFromGeometry(feature.geometry);
+    if (vertexCount <= bestVertexCount) continue;
+    bestFeature = feature;
+    bestVertexCount = vertexCount;
+    bestIndex = featureIndex;
+  }
+  if (!bestFeature || bestIndex < 0 || bestVertexCount < 0) return null;
+  return {
+    feature: bestFeature,
+    featureIndex: bestIndex,
+    vertexCount: bestVertexCount,
+  };
+};
+
+export const findBaseToleranceByBisection = async (
+  params: BaseToleranceSearchParams,
+): Promise<BaseToleranceSearchResult> => {
+  const {
+    feature,
+    retryVertexLimit,
+    maxIterations,
+    runSimplifyAttempt,
+    countVerticesFromGeometry,
+  } = params;
+
+  const epsilon = Math.max(1e-12, params.toleranceEpsilon ?? DEFAULT_BISECTION_EPSILON);
+  const boundedMaxIterations = Math.max(1, Math.min(64, Math.round(maxIterations)));
+  const lowStart = Number.isFinite(params.initialLow) ? Math.max(0, params.initialLow ?? 0) : 0;
+  let low = lowStart;
+  let high = Number.isFinite(params.initialHigh) && (params.initialHigh ?? 0) > low
+    ? (params.initialHigh as number)
+    : DEFAULT_INITIAL_HIGH;
+  const highCap = Number.isFinite(params.highCap) && (params.highCap ?? 0) > 0
+    ? (params.highCap as number)
+    : DEFAULT_MAX_HIGH;
+
+  const baseVertexCount = countVerticesFromGeometry(feature.geometry);
+  if (baseVertexCount < retryVertexLimit) {
+    return {
+      tolerance: low,
+      converged: true,
+      iterations: 0,
+      finalVertexCount: baseVertexCount,
+    };
+  }
+
+  let attempts = 0;
+  let highFeature: Feature | null = null;
+  let highVertexCount = Number.POSITIVE_INFINITY;
+  while (high <= highCap) {
+    const retryFeature = await runSimplifyAttempt(high);
+    attempts += 1;
+    if (retryFeature?.geometry) {
+      highFeature = retryFeature;
+      highVertexCount = countVerticesFromGeometry(retryFeature.geometry);
+      if (highVertexCount < retryVertexLimit) {
+        break;
+      }
+    }
+    high *= 2;
+  }
+
+  if (!highFeature || highVertexCount >= retryVertexLimit) {
+    return {
+      tolerance: Math.min(highCap, high),
+      converged: false,
+      iterations: attempts,
+      finalVertexCount: Number.isFinite(highVertexCount) ? highVertexCount : baseVertexCount,
+    };
+  }
+
+  let bestTolerance = high;
+  let bestVertexCount = highVertexCount;
+  for (let index = 0; index < boundedMaxIterations; index += 1) {
+    if (Math.abs(high - low) < epsilon) {
+      return {
+        tolerance: bestTolerance,
+        converged: true,
+        iterations: attempts,
+        finalVertexCount: bestVertexCount,
+      };
+    }
+    const mid = (low + high) / 2;
+    const retryFeature = await runSimplifyAttempt(mid);
+    attempts += 1;
+    if (!retryFeature?.geometry) {
+      low = mid;
+      continue;
+    }
+    const retryVertexCount = countVerticesFromGeometry(retryFeature.geometry);
+    if (retryVertexCount < retryVertexLimit) {
+      high = mid;
+      bestTolerance = mid;
+      bestVertexCount = retryVertexCount;
+      continue;
+    }
+    low = mid;
+  }
+  return {
+    tolerance: bestTolerance,
+    converged: true,
+    iterations: attempts,
+    finalVertexCount: bestVertexCount,
+  };
+};
+
 export const retrySimplifyFeatureWithinVertexLimit = async (
   params: RetryFeatureParams,
 ): Promise<RetrySimplifyFeatureResult> => {
@@ -61,8 +201,10 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     feature,
     baseTolerance,
     retryVertexLimit,
-    retryToleranceSecond,
     maxRetryAttempts,
+    maxTolerance,
+    minTolerance,
+    toleranceEpsilon,
     featureIndex,
     featureTotal,
     runRetrySimplifyAttempt,
@@ -96,7 +238,14 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
   let lastAttemptTolerance = baseTolerance;
   let retryAttempts = 0;
 
-  if (maxRetryAttempts <= 0 || !Number.isFinite(retryToleranceSecond)) {
+  const boundedAttempts = Math.max(0, Math.min(64, Math.floor(maxRetryAttempts)));
+  const epsilon = Math.max(1e-12, toleranceEpsilon ?? DEFAULT_BISECTION_EPSILON);
+  const lowStart = Number.isFinite(minTolerance)
+    ? Math.max(0, Math.min(minTolerance ?? 0, baseTolerance))
+    : baseTolerance;
+  const highStart = Number.isFinite(maxTolerance) ? maxTolerance : baseTolerance;
+
+  if (boundedAttempts <= 0 || !Number.isFinite(highStart) || highStart <= baseTolerance) {
     return {
       feature,
       vertexCount: baseVertexCount,
@@ -106,16 +255,52 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     };
   }
 
-  for (let attempt = 0; attempt < maxRetryAttempts; attempt += 1) {
-    const attemptNumber = attempt + 2;
-    const nextToleranceValue = attemptNumber === 2
-      ? retryToleranceSecond
-      : baseTolerance + (retryToleranceSecond - baseTolerance) * (2 ** (attemptNumber - 2));
+  let low = lowStart;
+  let high = highStart;
+
+  await updateRetrySimplifyAttemptPhase({
+    featureIndex,
+    featureTotal,
+    attempt: 1,
+    attemptTotal: boundedAttempts + 1,
+    tolerance: high,
+  });
+  const highFeature = await runRetrySimplifyAttempt(high);
+  retryAttempts += 1;
+  if (highFeature?.geometry) {
+    const highVertexCount = countVerticesFromGeometry(highFeature.geometry);
+    lastAttemptFeature = highFeature;
+    lastAttemptVertexCount = highVertexCount;
+    lastAttemptTolerance = high;
+    if (highVertexCount >= retryVertexLimit) {
+      return {
+        feature: lastAttemptFeature,
+        vertexCount: lastAttemptVertexCount,
+        overLimit: true,
+        retryAttempts,
+        finalTolerance: lastAttemptTolerance,
+      };
+    }
+  } else {
+    return {
+      feature: lastAttemptFeature,
+      vertexCount: lastAttemptVertexCount,
+      overLimit: true,
+      retryAttempts,
+      finalTolerance: lastAttemptTolerance,
+    };
+  }
+
+  for (let attempt = 0; attempt < boundedAttempts; attempt += 1) {
+    if (Math.abs(high - low) < epsilon) {
+      break;
+    }
+    const nextToleranceValue = (low + high) / 2;
     await updateRetrySimplifyAttemptPhase({
       featureIndex,
       featureTotal,
       attempt: retryAttempts + 1,
-      attemptTotal: maxRetryAttempts,
+      attemptTotal: boundedAttempts + 1,
       tolerance: nextToleranceValue,
     });
     const retryFeature = await runRetrySimplifyAttempt(nextToleranceValue);
@@ -128,8 +313,10 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     lastAttemptVertexCount = retryVertexCount;
 
     if (retryVertexCount < retryVertexLimit) {
-      break;
+      high = nextToleranceValue;
+      continue;
     }
+    low = nextToleranceValue;
   }
 
   return {

--- a/plugins/shape-plugin/src/ui/components/build-config/SimplifyToleranceByAdminLevelCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/SimplifyToleranceByAdminLevelCard.tsx
@@ -31,25 +31,28 @@ type AdminLevelTabKey = 'admin0' | 'admin1' | 'admin2' | 'admin3Plus';
 
 type AdminLevelProfile = {
   usePrevious: boolean;
-  toleranceByBand: number[];
-  retryToleranceByBand: number[];
-  retryCount: number;
+  multiplierByBand: number[];
+  minRatioByBand: number[];
+  maxRatioByBand: number[];
+  toleranceSearchMaxIterations: number;
 };
 
 type StoredAdminLevelProfile = {
   usePrevious?: boolean;
-  toleranceByBand?: number[];
-  retryToleranceByBand?: number[];
-  retryCount?: number;
+  multiplierByBand?: number[];
+  minRatioByBand?: number[];
+  maxRatioByBand?: number[];
+  toleranceSearchMaxIterations?: number;
 };
 
 type StoredAdminLevelProfiles = Partial<Record<AdminLevelTabKey, StoredAdminLevelProfile>>;
 
-const CURVE_Y_RANGE: [number, number] = [0, 12];
-const DEFAULT_RETRY_COUNT = 4;
-const DEFAULT_TOLERANCE_FALLBACK = 0.1;
-const DEFAULT_MAIN_ANCHORS = [0.1, 0.1, 0.1, 0.1] as const;
-const DEFAULT_RETRY_ANCHORS = [0.2, 0.2, 0.3, 0.4] as const;
+const CURVE_Y_RANGE: [number, number] = [0, 2];
+const DEFAULT_ITERATIONS = 24;
+const DEFAULT_FALLBACK = 1;
+const DEFAULT_MULTIPLIER_ANCHORS = [1, 1, 1, 1] as const;
+const DEFAULT_MIN_RATIO_ANCHORS = [0, 0, 0, 0] as const;
+const DEFAULT_MAX_RATIO_ANCHORS = [2, 2, 2, 2] as const;
 
 const ADMIN_LEVEL_TABS: ReadonlyArray<{ key: AdminLevelTabKey; label: string }> = [
   { key: 'admin0', label: 'Admin 0' },
@@ -64,37 +67,23 @@ const PREVIOUS_TAB_BY_KEY: Partial<Record<AdminLevelTabKey, AdminLevelTabKey>> =
   admin3Plus: 'admin2',
 };
 
-const clampRetryCount = (value: number): number => Math.min(10, Math.max(0, Math.round(value)));
-
+const clampIterations = (value: number): number => Math.min(64, Math.max(1, Math.round(value)));
+const clampRatio = (value: number): number => Math.max(0, Math.min(2, Number.parseFloat(value.toFixed(3))));
 const resolveSliderNumber = (value: number | number[]) => (Array.isArray(value) ? value[0] ?? 0 : value);
+const areRatioValuesEqual = (left: number, right: number): boolean => Math.abs(clampRatio(left) - clampRatio(right)) < 1e-9;
 
-const normalizeToleranceValue = (value: number): number => Number.parseFloat(value.toFixed(3));
-
-const clampToCurveYRange = (value: number): number => Math.max(CURVE_Y_RANGE[0], Math.min(CURVE_Y_RANGE[1], value));
-
-const areToleranceValuesEqual = (left: number, right: number): boolean => (
-  Math.abs(normalizeToleranceValue(left) - normalizeToleranceValue(right)) < 1e-9
-);
-
-const resolveToleranceByBand = (
+const resolveRatioByBand = (
   input: number[] | undefined,
   zoomBandBoundaries: number[],
   fallbackAnchors: readonly [number, number, number, number],
 ): number[] => {
-  const fallback = fallbackAnchors[0] ?? DEFAULT_TOLERANCE_FALLBACK;
+  const fallback = fallbackAnchors[0] ?? DEFAULT_FALLBACK;
   return buildToneCurveAnchorsFromToleranceByBand(
     input,
     zoomBandBoundaries,
     fallback,
     fallbackAnchors,
-  ).map((anchor) => normalizeToleranceValue(anchor.y));
-};
-
-const resolveRetryCount = (input: number | undefined, fallback: number): number => {
-  if (typeof input === 'number' && Number.isFinite(input)) {
-    return clampRetryCount(input);
-  }
-  return clampRetryCount(fallback);
+  ).map((anchor) => clampRatio(anchor.y));
 };
 
 const resolveStoredProfiles = (
@@ -115,17 +104,24 @@ const resolveEditableProfile = (
   const raw = storedProfiles[key];
   return {
     usePrevious: key === 'admin0' ? false : raw?.usePrevious === true,
-    toleranceByBand: resolveToleranceByBand(
-      raw?.toleranceByBand ?? geometryConfig.toleranceByBand,
+    multiplierByBand: resolveRatioByBand(
+      raw?.multiplierByBand ?? geometryConfig.toleranceMultiplierByBand,
       geometryConfig.zoomBandBoundaries,
-      DEFAULT_MAIN_ANCHORS,
+      DEFAULT_MULTIPLIER_ANCHORS,
     ),
-    retryToleranceByBand: resolveToleranceByBand(
-      raw?.retryToleranceByBand ?? geometryConfig.retryToleranceByBand,
+    minRatioByBand: resolveRatioByBand(
+      raw?.minRatioByBand ?? geometryConfig.toleranceMinRatioByBand,
       geometryConfig.zoomBandBoundaries,
-      DEFAULT_RETRY_ANCHORS,
+      DEFAULT_MIN_RATIO_ANCHORS,
     ),
-    retryCount: resolveRetryCount(raw?.retryCount, geometryConfig.retryCount ?? DEFAULT_RETRY_COUNT),
+    maxRatioByBand: resolveRatioByBand(
+      raw?.maxRatioByBand ?? geometryConfig.toleranceMaxRatioByBand,
+      geometryConfig.zoomBandBoundaries,
+      DEFAULT_MAX_RATIO_ANCHORS,
+    ),
+    toleranceSearchMaxIterations: typeof raw?.toleranceSearchMaxIterations === 'number'
+      ? clampIterations(raw.toleranceSearchMaxIterations)
+      : clampIterations(geometryConfig.toleranceSearchMaxIterations ?? DEFAULT_ITERATIONS),
   };
 };
 
@@ -151,6 +147,33 @@ const resolveEffectiveProfiles = (
     admin3Plus: admin3UsePrevious
       ? (admin2UsePrevious ? (admin1UsePrevious ? base.admin0 : base.admin1) : base.admin2)
       : base.admin3Plus,
+  };
+};
+
+const clampProfileBands = (
+  multiplierByBand: number[],
+  minRatioByBand: number[],
+  maxRatioByBand: number[],
+): Pick<AdminLevelProfile, 'multiplierByBand' | 'minRatioByBand' | 'maxRatioByBand'> => {
+  const maxLength = Math.max(multiplierByBand.length, minRatioByBand.length, maxRatioByBand.length);
+  const nextMultiplier: number[] = [];
+  const nextMin: number[] = [];
+  const nextMax: number[] = [];
+  for (let index = 0; index < maxLength; index += 1) {
+    const rawMin = clampRatio(minRatioByBand[index] ?? 0);
+    const rawMax = clampRatio(maxRatioByBand[index] ?? 2);
+    const minValue = Math.min(rawMin, rawMax);
+    const maxValue = Math.max(rawMin, rawMax);
+    const rawMultiplier = clampRatio(multiplierByBand[index] ?? 1);
+    const multiplierValue = Math.max(minValue, Math.min(maxValue, rawMultiplier));
+    nextMin.push(minValue);
+    nextMax.push(maxValue);
+    nextMultiplier.push(multiplierValue);
+  }
+  return {
+    multiplierByBand: nextMultiplier,
+    minRatioByBand: nextMin,
+    maxRatioByBand: nextMax,
   };
 };
 
@@ -191,20 +214,25 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
   const activeValues = usePrevious ? activeEffective : activeEditable;
 
   const xMarks = geometryConfig.zoomBandBoundaries.map((value) => ({ value, label: String(value) }));
-  const retryCountMarks = [0, 2, 4, 6, 8, 10].map((value) => ({ value, label: String(value) }));
+  const iterationMarks = [8, 16, 24, 32, 48, 64].map((value) => ({ value, label: String(value) }));
 
-  const resolvedMainAnchors = buildToneCurveAnchorsFromToleranceByBand(
-    activeValues.toleranceByBand,
+  const resolvedMultiplierAnchors = buildToneCurveAnchorsFromToleranceByBand(
+    activeValues.multiplierByBand,
     geometryConfig.zoomBandBoundaries,
-    DEFAULT_MAIN_ANCHORS[0] ?? DEFAULT_TOLERANCE_FALLBACK,
-    DEFAULT_MAIN_ANCHORS,
+    DEFAULT_MULTIPLIER_ANCHORS[0] ?? DEFAULT_FALLBACK,
+    DEFAULT_MULTIPLIER_ANCHORS,
   );
-
-  const resolvedRetryAnchors = buildToneCurveAnchorsFromToleranceByBand(
-    activeValues.retryToleranceByBand,
+  const resolvedMinAnchors = buildToneCurveAnchorsFromToleranceByBand(
+    activeValues.minRatioByBand,
     geometryConfig.zoomBandBoundaries,
-    DEFAULT_RETRY_ANCHORS[0] ?? DEFAULT_TOLERANCE_FALLBACK,
-    DEFAULT_RETRY_ANCHORS,
+    DEFAULT_MIN_RATIO_ANCHORS[0] ?? 0,
+    DEFAULT_MIN_RATIO_ANCHORS,
+  );
+  const resolvedMaxAnchors = buildToneCurveAnchorsFromToleranceByBand(
+    activeValues.maxRatioByBand,
+    geometryConfig.zoomBandBoundaries,
+    DEFAULT_MAX_RATIO_ANCHORS[0] ?? 2,
+    DEFAULT_MAX_RATIO_ANCHORS,
   );
 
   const updateStoredProfile = useCallback((
@@ -228,87 +256,50 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
 
     if (key === 'admin0') {
       const admin0 = nextProfiles.admin0 ?? {};
-      if (Array.isArray(admin0.toleranceByBand)) {
-        patch.toleranceByBand = admin0.toleranceByBand;
+      if (Array.isArray(admin0.multiplierByBand)) {
+        patch.toleranceMultiplierByBand = admin0.multiplierByBand;
       }
-      if (Array.isArray(admin0.retryToleranceByBand)) {
-        patch.retryToleranceByBand = admin0.retryToleranceByBand;
+      if (Array.isArray(admin0.minRatioByBand)) {
+        patch.toleranceMinRatioByBand = admin0.minRatioByBand;
       }
-      if (typeof admin0.retryCount === 'number' && Number.isFinite(admin0.retryCount)) {
-        patch.retryCount = clampRetryCount(admin0.retryCount);
+      if (Array.isArray(admin0.maxRatioByBand)) {
+        patch.toleranceMaxRatioByBand = admin0.maxRatioByBand;
+      }
+      if (typeof admin0.toleranceSearchMaxIterations === 'number' && Number.isFinite(admin0.toleranceSearchMaxIterations)) {
+        patch.toleranceSearchMaxIterations = clampIterations(admin0.toleranceSearchMaxIterations);
       }
     }
 
     onChange(patch);
   }, [onChange, storedProfiles]);
 
-  const handleMainAnchorYChange = useCallback((index: number, rawValue: number) => {
-    if (controlsDisabled || !Number.isFinite(rawValue)) {
+  const updateBands = useCallback((nextPartial: {
+    multiplierByBand?: number[];
+    minRatioByBand?: number[];
+    maxRatioByBand?: number[];
+  }) => {
+    const mergedMultiplier = nextPartial.multiplierByBand ?? activeEditable.multiplierByBand;
+    const mergedMin = nextPartial.minRatioByBand ?? activeEditable.minRatioByBand;
+    const mergedMax = nextPartial.maxRatioByBand ?? activeEditable.maxRatioByBand;
+    const normalized = clampProfileBands(mergedMultiplier, mergedMin, mergedMax);
+
+    const isSameMultiplier = normalized.multiplierByBand.length === activeEditable.multiplierByBand.length
+      && normalized.multiplierByBand.every((value, index) => areRatioValuesEqual(value, activeEditable.multiplierByBand[index] ?? value));
+    const isSameMin = normalized.minRatioByBand.length === activeEditable.minRatioByBand.length
+      && normalized.minRatioByBand.every((value, index) => areRatioValuesEqual(value, activeEditable.minRatioByBand[index] ?? value));
+    const isSameMax = normalized.maxRatioByBand.length === activeEditable.maxRatioByBand.length
+      && normalized.maxRatioByBand.every((value, index) => areRatioValuesEqual(value, activeEditable.maxRatioByBand[index] ?? value));
+
+    if (isSameMultiplier && isSameMin && isSameMax) {
       return;
     }
 
-    const nextAnchors = resolvedMainAnchors.map((anchor, anchorIndex) => (
-      anchorIndex === index ? { ...anchor, y: clampToCurveYRange(rawValue) } : anchor
-    ));
-
-    const next = buildToleranceByBandFromToneCurveAnchors(
-      nextAnchors,
-      geometryConfig.zoomBandBoundaries,
-      DEFAULT_MAIN_ANCHORS[0] ?? DEFAULT_TOLERANCE_FALLBACK,
-    ).map((value) => normalizeToleranceValue(value));
-
-    if (next.length === activeEditable.toleranceByBand.length
-      && next.every((value, toleranceIndex) => areToleranceValuesEqual(
-        value,
-        activeEditable.toleranceByBand[toleranceIndex] ?? value,
-      ))
-    ) {
-      return;
-    }
-
-    updateStoredProfile(activeTab, { toleranceByBand: next });
-  }, [
-    activeEditable.toleranceByBand,
-    activeTab,
-    controlsDisabled,
-    resolvedMainAnchors,
-    geometryConfig.zoomBandBoundaries,
-    updateStoredProfile,
-  ]);
-
-  const handleRetryAnchorYChange = useCallback((index: number, rawValue: number) => {
-    if (controlsDisabled || !Number.isFinite(rawValue)) {
-      return;
-    }
-
-    const nextAnchors = resolvedRetryAnchors.map((anchor, anchorIndex) => (
-      anchorIndex === index ? { ...anchor, y: clampToCurveYRange(rawValue) } : anchor
-    ));
-
-    const next = buildToleranceByBandFromToneCurveAnchors(
-      nextAnchors,
-      geometryConfig.zoomBandBoundaries,
-      DEFAULT_RETRY_ANCHORS[0] ?? DEFAULT_TOLERANCE_FALLBACK,
-    ).map((value) => normalizeToleranceValue(value));
-
-    if (next.length === activeEditable.retryToleranceByBand.length
-      && next.every((value, toleranceIndex) => areToleranceValuesEqual(
-        value,
-        activeEditable.retryToleranceByBand[toleranceIndex] ?? value,
-      ))
-    ) {
-      return;
-    }
-
-    updateStoredProfile(activeTab, { retryToleranceByBand: next });
-  }, [
-    activeEditable.retryToleranceByBand,
-    activeTab,
-    controlsDisabled,
-    resolvedRetryAnchors,
-    geometryConfig.zoomBandBoundaries,
-    updateStoredProfile,
-  ]);
+    updateStoredProfile(activeTab, {
+      multiplierByBand: normalized.multiplierByBand,
+      minRatioByBand: normalized.minRatioByBand,
+      maxRatioByBand: normalized.maxRatioByBand,
+    });
+  }, [activeEditable.maxRatioByBand, activeEditable.minRatioByBand, activeEditable.multiplierByBand, activeTab, updateStoredProfile]);
 
   const copyFromPreviousTab = useCallback(() => {
     if (!previousTabKey || controlsDisabled) {
@@ -317,9 +308,10 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
     const source = effectiveProfiles[previousTabKey];
     updateStoredProfile(activeTab, {
       usePrevious: false,
-      toleranceByBand: source.toleranceByBand,
-      retryToleranceByBand: source.retryToleranceByBand,
-      retryCount: source.retryCount,
+      multiplierByBand: source.multiplierByBand,
+      minRatioByBand: source.minRatioByBand,
+      maxRatioByBand: source.maxRatioByBand,
+      toleranceSearchMaxIterations: source.toleranceSearchMaxIterations,
     });
   }, [activeTab, controlsDisabled, effectiveProfiles, previousTabKey, updateStoredProfile]);
 
@@ -328,6 +320,12 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
       lineColor: '#0b5ed7',
       anchorPointColor: '#0b5ed7',
       lineWidth: 2,
+    },
+    {
+      lineColor: '#6b7280',
+      anchorPointColor: '#6b7280',
+      lineWidth: 2,
+      lineDashArray: '6 4',
     },
     {
       lineColor: '#ef4444',
@@ -409,7 +407,7 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
             <Grid size={{ xs: 12, md: 8 }}>
               <Stack spacing={0.5}>
                 <Typography variant="body2" color="text.secondary">
-                  {t('processing.geometry.simplifyTolerance.label', 'Simplify tolerance')}
+                  {t('processing.geometry.simplifyTolerance.label', 'Simplify tolerance profile')}
                 </Typography>
                 <div
                   ref={curveWidthRef}
@@ -425,18 +423,17 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
                     yRange={CURVE_Y_RANGE}
                     lineStyles={toneCurveLineStyles}
                     xMarks={xMarks}
-                    anchors={resolvedMainAnchors}
-                    xFixedValues={resolvedMainAnchors.map((anchor) => anchor.x)}
+                    anchors={resolvedMultiplierAnchors}
+                    xFixedValues={resolvedMultiplierAnchors.map((anchor) => anchor.x)}
                     allowAnchorCountChange={false}
                     horizontalZoom={false}
                     verticalZoom
                     xSnapStep={0.1}
-                    ySnapStep={0.1}
+                    ySnapStep={0.05}
                     overlaySeries={[
                       {
-                        anchors: resolvedRetryAnchors,
-                        xFixedValues: resolvedRetryAnchors.map((anchor) => anchor.x),
-                        yFixedValues: [],
+                        anchors: resolvedMinAnchors,
+                        xFixedValues: resolvedMinAnchors.map((anchor) => anchor.x),
                         allowAnchorCountChange: false,
                         editable: !controlsDisabled,
                         onChange: (overlayAnchors) => {
@@ -444,18 +441,24 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
                           const next = buildToleranceByBandFromToneCurveAnchors(
                             overlayAnchors,
                             geometryConfig.zoomBandBoundaries,
-                            DEFAULT_RETRY_ANCHORS[0] ?? DEFAULT_TOLERANCE_FALLBACK,
-                          ).map((value) => normalizeToleranceValue(value));
-
-                          if (next.length === activeEditable.retryToleranceByBand.length
-                            && next.every((value, index) => areToleranceValuesEqual(
-                              value,
-                              activeEditable.retryToleranceByBand[index] ?? value,
-                            ))
-                          ) {
-                            return;
-                          }
-                          updateStoredProfile(activeTab, { retryToleranceByBand: next });
+                            DEFAULT_MIN_RATIO_ANCHORS[0] ?? 0,
+                          ).map((value) => clampRatio(value));
+                          updateBands({ minRatioByBand: next });
+                        },
+                      },
+                      {
+                        anchors: resolvedMaxAnchors,
+                        xFixedValues: resolvedMaxAnchors.map((anchor) => anchor.x),
+                        allowAnchorCountChange: false,
+                        editable: !controlsDisabled,
+                        onChange: (overlayAnchors) => {
+                          if (controlsDisabled) return;
+                          const next = buildToleranceByBandFromToneCurveAnchors(
+                            overlayAnchors,
+                            geometryConfig.zoomBandBoundaries,
+                            DEFAULT_MAX_RATIO_ANCHORS[0] ?? 2,
+                          ).map((value) => clampRatio(value));
+                          updateBands({ maxRatioByBand: next });
                         },
                       },
                     ]}
@@ -464,55 +467,12 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
                       const next = buildToleranceByBandFromToneCurveAnchors(
                         anchors,
                         geometryConfig.zoomBandBoundaries,
-                        DEFAULT_MAIN_ANCHORS[0] ?? DEFAULT_TOLERANCE_FALLBACK,
-                      ).map((value) => normalizeToleranceValue(value));
-
-                      if (next.length === activeEditable.toleranceByBand.length
-                        && next.every((value, index) => areToleranceValuesEqual(
-                          value,
-                          activeEditable.toleranceByBand[index] ?? value,
-                        ))
-                      ) {
-                        return;
-                      }
-                      updateStoredProfile(activeTab, { toleranceByBand: next });
+                        DEFAULT_MULTIPLIER_ANCHORS[0] ?? DEFAULT_FALLBACK,
+                      ).map((value) => clampRatio(value));
+                      updateBands({ multiplierByBand: next });
                     }}
                   />
                 </div>
-
-                <Paper
-                  variant="outlined"
-                  sx={{
-                    mt: 1.5,
-                    p: 1,
-                    borderColor: '#ef4444',
-                    width: '100%',
-                    overflow: 'visible',
-                  }}
-                >
-                  <Stack direction="row" spacing={1} sx={{ flexWrap: 'nowrap', overflowX: 'auto', pt: 1 }}>
-                    {resolvedRetryAnchors.map((anchor, index) => (
-                      <TextField
-                        key={`retry-anchor-${index}`}
-                        label={String(normalizeToleranceValue(anchor.x))}
-                        type="number"
-                        size="small"
-                        value={normalizeToleranceValue(anchor.y)}
-                        inputProps={{
-                          step: 0.1,
-                          min: CURVE_Y_RANGE[0],
-                          max: CURVE_Y_RANGE[1],
-                        }}
-                        disabled={controlsDisabled}
-                        onChange={(event) => {
-                          const nextValue = Number.parseFloat(event.target.value);
-                          handleRetryAnchorYChange(index, nextValue);
-                        }}
-                        sx={spinnerTextFieldSx}
-                      />
-                    ))}
-                  </Stack>
-                </Paper>
 
                 <Paper
                   variant="outlined"
@@ -525,22 +485,99 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
                   }}
                 >
                   <Stack direction="row" spacing={1} sx={{ flexWrap: 'nowrap', overflowX: 'auto', pt: 1 }}>
-                    {resolvedMainAnchors.map((anchor, index) => (
+                    {resolvedMultiplierAnchors.map((anchor, index) => (
                       <TextField
-                        key={`anchor-${index}`}
-                        label={String(normalizeToleranceValue(anchor.x))}
+                        key={`multiplier-anchor-${index}`}
+                        label={String(clampRatio(anchor.x))}
                         type="number"
                         size="small"
-                        value={normalizeToleranceValue(anchor.y)}
+                        value={clampRatio(anchor.y)}
                         inputProps={{
-                          step: 0.1,
+                          step: 0.05,
                           min: CURVE_Y_RANGE[0],
                           max: CURVE_Y_RANGE[1],
                         }}
                         disabled={controlsDisabled}
                         onChange={(event) => {
                           const nextValue = Number.parseFloat(event.target.value);
-                          handleMainAnchorYChange(index, nextValue);
+                          if (!Number.isFinite(nextValue)) return;
+                          const next = [...activeEditable.multiplierByBand];
+                          next[index] = clampRatio(nextValue);
+                          updateBands({ multiplierByBand: next });
+                        }}
+                        sx={spinnerTextFieldSx}
+                      />
+                    ))}
+                  </Stack>
+                </Paper>
+
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    mt: 1,
+                    p: 1,
+                    borderColor: '#6b7280',
+                    width: '100%',
+                    overflow: 'visible',
+                  }}
+                >
+                  <Stack direction="row" spacing={1} sx={{ flexWrap: 'nowrap', overflowX: 'auto', pt: 1 }}>
+                    {resolvedMinAnchors.map((anchor, index) => (
+                      <TextField
+                        key={`min-anchor-${index}`}
+                        label={String(clampRatio(anchor.x))}
+                        type="number"
+                        size="small"
+                        value={clampRatio(anchor.y)}
+                        inputProps={{
+                          step: 0.05,
+                          min: CURVE_Y_RANGE[0],
+                          max: CURVE_Y_RANGE[1],
+                        }}
+                        disabled={controlsDisabled}
+                        onChange={(event) => {
+                          const nextValue = Number.parseFloat(event.target.value);
+                          if (!Number.isFinite(nextValue)) return;
+                          const next = [...activeEditable.minRatioByBand];
+                          next[index] = clampRatio(nextValue);
+                          updateBands({ minRatioByBand: next });
+                        }}
+                        sx={spinnerTextFieldSx}
+                      />
+                    ))}
+                  </Stack>
+                </Paper>
+
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    mt: 1,
+                    p: 1,
+                    borderColor: '#ef4444',
+                    width: '100%',
+                    overflow: 'visible',
+                  }}
+                >
+                  <Stack direction="row" spacing={1} sx={{ flexWrap: 'nowrap', overflowX: 'auto', pt: 1 }}>
+                    {resolvedMaxAnchors.map((anchor, index) => (
+                      <TextField
+                        key={`max-anchor-${index}`}
+                        label={String(clampRatio(anchor.x))}
+                        type="number"
+                        size="small"
+                        value={clampRatio(anchor.y)}
+                        inputProps={{
+                          step: 0.05,
+                          min: CURVE_Y_RANGE[0],
+                          max: CURVE_Y_RANGE[1],
+                        }}
+                        disabled={controlsDisabled}
+                        onChange={(event) => {
+                          const nextValue = Number.parseFloat(event.target.value);
+                          if (!Number.isFinite(nextValue)) return;
+                          const next = [...activeEditable.maxRatioByBand];
+                          next[index] = clampRatio(nextValue);
+                          updateBands({ maxRatioByBand: next });
                         }}
                         sx={spinnerTextFieldSx}
                       />
@@ -553,24 +590,24 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
             <Grid size={{ xs: 12, md: 4 }}>
               <Stack spacing={0.5} alignItems="flex-start">
                 <Typography variant="body2" color="text.secondary">
-                  {t('processing.geometry.retryToleranceStep.label', 'Retry count')}
+                  {t('processing.geometry.retryToleranceStep.label', 'Max search iterations')}
                 </Typography>
                 <Stack direction="row" spacing={2} alignItems="center" sx={{ paddingTop: '20px' }}>
                   <Slider
                     sx={{ flex: 1, minWidth: 220, mt: '16px' }}
-                    value={activeValues.retryCount}
-                    min={0}
-                    max={10}
+                    value={activeValues.toleranceSearchMaxIterations}
+                    min={1}
+                    max={64}
                     step={1}
-                    marks={retryCountMarks}
+                    marks={iterationMarks}
                     disabled={controlsDisabled}
                     valueLabelDisplay="on"
                     onChange={(_event, value) => {
-                      const next = clampRetryCount(resolveSliderNumber(value));
-                      if (next === activeEditable.retryCount) {
+                      const next = clampIterations(resolveSliderNumber(value));
+                      if (next === activeEditable.toleranceSearchMaxIterations) {
                         return;
                       }
-                      updateStoredProfile(activeTab, { retryCount: next });
+                      updateStoredProfile(activeTab, { toleranceSearchMaxIterations: next });
                     }}
                   />
                 </Stack>

--- a/plugins/shape-plugin/src/ui/components/build-config/ZoomBandConfigSection.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/ZoomBandConfigSection.tsx
@@ -20,6 +20,9 @@ export const ZoomBandConfigSection: React.FC<Props> = ({
   const { t } = useTranslation();
   const { baseGeometryConfig, update } = useGeometryConfigSection({ config, onChange });
   const toleranceFallback = 0.1;
+  const multiplierFallback = 1;
+  const minRatioFallback = 0;
+  const maxRatioFallback = 2;
   const simplifyToleranceByAdminLevel = baseGeometryConfig.simplifyToleranceByAdminLevel;
 
   return (
@@ -33,72 +36,108 @@ export const ZoomBandConfigSection: React.FC<Props> = ({
           zoomBandBoundaries,
           toleranceFallback,
         );
-        const nextRetryToleranceByBand = resampleToleranceByBand(
-          baseGeometryConfig.retryToleranceByBand,
+        const nextMultiplierByBand = resampleToleranceByBand(
+          baseGeometryConfig.toleranceMultiplierByBand,
           baseGeometryConfig.zoomBandBoundaries,
           zoomBandBoundaries,
-          toleranceFallback,
+          multiplierFallback,
+        );
+        const nextMinRatioByBand = resampleToleranceByBand(
+          baseGeometryConfig.toleranceMinRatioByBand,
+          baseGeometryConfig.zoomBandBoundaries,
+          zoomBandBoundaries,
+          minRatioFallback,
+        );
+        const nextMaxRatioByBand = resampleToleranceByBand(
+          baseGeometryConfig.toleranceMaxRatioByBand,
+          baseGeometryConfig.zoomBandBoundaries,
+          zoomBandBoundaries,
+          maxRatioFallback,
         );
         const nextSimplifyToleranceByAdminLevel = simplifyToleranceByAdminLevel
           ? {
             admin0: {
               ...simplifyToleranceByAdminLevel.admin0,
-              toleranceByBand: resampleToleranceByBand(
-                simplifyToleranceByAdminLevel.admin0?.toleranceByBand,
+              multiplierByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin0?.multiplierByBand,
                 baseGeometryConfig.zoomBandBoundaries,
                 zoomBandBoundaries,
-                toleranceFallback,
+                multiplierFallback,
               ),
-              retryToleranceByBand: resampleToleranceByBand(
-                simplifyToleranceByAdminLevel.admin0?.retryToleranceByBand,
+              minRatioByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin0?.minRatioByBand,
                 baseGeometryConfig.zoomBandBoundaries,
                 zoomBandBoundaries,
-                toleranceFallback,
+                minRatioFallback,
+              ),
+              maxRatioByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin0?.maxRatioByBand,
+                baseGeometryConfig.zoomBandBoundaries,
+                zoomBandBoundaries,
+                maxRatioFallback,
               ),
             },
             admin1: {
               ...simplifyToleranceByAdminLevel.admin1,
-              toleranceByBand: resampleToleranceByBand(
-                simplifyToleranceByAdminLevel.admin1?.toleranceByBand,
+              multiplierByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin1?.multiplierByBand,
                 baseGeometryConfig.zoomBandBoundaries,
                 zoomBandBoundaries,
-                toleranceFallback,
+                multiplierFallback,
               ),
-              retryToleranceByBand: resampleToleranceByBand(
-                simplifyToleranceByAdminLevel.admin1?.retryToleranceByBand,
+              minRatioByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin1?.minRatioByBand,
                 baseGeometryConfig.zoomBandBoundaries,
                 zoomBandBoundaries,
-                toleranceFallback,
+                minRatioFallback,
+              ),
+              maxRatioByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin1?.maxRatioByBand,
+                baseGeometryConfig.zoomBandBoundaries,
+                zoomBandBoundaries,
+                maxRatioFallback,
               ),
             },
             admin2: {
               ...simplifyToleranceByAdminLevel.admin2,
-              toleranceByBand: resampleToleranceByBand(
-                simplifyToleranceByAdminLevel.admin2?.toleranceByBand,
+              multiplierByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin2?.multiplierByBand,
                 baseGeometryConfig.zoomBandBoundaries,
                 zoomBandBoundaries,
-                toleranceFallback,
+                multiplierFallback,
               ),
-              retryToleranceByBand: resampleToleranceByBand(
-                simplifyToleranceByAdminLevel.admin2?.retryToleranceByBand,
+              minRatioByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin2?.minRatioByBand,
                 baseGeometryConfig.zoomBandBoundaries,
                 zoomBandBoundaries,
-                toleranceFallback,
+                minRatioFallback,
+              ),
+              maxRatioByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin2?.maxRatioByBand,
+                baseGeometryConfig.zoomBandBoundaries,
+                zoomBandBoundaries,
+                maxRatioFallback,
               ),
             },
             admin3Plus: {
               ...simplifyToleranceByAdminLevel.admin3Plus,
-              toleranceByBand: resampleToleranceByBand(
-                simplifyToleranceByAdminLevel.admin3Plus?.toleranceByBand,
+              multiplierByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin3Plus?.multiplierByBand,
                 baseGeometryConfig.zoomBandBoundaries,
                 zoomBandBoundaries,
-                toleranceFallback,
+                multiplierFallback,
               ),
-              retryToleranceByBand: resampleToleranceByBand(
-                simplifyToleranceByAdminLevel.admin3Plus?.retryToleranceByBand,
+              minRatioByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin3Plus?.minRatioByBand,
                 baseGeometryConfig.zoomBandBoundaries,
                 zoomBandBoundaries,
-                toleranceFallback,
+                minRatioFallback,
+              ),
+              maxRatioByBand: resampleToleranceByBand(
+                simplifyToleranceByAdminLevel.admin3Plus?.maxRatioByBand,
+                baseGeometryConfig.zoomBandBoundaries,
+                zoomBandBoundaries,
+                maxRatioFallback,
               ),
             },
           }
@@ -106,7 +145,9 @@ export const ZoomBandConfigSection: React.FC<Props> = ({
         update({
           geometryConfig: {
             toleranceByBand: nextToleranceByBand,
-            retryToleranceByBand: nextRetryToleranceByBand,
+            toleranceMultiplierByBand: nextMultiplierByBand,
+            toleranceMinRatioByBand: nextMinRatioByBand,
+            toleranceMaxRatioByBand: nextMaxRatioByBand,
             simplifyToleranceByAdminLevel: nextSimplifyToleranceByAdminLevel,
             zoomBandBoundaries,
           },


### PR DESCRIPTION
## Summary
- switch geometry simplify tolerance selection to bisection-based `t_base` search using the max-vertex representative feature
- apply per-band tolerance as `clamp(t_base * multiplier, t_base * minRatio, t_base * maxRatio)`
- replace retry simplify loop with bisection-based search and expose diagnostics metadata
- update shape build UI from 2-line editor to 3-line editor (multiplier/min/max) and add search-iteration control
- remove legacy admin-level compatibility keys (`toleranceByBand/retryToleranceByBand/retryCount`) from simplify profile path

## Validation
- `pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator -- --run simplifyProfile.unit.test.ts` (exit 0)

Closes #677
