### PR TITLE
fix(shape): disable intake guard UI and reorder simplify/tileemit cards

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #682 / `codex/fix/shape/disable-intake-guard-and-card-order-682` / start: 2026-03-02 11:36 JST
 - #680 / `codex/feat/shape/invalid-geometry-filter-tileemit-680` / start: 2026-03-02 11:12 JST
 - #677 / `codex/feat/shape/tolerance-bisection-pipeline-677` / start: 2026-03-02 11:03 JST
 - #675 / `codex/docs/shape4/tolerance-bisection-spec-plan-675` / start: 2026-03-02 10:27 JST
@@ -153,6 +154,8 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- update: 2026-03-02 11:40 JST #682 原因は Source Geometry Intake Guard が実行ロジック未接続のまま編集可能UIとして残っていたこと、および Simplify 3線カード順と入力ラベルが運用意図（赤/青/灰・ズーム表記）に一致していなかったこと。発生範囲は `plugins/shape-plugin` の build-config UI（`SourceInvalidGeometryFilterCard.tsx`, `SimplifyToleranceByAdminLevelCard.tsx`）と `packages/ui/accordion-config` の `TileEmitConfigSection.tsx`。修正として Intake Guard を常時 disabled + 将来実装注記へ変更、Simplify カード順を `max(赤)→multiplier(青)→min(灰)` に変更しラベルを `Zoom {{zoom}}` へ修正、TileEmit カード順を `Invalid geometry filtering → Tile geometry & margin` へ変更。検証: `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/ui-accordion-config` exit 0、`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/mergeBuildConfig.unit.test.ts` exit 0。
+- start: 2026-03-02 11:36 JST #682 を起票（https://github.com/kubohiroya/hierarchidb/issues/682）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape/disable-intake-guard-and-card-order-682` を作成して、Step5 の Source Geometry Intake Guard 無効化、Simplify 3線順序修正、TileEmit カード順序修正、ラベル不具合修正に着手。
 - update: 2026-03-02 11:18 JST #680 invalid geometry filtering の設定保持先を `sourceConfig` から `tileEmitConfig` へ移設。原因は Stage責務に対して設定配置が不整合だったこと。発生範囲は `packages/gis-sdk` 型定義、`packages/shape-api` デフォルト、`plugins/shape-plugin` の build-config UI/patch merge/source stage 実行参照、および `packages/ui/accordion-config` の TileEmit セクション拡張。修正として `TileEmitConfig.invalidGeometryFilter` を追加し Source 側定義を除去、Sourceカードを Intake Guard と Invalid Filter に分離して後者を TileEmit セクションへ移設。旧設定互換読み込みは未実装（追加しない方針）。検証: `pnpm -w turbo run build --filter @hierarchidb/gis-sdk --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/shape-api` exit 0、`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/vt-orchestrator` exit 0、`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/mergeBuildConfig.unit.test.ts` exit 0。
 - start: 2026-03-02 11:12 JST #680 を起票（https://github.com/kubohiroya/hierarchidb/issues/680）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/feat/shape/invalid-geometry-filter-tileemit-680` を作成して、invalid geometry filtering 設定の Source→TileEmit 移設に着手。
 - start: 2026-03-02 11:03 JST #677 を再オープンし実装タスクへ再定義（https://github.com/kubohiroya/hierarchidb/issues/677）。Project `hierarchidb` の Status を `In Progress` に更新し、ブランチ `codex/feat/shape/tolerance-bisection-pipeline-677` を作成。#675（仕様/計画）は main 反映済みのため close し、#675→#677 の順で Shape ビルドパイプライン改修を一体運用で開始。

--- a/packages/ui/accordion-config/src/build-config/TileEmitConfigSection.tsx
+++ b/packages/ui/accordion-config/src/build-config/TileEmitConfigSection.tsx
@@ -102,6 +102,12 @@ export const TileEmitConfigSection = <TDataSourceName,>({
       </AccordionSummary>
       <AccordionDetails sx={{ p: 1 }}>
         <Stack spacing={3}>
+          {additionalCards ? (
+            <Paper variant="outlined" sx={{ p: 2, ...hoverCardSx }}>
+              {additionalCards}
+            </Paper>
+          ) : null}
+
           <Paper variant="outlined" sx={{ p: 2, ...hoverCardSx }}>
             <Stack spacing={2}>
               <BuildConfigSectionTitle
@@ -377,11 +383,6 @@ export const TileEmitConfigSection = <TDataSourceName,>({
                   )}
                 </Typography>
               </Stack>
-            </Paper>
-          ) : null}
-          {additionalCards ? (
-            <Paper variant="outlined" sx={{ p: 2, ...hoverCardSx }}>
-              {additionalCards}
             </Paper>
           ) : null}
 

