### PR TITLE
fix(shape-plugin): use sessionRecord for pause sync check

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #709 / codex/fix/shape/pause-session-sync / 2026-03-03 23:36
 - #705 / codex/refactor/ui-extract-logic-hooks / 2026-03-03 20:25
 - #708 / codex/chore/ci-build-checks-separation / 2026-03-03 22:10
 
@@ -8,6 +9,8 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-03: Issue #709 開始 - Shape build pause同期判定を `sessionRecord` ベースへ修正
+- 2026-03-03: Issue #709 進捗 - `PauseWithCancelHookActionsArgs` へ `sessionRecord` を追加し、pause同期判定を `sessionRecord?.status === 'paused'` へ更新（`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` 成功）
 - 2026-03-03: Issue #708 開始 - `pnpm build` から非必須チェックを分離し、CI向け `ci:checks` と `use*.tsx` ガードを追加
 - 2026-03-03: Issue #708 進捗 - `check:ui-hooks-tsx` / `ci:checks` を追加し、`dep-fence-guards.yml` で CI checks → build の順に実行する構成へ変更（`pnpm build` / `pnpm ci:checks` 成功）
 - 2026-03-03: Issue #708 進捗 - `app/scripts/generate-favicon.mjs` に既存 `favicon.png`/`favicon.ico` 検出時のスキップを追加し、`pnpm -C app run generate:favicon` でスキップ動作を確認

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions.ts
@@ -31,6 +31,7 @@ export const useShapeBuildStepControlActions = ({
   updateSessionRecord,
   setIsStopRequested,
   setIsStopAccepted,
+  sessionRecord,
 }: StartOrResumeControlActionsArgs & PauseControlActionsArgs & CancelQueuedControlActionsArgs) => {
   const handleStartOrResume = useShapeBuildStartOrResume({
     activeNodeId,
@@ -80,6 +81,7 @@ export const useShapeBuildStepControlActions = ({
     setRequestedControlAction,
     setIsStopRequested,
     setIsStopAccepted,
+    sessionRecord,
     handleCancelQueued,
   });
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/types.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/types.ts
@@ -138,7 +138,9 @@ export type PauseControlActionsArgs = Pick<
   | 'setRequestedControlAction'
   | 'setIsStopRequested'
   | 'setIsStopAccepted'
->;
+> & {
+  sessionRecord: ShapeBuildSessionRecord | null;
+};
 
 export type PauseWithCancelHookActionsArgs = PauseControlActionsArgs & {
   handleCancelQueued: (reason: ShapeBuildPauseReason) => Promise<void>;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildPause.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildPause.ts
@@ -17,6 +17,7 @@ export const useShapeBuildPause = ({
   setRequestedControlAction,
   setIsStopRequested,
   setIsStopAccepted,
+  sessionRecord,
   handleCancelQueued,
 }: PauseWithCancelHookActionsArgs) => {
   const handlePause = useCallback(async (reason: ShapeBuildPauseReason = 'user-pause'): Promise<void> => {
@@ -85,11 +86,7 @@ export const useShapeBuildPause = ({
 
       // セッション状態の同期を待機（オプション）
       const sessionSyncSuccess = await waitForSessionStateSync(
-        () => {
-          // この関数は外部のsessionRecordを参照できないため、
-          // 実際の実装では親コンポーネントから状態チェック関数を渡す必要がある
-          return false; // 暫定的にfalseを返す
-        },
+        () => sessionRecord?.status === 'paused',
         PAUSE_STATE_SYNC_TIMEOUT_MS,
       );
 
@@ -139,6 +136,7 @@ export const useShapeBuildPause = ({
     handleCancelQueued,
     setIsStopRequested,
     setIsStopAccepted,
+    sessionRecord,
   ]);
 
   return handlePause;

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
@@ -371,6 +371,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     updateSessionRecord,
     setIsStopRequested,
     setIsStopAccepted,
+    sessionRecord,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- pass `sessionRecord` into pause control actions
- replace hardcoded `() => false` pause sync check with `() => sessionRecord?.status === 'paused'`
- keep pause callback deps aligned with the new argument

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` (exit 0)

Closes #709
