### PR TITLE
fix(shape-api): export DEFAULT_MAX_RATIO_VALUE and remove unused import

### DIFF
--- a/packages/gis-sdk/src/ephemeral/EphemeralDB.ts
+++ b/packages/gis-sdk/src/ephemeral/EphemeralDB.ts
@@ -7,7 +7,6 @@ import type {
   BuildSessionStatus,
   BuildStage,
   BuildStageStatus,
-  EphemeralBuildSessionRecord,
   EphemeralBuildTaskRecord,
   EphemeralFetchCacheMetaRecord,
   EphemeralFetchCacheRecord,

--- a/packages/shape-api/src/index.ts
+++ b/packages/shape-api/src/index.ts
@@ -34,7 +34,7 @@ export type {
   ShapeErrorLineFeatureCollection,
   ShapeGeometryErrorRecord,
 } from './shapeBuildTypes.js';
-export { DEFAULT_BUILD_CONFIG, DEFAULT_PROCESSING_CONFIG } from './defaults.js';
+export { DEFAULT_BUILD_CONFIG, DEFAULT_PROCESSING_CONFIG, DEFAULT_MAX_RATIO_VALUE } from './defaults.js';
 export type {
   ShapeBuildStopReason,
   ShapeSourceStageMaxima,


### PR DESCRIPTION
## 概要
`@hierarchidb/shape-api` から `DEFAULT_MAX_RATIO_VALUE` がエクスポートされていなかったため、`vt-orchestrator` と `shape-plugin` でモジュール解決エラーが発生していました。

## 変更内容
- `packages/shape-api/src/index.ts` に `DEFAULT_MAX_RATIO_VALUE` のエクスポートを追加
- `packages/gis-sdk/src/ephemeral/EphemeralDB.ts` から未使用の `EphemeralBuildSessionRecord` import を削除

## 検証
- `pnpm -w turbo run build --filter @hierarchidb/shape-api` ✅
- `pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` ✅
- `pnpm -w turbo run typecheck --filter @hierarchidb/gis-sdk` ✅

## 関連
- 修正により、アプリケーションの起動時のモジュール解決エラーが解消されます