### PR TITLE
feat(shape): move invalid geometry filtering config to tile emit

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #680 / `codex/feat/shape/invalid-geometry-filter-tileemit-680` / start: 2026-03-02 11:12 JST
 - #677 / `codex/feat/shape/tolerance-bisection-pipeline-677` / start: 2026-03-02 11:03 JST
 - #675 / `codex/docs/shape4/tolerance-bisection-spec-plan-675` / start: 2026-03-02 10:27 JST
 - #670 / `codex/fix/shape/step5-elapsed-time-consistency-670` / start: 2026-03-02 01:02 JST
@@ -152,6 +153,8 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- update: 2026-03-02 11:18 JST #680 invalid geometry filtering の設定保持先を `sourceConfig` から `tileEmitConfig` へ移設。原因は Stage責務に対して設定配置が不整合だったこと。発生範囲は `packages/gis-sdk` 型定義、`packages/shape-api` デフォルト、`plugins/shape-plugin` の build-config UI/patch merge/source stage 実行参照、および `packages/ui/accordion-config` の TileEmit セクション拡張。修正として `TileEmitConfig.invalidGeometryFilter` を追加し Source 側定義を除去、Sourceカードを Intake Guard と Invalid Filter に分離して後者を TileEmit セクションへ移設。旧設定互換読み込みは未実装（追加しない方針）。検証: `pnpm -w turbo run build --filter @hierarchidb/gis-sdk --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-api` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/vt-orchestrator` exit 0、`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/mergeBuildConfig.unit.test.ts` exit 0。
+- start: 2026-03-02 11:12 JST #680 を起票（https://github.com/kubohiroya/hierarchidb/issues/680）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/feat/shape/invalid-geometry-filter-tileemit-680` を作成して、invalid geometry filtering 設定の Source→TileEmit 移設に着手。
 - start: 2026-03-02 11:03 JST #677 を再オープンし実装タスクへ再定義（https://github.com/kubohiroya/hierarchidb/issues/677）。Project `hierarchidb` の Status を `In Progress` に更新し、ブランチ `codex/feat/shape/tolerance-bisection-pipeline-677` を作成。#675（仕様/計画）は main 反映済みのため close し、#675→#677 の順で Shape ビルドパイプライン改修を一体運用で開始。
 - update: 2026-03-02 10:40 JST #675 Shape4 Geometry tolerance 新方式の文書化を実施。`docs/spec/shape4-geometry-tolerance-bisection-spec.md` に仕様（`t_base` 2分法、`multiplier/minRatio/maxRatio`、ToneCurveEditor 3線化、失敗時挙動、段階移行）を記載し、`plans/shape4-geometry-tolerance-bisection-execplan.md` に実装マイルストーンと検証手順を定義。確認: `test -f docs/spec/shape4-geometry-tolerance-bisection-spec.md` exit 0、`test -f plans/shape4-geometry-tolerance-bisection-execplan.md` exit 0、`rg -n \"t_base|2分法|multiplier|minRatio|maxRatio|ToneCurveEditor|0.0..2.0|6553\" docs/spec/shape4-geometry-tolerance-bisection-spec.md plans/shape4-geometry-tolerance-bisection-execplan.md` exit 0。
 - start: 2026-03-02 10:27 JST #675 を起票（https://github.com/kubohiroya/hierarchidb/issues/675）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/docs/shape4/tolerance-bisection-spec-plan-675` を作成し、Shape4 の tolerance 新方式（`t_base` 2分法 + `multiplier/min/max`）仕様/作業計画ドキュメント整備に着手。

--- a/packages/gis-sdk/src/config.ts
+++ b/packages/gis-sdk/src/config.ts
@@ -17,7 +17,6 @@ export interface SourceConfig {
   retryLimit: number;
   retryBackoff: 'linear' | 'exponential';
   geometryIntakeGuard?: FetchGeometryIntakeGuardConfig;
-  invalidGeometryFilter?: FetchInvalidGeometryFilterConfig;
 }
 
 export type GeometryIntakeValidationLevel = 'off' | 'basic' | 'strict';