--- a/plugins/shape-plugin/src/ui/components/build-config/SimplifyToleranceByAdminLevelCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/SimplifyToleranceByAdminLevelCard.tsx
@@ -215,6 +215,11 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
 
   const xMarks = geometryConfig.zoomBandBoundaries.map((value) => ({ value, label: String(value) }));
   const iterationMarks = [8, 16, 24, 32, 48, 64].map((value) => ({ value, label: String(value) }));
+  const buildZoomLabel = useCallback((zoomValue: number): string => (
+    t('processing.geometry.simplifyTolerance.zoomLabel', 'Zoom {{zoom}}', {
+      zoom: Number.isFinite(zoomValue) ? Number.parseFloat(zoomValue.toFixed(3)) : '-',
+    })
+  ), [t]);
 
   const resolvedMultiplierAnchors = buildToneCurveAnchorsFromToleranceByBand(
     activeValues.multiplierByBand,
@@ -479,6 +484,43 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
                   sx={{
                     mt: 1,
                     p: 1,
+                    borderColor: '#ef4444',
+                    width: '100%',
+                    overflow: 'visible',
+                  }}
+                >
+                  <Stack direction="row" spacing={1} sx={{ flexWrap: 'nowrap', overflowX: 'auto', pt: 1 }}>
+                    {resolvedMaxAnchors.map((anchor, index) => (
+                      <TextField
+                        key={`max-anchor-${index}`}
+                        label={buildZoomLabel(anchor.x)}
+                        type="number"
+                        size="small"
+                        value={clampRatio(anchor.y)}
+                        inputProps={{
+                          step: 0.05,
+                          min: CURVE_Y_RANGE[0],
+                          max: CURVE_Y_RANGE[1],
+                        }}
+                        disabled={controlsDisabled}
+                        onChange={(event) => {
+                          const nextValue = Number.parseFloat(event.target.value);
+                          if (!Number.isFinite(nextValue)) return;
+                          const next = [...activeEditable.maxRatioByBand];
+                          next[index] = clampRatio(nextValue);
+                          updateBands({ maxRatioByBand: next });
+                        }}
+                        sx={spinnerTextFieldSx}
+                      />
+                    ))}
+                  </Stack>
+                </Paper>
+
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    mt: 1,
+                    p: 1,
                     borderColor: '#0b5ed7',
                     width: '100%',
                     overflow: 'visible',
@@ -488,7 +530,7 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
                     {resolvedMultiplierAnchors.map((anchor, index) => (
                       <TextField
                         key={`multiplier-anchor-${index}`}
-                        label={String(clampRatio(anchor.x))}
+                        label={buildZoomLabel(anchor.x)}
                         type="number"
                         size="small"
                         value={clampRatio(anchor.y)}
@@ -525,7 +567,7 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
                     {resolvedMinAnchors.map((anchor, index) => (
                       <TextField
                         key={`min-anchor-${index}`}
-                        label={String(clampRatio(anchor.x))}
+                        label={buildZoomLabel(anchor.x)}
                         type="number"
                         size="small"
                         value={clampRatio(anchor.y)}
@@ -541,43 +583,6 @@ export const SimplifyToleranceByAdminLevelCard: React.FC<Props> = ({
                           const next = [...activeEditable.minRatioByBand];
                           next[index] = clampRatio(nextValue);
                           updateBands({ minRatioByBand: next });
-                        }}
-                        sx={spinnerTextFieldSx}
-                      />
-                    ))}
-                  </Stack>
-                </Paper>
-
-                <Paper
-                  variant="outlined"
-                  sx={{
-                    mt: 1,
-                    p: 1,
-                    borderColor: '#ef4444',
-                    width: '100%',
-                    overflow: 'visible',
-                  }}
-                >
-                  <Stack direction="row" spacing={1} sx={{ flexWrap: 'nowrap', overflowX: 'auto', pt: 1 }}>
-                    {resolvedMaxAnchors.map((anchor, index) => (
-                      <TextField
-                        key={`max-anchor-${index}`}
-                        label={String(clampRatio(anchor.x))}
-                        type="number"
-                        size="small"
-                        value={clampRatio(anchor.y)}
-                        inputProps={{
-                          step: 0.05,
-                          min: CURVE_Y_RANGE[0],
-                          max: CURVE_Y_RANGE[1],
-                        }}
-                        disabled={controlsDisabled}
-                        onChange={(event) => {
-                          const nextValue = Number.parseFloat(event.target.value);
-                          if (!Number.isFinite(nextValue)) return;
-                          const next = [...activeEditable.maxRatioByBand];
-                          next[index] = clampRatio(nextValue);
-                          updateBands({ maxRatioByBand: next });
                         }}
                         sx={spinnerTextFieldSx}
                       />

--- a/plugins/shape-plugin/src/ui/components/build-config/SourceInvalidGeometryFilterCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/SourceInvalidGeometryFilterCard.tsx
@@ -66,11 +66,11 @@ const resolveInvalidGeometryFilter = (config: ShapeBuildConfig): InvalidGeometry
 export const SourceGeometryIntakeGuardCard: React.FC<Props> = ({
   config,
   onChange,
-  disabled,
   disableHoverLift = false,
 }) => {
   const { t } = useTranslation();
-  const hoverCardSx = getBuildConfigHoverCardSx(disabled, disableHoverLift);
+  const guardCardDisabled = true;
+  const hoverCardSx = getBuildConfigHoverCardSx(guardCardDisabled, disableHoverLift);
   const resolvedGuard = useMemo(() => resolveGeometryIntakeGuard(config), [config]);
 
   const updateGuard = useCallback((partial: Partial<GeometryIntakeGuardState>): void => {
@@ -88,11 +88,11 @@ export const SourceGeometryIntakeGuardCard: React.FC<Props> = ({
     });
   }, [onChange]);
 
-  const isDisabled = Boolean(disabled);
+  const isDisabled = true;
 
   return (
     <Paper variant="outlined" sx={{ p: 2, ...hoverCardSx }}>
-      <Stack spacing={1.5} sx={{ opacity: disabled ? 0.6 : 1 }}>
+      <Stack spacing={1.5} sx={{ opacity: guardCardDisabled ? 0.6 : 1 }}>
         <BuildConfigSectionTitle
           icon={<SecurityIcon fontSize="small" color="primary" />}
           title={t('processing.source.geometryIntakeGuard.title', 'Geometry intake guard')}
@@ -103,10 +103,16 @@ export const SourceGeometryIntakeGuardCard: React.FC<Props> = ({
             'Configure normalization and strictness for source geometry intake checks.',
           )}
         </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {t(
+            'processing.source.geometryIntakeGuard.comingSoon',
+            'This guard is reserved for a future implementation. Editing is currently disabled.',
+          )}
+        </Typography>
 
         <Grid container spacing={1.5} alignItems="flex-start">
           <Grid size={{ xs: 12, md: 4 }}>
-            <FormControl fullWidth disabled={disabled}>
+            <FormControl fullWidth disabled>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                 {t('processing.source.geometryIntakeGuard.validationLevel', 'Validation Level')}
               </Typography>
@@ -133,7 +139,7 @@ export const SourceGeometryIntakeGuardCard: React.FC<Props> = ({
               type="number"
               label={t('processing.source.geometryIntakeGuard.dedupeEpsilon', 'Duplicate vertex epsilon')}
               value={resolvedGuard.dedupeEpsilon}
-              disabled={disabled}
+              disabled
               onChange={(event) => {
                 const value = Number(event.target.value);
                 if (!Number.isFinite(value)) return;
@@ -147,7 +153,7 @@ export const SourceGeometryIntakeGuardCard: React.FC<Props> = ({
               type="number"
               label={t('processing.source.geometryIntakeGuard.minRingAreaThreshold', 'Minimum ring area threshold')}
               value={resolvedGuard.minRingAreaThreshold}
-              disabled={disabled}
+              disabled
               onChange={(event) => {
                 const value = Number(event.target.value);
                 if (!Number.isFinite(value)) return;


### PR DESCRIPTION
## Summary
- Disable `Source Geometry Intake Guard` card controls in Step5 and add future-implementation notice.
- Reorder Simplify settings cards to `max(red) -> multiplier(blue) -> min(gray)`.
- Fix simplify input labels to show zoom-aware labels (`Zoom {{zoom}}`) instead of static value.
- Reorder TileEmit section card order to `Invalid geometry filtering -> Tile geometry & margin`.

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/ui-accordion-config` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/mergeBuildConfig.unit.test.ts` (exit 0)

Closes #682
