### PR TITLE
fix(shape-plugin): harden Step5 task sync to prevent DataCloneError

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,6 +38,7 @@
 ## Kanban
 
 ### Doing
+- #689 / `codex/fix/shape/step5-dataclone-hardening-689` / start: 2026-03-02 21:28 JST
 - #688 / `codex/fix/shape/step5-datacloneerror-688` / start: 2026-03-02 20:55 JST
 - #687 / `codex/fix/shape/step5-menu-relocate-687` / start: 2026-03-02 16:49 JST
 - #686 / `codex/refactor/shape/common-stage-reconcile-686` / start: 2026-03-02 15:47 JST
@@ -159,6 +160,7 @@
 - #225 / `codex/fix/shape/session-reset-init-log-flood` / blocked: 2026-02-12 22:05 JST (`@hierarchidb/vt-orchestrator` の既知 TS7016: `topojson-simplify` / `topojson-server`)
 
 ## 今日の運用ログ
+- start: 2026-03-02 21:28 JST #689 を起票（https://github.com/kubohiroya/hierarchidb/issues/689）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。別ワークツリー `/Users/hiroya/WebstormProjects/hierarchidb-codex-step5-689` とブランチ `codex/fix/shape/step5-dataclone-hardening-689` を作成し、Step5 の `DataCloneError` クラッシュ抑止（payload軽量化・task同期最適化・previewメモリ解放）に着手。
 - update: 2026-03-02 21:18 JST #688 Step5 クラッシュ調査。`DataCloneError (Performance.measure)` は React dev 計測層で表面化しているが、根本は Step5 の再レンダー負荷/メモリ肥大が主因と判断。確認した発生範囲は (1) `plugins/shape-plugin/src/worker/api/api-internal-execution-metrics.ts` の `mapTaskQueueRecordToTaskSummary` が `task.metadata` をそのままUIへ流し込む経路、(2) `plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStageState.ts` の `persistedTasksAtom` への全タスク配列複製、(3) `plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts` の flush ごとの全件 Map 再構築、(4) `plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx` の GeoJSON プレビュー常駐保持。修正方針は task summary payload の軽量化（metadata whitelist化）、persisted tasks 複製抑止、task sync の増分更新化/flush間引き、プレビューの遅延読込・上限制御。
 - start: 2026-03-02 20:55 JST #688 を起票（https://github.com/kubohiroya/hierarchidb/issues/688）し、Project `hierarchidb` へ追加後 Status を `In Progress` に設定。ブランチ `codex/fix/shape/step5-datacloneerror-688` を作成して、shape Step5 の `DataCloneError`（`Performance.measure`）クラッシュ原因調査と修正ポイント特定に着手。
 - update: 2026-03-02 17:02 JST #687 原因は Step5 のメニュー配置が操作対象ステージと不一致だったこと（`Delete transpose index` が Build Session にあり、TileEmit 側に `Delete tile data` が残存）。発生範囲は `plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelController/base/useShapeBuildProgressPanelControllerBaseState/useShapeBuildProgressPanelControllerBaseStateDataCore.ts` の `stageMenus` と `controlMenuItems` 構成。修正として `Delete transpose index` を Build Session メニューから除去して TileEmit メニューへ移設し、TileEmit メニューの `Delete tile data` を削除。適用範囲は Step5 メニューUIのみで、削除処理ハンドラ本体は変更なし。検証: `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/components --filter @hierarchidb/ui-accordion-config` exit 0、`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/ShapeBuildProgressPanel.unit.test.tsx` exit 0。

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
@@ -1091,7 +1091,7 @@ export const TaskItemDetailWindow = ({
   }), [windowState, zIndex]);
 
   useEffect(() => {
-    if (!activeDetail) {
+    if (!open || !activeDetail) {
       setPreview(null);
       setPreviewLoading(false);
       return;
@@ -1122,10 +1122,10 @@ export const TaskItemDetailWindow = ({
     return () => {
       cancelled = true;
     };
-  }, [activeDetail]);
+  }, [activeDetail, open]);
 
   useEffect(() => {
-    if (!activeDetail) {
+    if (!open || !activeDetail) {
       setSourceStageMaxima(null);
       return;
     }
@@ -1147,7 +1147,7 @@ export const TaskItemDetailWindow = ({
     return () => {
       cancelled = true;
     };
-  }, [activeDetail]);
+  }, [activeDetail, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -1170,6 +1170,13 @@ export const TaskItemDetailWindow = ({
     hide();
   }, [hide, open, show]);
 
+  useEffect(() => {
+    if (open) return;
+    setPreview(null);
+    setPreviewLoading(false);
+    setSourceStageMaxima(null);
+  }, [open]);
+
   const resultColor = useMemo(() => {
     if (!summary) return theme.palette.info.main;
     if (summary.kind === 'failed') return theme.palette.error.main;
@@ -1178,7 +1185,7 @@ export const TaskItemDetailWindow = ({
   }, [summary, theme.palette.error.main, theme.palette.info.main, theme.palette.success.main, theme.palette.warning.main]);
 
   const overlays = useMemo<OverlaySpec[]>(() => {
-    if (!preview) return [];
+    if (!open || !preview) return [];
     const next: OverlaySpec[] = [];
     if (preview.previousOriginal) {
       next.push({
@@ -1208,7 +1215,7 @@ export const TaskItemDetailWindow = ({
       });
     }
     return next;
-  }, [preview, resultColor, theme.palette.grey]);
+  }, [open, preview, resultColor, theme.palette.grey]);
 
   const handleDownload = () => {
     if (!activeDetail) return;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStageState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStageState.ts
@@ -12,6 +12,7 @@ import {
   type StageId,
   type BuildStageStateById,
 } from '~/ui/components/build-progress/useShapeBuildTaskSnapshotProgressState/useShapeBuildTaskSnapshotProgressState';
+import { areTaskListsEquivalentForView } from '~/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.comparison.utils';
 import { resolveMostAdvancedInFlightStageId, resolveMostAdvancedRunningStageId } from '~/ui/components/build-progress/internal/useShapeBuildStepHelpers/stage';
 import { resolveDisplayBuildStatus } from '~/ui/components/build-progress/internal/useShapeBuildStepHelpers/status';
 
@@ -154,8 +155,9 @@ export const useShapeBuildStepStageState = ({
 
   useEffect(() => {
     if (tasks.length === 0) return;
+    if (areTaskListsEquivalentForView(persistedTasks, tasks)) return;
     setPersistedTasks(tasks);
-  }, [setPersistedTasks, tasks]);
+  }, [persistedTasks, setPersistedTasks, tasks]);
 
   const rawDisplayTasks = tasks.length > 0 ? tasks : persistedTasks;
   const displayTasks = useMemo<ShapeBuildTaskSummary[]>(() => (

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSync.sync.ts
@@ -178,13 +178,6 @@ export const useShapeBuildTaskSyncScheduling = ({
       changed = changed || result.changed;
     });
 
-    tasksMapRef.current = new Map(nextList.map((task) => [task.taskId, task]));
-    completedTasksRef.current = new Map(
-      nextList
-        .filter((task) => isCompletedAtFullProgress(task))
-        .map((task) => [task.taskId, task]),
-    );
-
     return { nextList, changed };
   }, [
     bufferedSnapshotRef,

--- a/plugins/shape-plugin/src/worker/api/api-internal-execution-metrics.ts
+++ b/plugins/shape-plugin/src/worker/api/api-internal-execution-metrics.ts
@@ -418,6 +418,102 @@ const readNumber = (value: unknown): number | null => (
   typeof value === 'number' && Number.isFinite(value) ? value : null
 );
 
+const pickPrimitiveMetadataField = (metadata: Record<string, unknown>, key: string): unknown => {
+  const value = metadata[key];
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  return undefined;
+};
+
+const pickRecordMetadataField = (metadata: Record<string, unknown>, key: string): Record<string, unknown> | undefined => {
+  const value = asRecord(metadata[key]);
+  if (!value) return undefined;
+  return value;
+};
+
+const sanitizeTaskMetadataForSummary = (
+  task: TaskQueueRecord,
+  preview: Record<string, unknown> | null,
+): Record<string, unknown> | undefined => {
+  const metadata = asRecord(task.metadata);
+  const next: Record<string, unknown> = {};
+
+  if (preview) {
+    next.preview = preview;
+  }
+
+  if (!metadata) {
+    return Object.keys(next).length > 0 ? next : undefined;
+  }
+
+  const primitiveKeys = [
+    'message',
+    'retryAttempt',
+    'retryCount',
+    'retryLimit',
+    'maxRetryAttempts',
+    'effectiveTolerance',
+    'effective_tolerance',
+    'finalTolerance',
+    'finalEffectiveTolerance',
+    'extractionRatio',
+    'retryVertexLimit',
+    'vertexLimit',
+    'maxVerticesPerFeature',
+    'cacheReuse',
+    'authState',
+  ] as const;
+
+  for (const key of primitiveKeys) {
+    const value = pickPrimitiveMetadataField(metadata, key);
+    if (value !== undefined) {
+      next[key] = value;
+    }
+  }
+
+  const fetchDetail = pickRecordMetadataField(metadata, 'fetchDetail');
+  if (fetchDetail) {
+    next.fetchDetail = fetchDetail;
+  }
+
+  const tileEmitParentInputSummary = pickRecordMetadataField(metadata, 'tileEmitParentInputSummary');
+  if (tileEmitParentInputSummary) {
+    next.tileEmitParentInputSummary = tileEmitParentInputSummary;
+  }
+
+  const nestedMetadata = pickRecordMetadataField(metadata, 'metadata');
+  if (nestedMetadata) {
+    const compactNested: Record<string, unknown> = {};
+    for (const key of [
+      'effectiveTolerance',
+      'finalTolerance',
+      'extractionRatio',
+      'retryCount',
+      'retryLimit',
+      'maxRetryAttempts',
+      'retryVertexLimit',
+      'vertexLimit',
+      'maxVerticesPerFeature',
+    ]) {
+      const value = pickPrimitiveMetadataField(nestedMetadata, key);
+      if (value !== undefined) {
+        compactNested[key] = value;
+      }
+    }
+    if (Object.keys(compactNested).length > 0) {
+      next.metadata = compactNested;
+    }
+  }
+
+  if (isTileEmitStage(task.stage) && !next.tileEmitParentInputSummary) {
+    // TileEmit tasks are high-cardinality; avoid carrying non-essential metadata per task.
+    return Object.keys(next).length > 0 ? next : undefined;
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined;
+};
+
 const buildPreviewMetadataFromTask = (task: TaskQueueRecord): Record<string, unknown> | null => {
   const metadata = asRecord(task.metadata);
   const preview = asRecord(metadata?.preview);
@@ -489,10 +585,7 @@ const mapTaskQueueRecordToTaskSummary = (
 ): ShapeBuildTaskSummary => {
   const base = buildTaskSummaryFields(task);
   const preview = buildPreviewMetadataFromTask(task);
-  const metadata = {
-    ...(base.metadata ?? {}),
-    ...(preview ? { preview } : {}),
-  };
+  const metadata = sanitizeTaskMetadataForSummary(task, preview);
   return {
     taskId: task.taskId,
     nodeId: task.nodeId,


### PR DESCRIPTION
## Summary
- sanitize Step5 task summary metadata in worker API and stop forwarding full task metadata payloads to UI
- suppress redundant persisted task writes and remove full-map rebuild on each task-sync flush
- release task detail preview/maxima state when detail window is closed to reduce retained memory

## Root cause / scope / fix
- Cause: high-cardinality Step5 tasks carried large metadata objects across worker->UI sync, and UI state paths repeatedly duplicated those task arrays/maps, amplifying memory pressure during passive effect commits
- Scope: shape plugin Step5 build-progress pipeline (`api-internal-execution-metrics`, `useShapeBuildTaskSync`, `useShapeBuildStepStageState`, `TaskItemDetailWindow`)
- Fix: whitelist/compact metadata for summaries, avoid unchanged persisted-task copies, avoid per-flush full map reconstruction, and aggressively clear preview state when closed

## Validation
- ✅ `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/ShapeBuildProgressPanel.unit.test.tsx`
- ⚠️ `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin`
  - failed due to existing unrelated dependency error in `@hierarchidb/chunk-store`: TS2307 `Cannot find module '@hierarchidb/download'`

Closes #689