@@ -177,6 +176,7 @@ export interface TileEmitConfig {
   enableTopojsonSimplify: boolean;
   maxConcurrent: number;
   dynamicConcurrency?: DynamicConcurrencyConfig;
+  invalidGeometryFilter?: FetchInvalidGeometryFilterConfig;
   tolerance: number;
   extent: number;
   buffer?: number;

--- a/packages/shape-api/src/defaults.ts
+++ b/packages/shape-api/src/defaults.ts
@@ -20,13 +20,6 @@ export const DEFAULT_BUILD_CONFIG = {
       normalizeRingOrientation: true,
       keepBaselineSnapshot: true,
     },
-    invalidGeometryFilter: {
-      area: false,
-      lineLength: false,
-      maxEdgeLength: false,
-      selfIntersection: false,
-      triangleRingRatio: false,
-    },
   },
   geometryConfig: {
     zoomBandBoundaries: DEFAULT_ZOOM_BAND_BOUNDARIES,
@@ -94,6 +87,13 @@ export const DEFAULT_BUILD_CONFIG = {
     boundaryDisableAtZoomOrAbove: 3,
   },
   tileEmitConfig: {
+    invalidGeometryFilter: {
+      area: false,
+      lineLength: false,
+      maxEdgeLength: false,
+      selfIntersection: false,
+      triangleRingRatio: false,
+    },
     enableTopojsonSimplify: false,
     tolerance: 0,
     extent: 8192,

--- a/packages/ui/accordion-config/src/build-config/TileEmitConfigSection.tsx
+++ b/packages/ui/accordion-config/src/build-config/TileEmitConfigSection.tsx
@@ -24,6 +24,7 @@ import {
   Update as UpdateIcon,
 } from '@mui/icons-material';
 import { useEffect, useMemo } from 'react';
+import type { ReactNode } from 'react';
 import type { BaseBuildConfig, DynamicConcurrencyConfig } from '@hierarchidb/gis-sdk';
 import { BuildConfigAccordionSummary } from './BuildConfigAccordionSummary.js';
 import { WorkerNumberConfigCard } from './WorkerNumberConfigCard.js';
@@ -39,6 +40,7 @@ type Props<TDataSourceName = unknown> = {
   update: (partial: Partial<BaseBuildConfig<TDataSourceName>>) => void;
   showConcurrencyCard?: boolean;
   disableHoverLift?: boolean;
+  additionalCards?: ReactNode;
 };
 
 const createDefaultDynamicConcurrency = (maxConcurrent: number): DynamicConcurrencyConfig => ({
@@ -58,6 +60,7 @@ export const TileEmitConfigSection = <TDataSourceName,>({
   update,
   showConcurrencyCard = true,
   disableHoverLift = false,
+  additionalCards,
 }: Props<TDataSourceName>) => {
   const resolvedMaxConcurrent = Number.isFinite(buildConfig.tileEmitConfig.maxConcurrent)
     ? buildConfig.tileEmitConfig.maxConcurrent
@@ -374,6 +377,11 @@ export const TileEmitConfigSection = <TDataSourceName,>({
                   )}
                 </Typography>
               </Stack>
+            </Paper>
+          ) : null}
+          {additionalCards ? (
+            <Paper variant="outlined" sx={{ p: 2, ...hoverCardSx }}>
+              {additionalCards}
             </Paper>
           ) : null}
 

--- a/plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/mergeBuildConfig.unit.test.ts
@@ -112,13 +112,6 @@ describe('applyBuildConfigPatch', () => {
           normalizeRingOrientation: true,
           keepBaselineSnapshot: true,
         },
-        invalidGeometryFilter: {
-          area: true,
-          lineLength: false,
-          maxEdgeLength: true,
-          selfIntersection: false,
-          triangleRingRatio: true,
-        },
       },
       geometryConfig: {
         executionLogLevel: 'verbose',
@@ -146,6 +139,13 @@ describe('applyBuildConfigPatch', () => {
         },
       },
       tileEmitConfig: {
+        invalidGeometryFilter: {
+          area: true,
+          lineLength: false,
+          maxEdgeLength: true,
+          selfIntersection: false,
+          triangleRingRatio: true,
+        },
         outputQualityGuard: {
           enabled: true,
           minZoom: 3,
@@ -163,8 +163,8 @@ describe('applyBuildConfigPatch', () => {
     });
 
     expect(merged.sourceConfig.geometryIntakeGuard?.validationLevel).toBe('strict');
-    expect(merged.sourceConfig.invalidGeometryFilter?.area).toBe(true);
-    expect(merged.sourceConfig.invalidGeometryFilter?.triangleRingRatio).toBe(true);
+    expect(merged.tileEmitConfig.invalidGeometryFilter?.area).toBe(true);
+    expect(merged.tileEmitConfig.invalidGeometryFilter?.triangleRingRatio).toBe(true);
     expect(merged.geometryConfig.executionLogLevel).toBe('verbose');
     expect(merged.geometryConfig.anomalyDetection?.scoreThreshold).toBe(1.8);
     expect(merged.geometryConfig.anomalyDetection?.geojson?.maxTriangleShareDriftPercent).toBe(4);

--- a/plugins/shape-plugin/src/services/utils/utils.ts
+++ b/plugins/shape-plugin/src/services/utils/utils.ts
@@ -351,12 +351,6 @@ export function applyBuildConfigPatch(
           ...overrides.sourceConfig.geometryIntakeGuard,
         }
         : base.sourceConfig.geometryIntakeGuard,
-      invalidGeometryFilter: overrides.sourceConfig.invalidGeometryFilter
-        ? {
-          ...(base.sourceConfig.invalidGeometryFilter ?? {}),
-          ...overrides.sourceConfig.invalidGeometryFilter,
-        }
-        : base.sourceConfig.invalidGeometryFilter,
     }
     : base.sourceConfig;
 
@@ -395,7 +389,16 @@ export function applyBuildConfigPatch(
     }
     : base.geometryConfig;
   const tileEmitConfig = overrides.tileEmitConfig
-    ? { ...base.tileEmitConfig, ...overrides.tileEmitConfig }
+    ? {
+      ...base.tileEmitConfig,
+      ...overrides.tileEmitConfig,
+      invalidGeometryFilter: overrides.tileEmitConfig.invalidGeometryFilter
+        ? {
+          ...(base.tileEmitConfig.invalidGeometryFilter ?? {}),
+          ...overrides.tileEmitConfig.invalidGeometryFilter,
+        }
+        : base.tileEmitConfig.invalidGeometryFilter,
+    }
     : base.tileEmitConfig;
 
   const cleanupConfig = overrides.cleanupConfig

--- a/plugins/shape-plugin/src/services/vt/shapeSourceStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapeSourceStage.ts
@@ -825,7 +825,7 @@ const createSourceHandler = (params: {
   const strategy = factory.create(strategyId);
   const taskQueue = new VtTaskQueueDb();
   const retryConfig = buildRetryConfig(params.buildConfig);
-  const invalidGeometryFilter = params.buildConfig.sourceConfig.invalidGeometryFilter;
+  const invalidGeometryFilter = params.buildConfig.tileEmitConfig.invalidGeometryFilter;
   const hasInvalidGeometryFilter = Boolean(
     invalidGeometryFilter
     && (

--- a/plugins/shape-plugin/src/ui/components/build-config/ShapeBuildConfigStep.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/ShapeBuildConfigStep.tsx
@@ -10,7 +10,10 @@ import {
 import { GeometryConfigSection } from './GeometryConfigSection.js';
 import { ZoomBandConfigSection } from './ZoomBandConfigSection.js';
 import { CacheManagementSection } from './CacheManagementSection.tsx';
-import { SourceInvalidGeometryFilterCard } from './SourceInvalidGeometryFilterCard.tsx';
+import {
+  SourceGeometryIntakeGuardCard,
+  TileEmitInvalidGeometryFilterCard,
+} from './SourceInvalidGeometryFilterCard.tsx';
 import { useShapeBuildConfigStep } from './useShapeBuildConfigStep.js';
 import { useHeapPressureMonitor } from '@hierarchidb/ui-memory';
 import { useTranslation } from '~/ui/i18n';
@@ -204,7 +207,7 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
         disabled={disabled}
         disableHoverLift
         additionalCards={
-          <SourceInvalidGeometryFilterCard
+          <SourceGeometryIntakeGuardCard
             config={workingConfig}
             onChange={updateWorkingConfig}
             disabled={disabled}
@@ -225,6 +228,14 @@ const ShapeBuildConfigContent: React.FC<ShapeDialogStepProps> = ({
         showConcurrencyCard={false}
         disabled={disabled}
         disableHoverLift
+        additionalCards={(
+          <TileEmitInvalidGeometryFilterCard
+            config={workingConfig}
+            onChange={updateWorkingConfig}
+            disabled={disabled}
+            disableHoverLift
+          />
+        )}
       />
       <CacheManagementSection
         config={workingConfig}

--- a/plugins/shape-plugin/src/ui/components/build-config/SourceInvalidGeometryFilterCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/SourceInvalidGeometryFilterCard.tsx
@@ -10,7 +10,10 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { Rule as RuleIcon } from '@mui/icons-material';
+import {
+  Rule as RuleIcon,
+  Security as SecurityIcon,
+} from '@mui/icons-material';
 import { BuildConfigSectionTitle, getBuildConfigHoverCardSx } from '@hierarchidb/ui-accordion-config';
 import { useTranslation } from '~/ui/i18n';
 import type { ShapeBuildConfig } from '~/common/types/index';
@@ -25,7 +28,42 @@ type Props = {
   disableHoverLift?: boolean;
 };
 
-export const SourceInvalidGeometryFilterCard: React.FC<Props> = ({
+type InvalidGeometryFilterState = {
+  area: boolean;
+  lineLength: boolean;
+  maxEdgeLength: boolean;
+  selfIntersection: boolean;
+  triangleRingRatio: boolean;
+};
+
+type GeometryIntakeGuardState = {
+  validationLevel: 'off' | 'basic' | 'strict';
+  dedupeEpsilon: number;
+  minRingAreaThreshold: number;
+  normalizeRingOrientation: boolean;
+  keepBaselineSnapshot: boolean;
+};
+
+const resolveGeometryIntakeGuard = (config: ShapeBuildConfig): GeometryIntakeGuardState => {
+  const guard = config.sourceConfig.geometryIntakeGuard;
+  return {
+    validationLevel: guard?.validationLevel ?? 'off',
+    dedupeEpsilon: guard?.dedupeEpsilon ?? 0.000001,
+    minRingAreaThreshold: guard?.minRingAreaThreshold ?? 0,
+    normalizeRingOrientation: guard?.normalizeRingOrientation ?? true,
+    keepBaselineSnapshot: guard?.keepBaselineSnapshot ?? true,
+  };
+};
+
+const resolveInvalidGeometryFilter = (config: ShapeBuildConfig): InvalidGeometryFilterState => ({
+  area: config.tileEmitConfig.invalidGeometryFilter?.area ?? false,
+  lineLength: config.tileEmitConfig.invalidGeometryFilter?.lineLength ?? false,
+  maxEdgeLength: config.tileEmitConfig.invalidGeometryFilter?.maxEdgeLength ?? false,
+  selfIntersection: config.tileEmitConfig.invalidGeometryFilter?.selfIntersection ?? false,
+  triangleRingRatio: config.tileEmitConfig.invalidGeometryFilter?.triangleRingRatio ?? false,
+});
+
+export const SourceGeometryIntakeGuardCard: React.FC<Props> = ({
   config,
   onChange,
   disabled,
@@ -33,42 +71,11 @@ export const SourceInvalidGeometryFilterCard: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const hoverCardSx = getBuildConfigHoverCardSx(disabled, disableHoverLift);
-  const guard = config.sourceConfig.geometryIntakeGuard;
+  const resolvedGuard = useMemo(() => resolveGeometryIntakeGuard(config), [config]);
 
-  const resolved = useMemo(()=>({
-    area: config.sourceConfig.invalidGeometryFilter?.area ?? false,
-    lineLength: config.sourceConfig.invalidGeometryFilter?.lineLength ?? false,
-    maxEdgeLength: config.sourceConfig.invalidGeometryFilter?.maxEdgeLength ?? false,
-    selfIntersection: config.sourceConfig.invalidGeometryFilter?.selfIntersection ?? false,
-    triangleRingRatio: config.sourceConfig.invalidGeometryFilter?.triangleRingRatio ?? false,
-  } as const),[config.sourceConfig.invalidGeometryFilter?.area, config.sourceConfig.invalidGeometryFilter?.lineLength, config.sourceConfig.invalidGeometryFilter?.maxEdgeLength, config.sourceConfig.invalidGeometryFilter?.selfIntersection, config.sourceConfig.invalidGeometryFilter?.triangleRingRatio]);
-  const resolvedGuard = useMemo(()=>({
-    validationLevel: guard?.validationLevel ?? 'off',
-    dedupeEpsilon: guard?.dedupeEpsilon ?? 0.000001,
-    minRingAreaThreshold: guard?.minRingAreaThreshold ?? 0,
-    normalizeRingOrientation: guard?.normalizeRingOrientation ?? true,
-    keepBaselineSnapshot: guard?.keepBaselineSnapshot ?? true,
-  } as const),[
-    guard?.validationLevel, guard?.dedupeEpsilon, guard?.minRingAreaThreshold, guard?.normalizeRingOrientation, guard?.keepBaselineSnapshot
-  ]);
-
-  const updateFilter = useCallback((partial: Partial<typeof resolved>): void => {
+  const updateGuard = useCallback((partial: Partial<GeometryIntakeGuardState>): void => {
     onChange((prevConfig) => {
-      const current = prevConfig.sourceConfig.invalidGeometryFilter ?? resolved;
-      return applyBuildConfigPatch(prevConfig, {
-        sourceConfig: {
-          ...prevConfig.sourceConfig,
-          invalidGeometryFilter: {
-            ...current,
-            ...partial,
-          },
-        },
-      });
-    });
-  }, [onChange, resolved]);
-  const updateGuard = useCallback((partial: Partial<typeof resolvedGuard>): void => {
-    onChange((prevConfig) => {
-      const current = prevConfig.sourceConfig.geometryIntakeGuard ?? resolvedGuard;
+      const current = resolveGeometryIntakeGuard(prevConfig);
       return applyBuildConfigPatch(prevConfig, {
         sourceConfig: {
           ...prevConfig.sourceConfig,
@@ -79,78 +86,24 @@ export const SourceInvalidGeometryFilterCard: React.FC<Props> = ({
         },
       });
     });
-  }, [onChange, resolvedGuard]);
-  type SwitchItem = {
-    checked: boolean;
-    disabled: boolean;
-    label: string;
-    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  };
+  }, [onChange]);
+
   const isDisabled = Boolean(disabled);
-  const switchGroups: Array<Array<SwitchItem>> = [
-    [
-      {
-        checked: resolvedGuard.normalizeRingOrientation,
-        disabled: isDisabled,
-        label: t('processing.source.geometryIntakeGuard.normalizeRingOrientation', 'Normalize ring orientation'),
-        onChange: (event) => updateGuard({ normalizeRingOrientation: event.target.checked }),
-      },
-      {
-        checked: resolvedGuard.keepBaselineSnapshot,
-        disabled: isDisabled,
-        label: t('processing.source.geometryIntakeGuard.keepBaselineSnapshot', 'Keep baseline snapshot for anomaly scoring'),
-        onChange: (event) => updateGuard({ keepBaselineSnapshot: event.target.checked }),
-      },
-    ],
-    [
-      {
-        checked: resolved.selfIntersection,
-        disabled: isDisabled,
-        label: t('processing.source.invalidGeometryFilter.selfIntersection', 'Self intersection'),
-        onChange: (event) => updateFilter({ selfIntersection: event.target.checked }),
-      },
-      {
-        checked: resolved.triangleRingRatio,
-        disabled: isDisabled,
-        label: t('processing.source.invalidGeometryFilter.triangleRingRatio', 'Triangle ring ratio'),
-        onChange: (event) => updateFilter({ triangleRingRatio: event.target.checked }),
-      },
-    ],
-    [
-      {
-        checked: resolved.area,
-        disabled: isDisabled,
-        label: t('processing.source.invalidGeometryFilter.area', 'Area'),
-        onChange: (event) => updateFilter({ area: event.target.checked }),
-      },
-      {
-        checked: resolved.lineLength,
-        disabled: isDisabled,
-        label: t('processing.source.invalidGeometryFilter.lineLength', 'Line length'),
-        onChange: (event) => updateFilter({ lineLength: event.target.checked }),
-      },
-      {
-        checked: resolved.maxEdgeLength,
-        disabled: isDisabled,
-        label: t('processing.source.invalidGeometryFilter.maxEdgeLength', 'Max edge length'),
-        onChange: (event) => updateFilter({ maxEdgeLength: event.target.checked }),
-      },
-    ],
-  ];
 
   return (
     <Paper variant="outlined" sx={{ p: 2, ...hoverCardSx }}>
       <Stack spacing={1.5} sx={{ opacity: disabled ? 0.6 : 1 }}>
         <BuildConfigSectionTitle
-          icon={<RuleIcon fontSize="small" color="primary" />}
-          title={t('processing.source.invalidGeometryFilter.title', 'Invalid geometry filtering')}
+          icon={<SecurityIcon fontSize="small" color="primary" />}
+          title={t('processing.source.geometryIntakeGuard.title', 'Geometry intake guard')}
         />
         <Typography variant="body2" color="text.secondary">
           {t(
-            'processing.source.invalidGeometryFilter.description',
-            'Run additional invalid-shape checks after small-shape filtering.',
+            'processing.source.geometryIntakeGuard.description',
+            'Configure normalization and strictness for source geometry intake checks.',
           )}
         </Typography>
+
         <Grid container spacing={1.5} alignItems="flex-start">
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth disabled={disabled}>
@@ -163,12 +116,8 @@ export const SourceInvalidGeometryFilterCard: React.FC<Props> = ({
                 exclusive
                 value={resolvedGuard.validationLevel}
                 onChange={(_event, value) => {
-                  if (value === null) {
-                    return;
-                  }
-                  if (value !== 'off' && value !== 'basic' && value !== 'strict') {
-                    return;
-                  }
+                  if (value === null) return;
+                  if (value !== 'off' && value !== 'basic' && value !== 'strict') return;
                   updateGuard({ validationLevel: value });
                 }}
               >
@@ -207,16 +156,120 @@ export const SourceInvalidGeometryFilterCard: React.FC<Props> = ({
             />
           </Grid>
         </Grid>
+
+        <Grid container spacing={1.5}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <FormControlLabel
+              control={<Switch checked={resolvedGuard.normalizeRingOrientation} onChange={(event) => updateGuard({ normalizeRingOrientation: event.target.checked })} />}
+              disabled={isDisabled}
+              label={t('processing.source.geometryIntakeGuard.normalizeRingOrientation', 'Normalize ring orientation')}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <FormControlLabel
+              control={<Switch checked={resolvedGuard.keepBaselineSnapshot} onChange={(event) => updateGuard({ keepBaselineSnapshot: event.target.checked })} />}
+              disabled={isDisabled}
+              label={t('processing.source.geometryIntakeGuard.keepBaselineSnapshot', 'Keep baseline snapshot for anomaly scoring')}
+            />
+          </Grid>
+        </Grid>
+      </Stack>
+    </Paper>
+  );
+};
+
+export const TileEmitInvalidGeometryFilterCard: React.FC<Props> = ({
+  config,
+  onChange,
+  disabled,
+  disableHoverLift = false,
+}) => {
+  const { t } = useTranslation();
+  const hoverCardSx = getBuildConfigHoverCardSx(disabled, disableHoverLift);
+  const resolved = useMemo(() => resolveInvalidGeometryFilter(config), [config]);
+
+  const updateFilter = useCallback((partial: Partial<InvalidGeometryFilterState>): void => {
+    onChange((prevConfig) => {
+      const current = resolveInvalidGeometryFilter(prevConfig);
+      return applyBuildConfigPatch(prevConfig, {
+        tileEmitConfig: {
+          ...prevConfig.tileEmitConfig,
+          invalidGeometryFilter: {
+            ...current,
+            ...partial,
+          },
+        },
+      });
+    });
+  }, [onChange]);
+
+  type SwitchItem = {
+    checked: boolean;
+    disabled: boolean;
+    label: string;
+    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  };
+
+  const isDisabled = Boolean(disabled);
+  const switchGroups: Array<Array<SwitchItem>> = [
+    [
+      {
+        checked: resolved.selfIntersection,
+        disabled: isDisabled,
+        label: t('processing.tileEmit.invalidGeometryFilter.selfIntersection', 'Self intersection'),
+        onChange: (event) => updateFilter({ selfIntersection: event.target.checked }),
+      },
+      {
+        checked: resolved.triangleRingRatio,
+        disabled: isDisabled,
+        label: t('processing.tileEmit.invalidGeometryFilter.triangleRingRatio', 'Triangle ring ratio'),
+        onChange: (event) => updateFilter({ triangleRingRatio: event.target.checked }),
+      },
+    ],
+    [
+      {
+        checked: resolved.area,
+        disabled: isDisabled,
+        label: t('processing.tileEmit.invalidGeometryFilter.area', 'Area'),
+        onChange: (event) => updateFilter({ area: event.target.checked }),
+      },
+      {
+        checked: resolved.lineLength,
+        disabled: isDisabled,
+        label: t('processing.tileEmit.invalidGeometryFilter.lineLength', 'Line length'),
+        onChange: (event) => updateFilter({ lineLength: event.target.checked }),
+      },
+      {
+        checked: resolved.maxEdgeLength,
+        disabled: isDisabled,
+        label: t('processing.tileEmit.invalidGeometryFilter.maxEdgeLength', 'Max edge length'),
+        onChange: (event) => updateFilter({ maxEdgeLength: event.target.checked }),
+      },
+    ],
+  ];
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, ...hoverCardSx }}>
+      <Stack spacing={1.5} sx={{ opacity: disabled ? 0.6 : 1 }}>
+        <BuildConfigSectionTitle
+          icon={<RuleIcon fontSize="small" color="primary" />}
+          title={t('processing.tileEmit.invalidGeometryFilter.title', 'Invalid geometry filtering')}
+        />
+        <Typography variant="body2" color="text.secondary">
+          {t(
+            'processing.tileEmit.invalidGeometryFilter.description',
+            'Run additional invalid-shape checks in the TileEmit-stage filtering pipeline.',
+          )}
+        </Typography>
+
         <Grid container spacing={1.5}>
           {switchGroups.map((group, groupIndex) => (
-            <Grid size={{ xs: 12, md: 4 }} key={`switch-group-${String(groupIndex)}`}>
+            <Grid size={{ xs: 12, md: 6 }} key={`switch-group-${String(groupIndex)}`}>
               <Stack spacing={0.75}>
                 {group.map((item) => (
                   <FormControlLabel
                     key={item.label}
-                    control={(
-                      <Switch checked={item.checked} onChange={item.onChange} />
-                    )}
+                    control={<Switch checked={item.checked} onChange={item.onChange} />}
                     disabled={item.disabled}
                     label={item.label}
                   />


### PR DESCRIPTION
## Summary
- move invalid geometry filtering config from `sourceConfig` to `tileEmitConfig`
- keep geometry intake guard in Source settings and move invalid-geometry filter controls to TileEmit settings
- add `additionalCards` slot to `TileEmitConfigSection` for plugin-specific controls
- update source-stage runtime reference to read `buildConfig.tileEmitConfig.invalidGeometryFilter`
- update shape build config patch/merge tests for the new config location
- intentionally do not implement legacy compatibility loading for old config key

## Validation
- `pnpm -w turbo run build --filter @hierarchidb/gis-sdk --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-api` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/vt-orchestrator` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/mergeBuildConfig.unit.test.ts` (exit 0)

Closes #680
