### PR TITLE
refactor(ui): extract component logic into custom hooks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -61,6 +61,11 @@
 - 2026-03-03: Issue #705 進捗 - `ui-monitoring` の `MemoryUsageChart` でメモリ計測・履歴管理を `useMemoryUsageChartData` へ、canvas描画副作用を `useMemoryUsageChartCanvas` へ分離（`typecheck/build` 成功）
 - 2026-03-03: Issue #705 進捗 - `ui-i18n` の `LanguageSelector` で言語切替イベント処理と表示ラベル解決を `useLanguageSelectorView` へ分離（`typecheck/build` 成功）
 - 2026-03-03: Issue #705 進捗 - `ui-dialog` の `CommonDialog` で表示モード/未保存確認/送信状態管理を `useCommonDialogView` へ分離（`typecheck/build` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-dialog` の `UnsavedChangesDialog` で container/slotProps 解決を `useUnsavedChangesDialogView` へ分離し、`CommonDialogActions` で表示条件/submitラベル/disabled判定を `useCommonDialogActionsView` へ分離（`typecheck/build` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-accordion-config` の `CacheSection` で削除実行フロー/進行状態/結果通知/トグル変更処理を `useCacheSectionView` へ分離（`typecheck/build` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-accordion-config` の `ConcurrencySection`/`DownloadRetryControls`/`BaseAccordion` を `useConcurrencySectionView`/`useDownloadRetryControlsView`/`useBaseAccordion` へ分離し、`ui-plugin-basic-info` の `TagChipsInput` を `useTagChipsInput` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-plugin-basic-info` の `BasicInfoFields` で ID生成/文言解決/入力ハンドラを `useBasicInfoFieldsView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-plugin-basic-info` の `BasicInfoStep` で入力更新/タグ削除確認/初期フォーカス/validation 合成を `useBasicInfoStepView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
 - 2026-03-03: blocked - `gh issue comment 705` 実行時に `error connecting to api.github.com`（ネットワーク復旧待ち）
 - 2026-03-03: Issue #703 完了 - Shape Plugin Pauseボタン状態管理とセッション復元の修正
   - Pauseボタンが「Pausing」状態で固まる問題を修正

--- a/packages/ui/accordion-config/src/build-config/DownloadRetryControls.tsx
+++ b/packages/ui/accordion-config/src/build-config/DownloadRetryControls.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import {
   FormControl,
   Grid,
@@ -16,6 +15,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import type { SourceConfig } from '@hierarchidb/gis-sdk';
 import { getBuildConfigHoverCardSx } from './buildConfigCardStyles.js';
+import { useDownloadRetryControlsView } from './useDownloadRetryControlsView.js';
 
 type TranslateFn = (key: string, fallback?: string, options?: Record<string, unknown>) => string;
 
@@ -32,8 +32,6 @@ type Props = {
   disableHoverEffect?: boolean;
 };
 
-const RETRY_ATTEMPTS_MAX = 8;
-
 export const DownloadRetryControls: React.FC<Props> = ({
   baseRetryConfig,
   disabled,
@@ -41,15 +39,17 @@ export const DownloadRetryControls: React.FC<Props> = ({
   t,
   disableHoverEffect = false,
 }) => {
-  const retryAttemptsValue = Math.min(baseRetryConfig.retryAttempts, RETRY_ATTEMPTS_MAX);
-
-  useEffect(() => {
-    if (baseRetryConfig.retryLimit === retryAttemptsValue) return;
-    onChange({
-      ...baseRetryConfig,
-      retryLimit: retryAttemptsValue,
-    });
-  }, [baseRetryConfig, onChange, retryAttemptsValue]);
+  const {
+    retryAttemptsMax,
+    retryAttemptsValue,
+    updateTimeoutMs,
+    updateRetryDelay,
+    updateRetryAttempts,
+    updateRetryBackoff,
+  } = useDownloadRetryControlsView({
+    baseRetryConfig,
+    onChange,
+  });
 
   const hoverCardSx = disableHoverEffect ? {} : getBuildConfigHoverCardSx(disabled);
 
@@ -70,13 +70,7 @@ export const DownloadRetryControls: React.FC<Props> = ({
                   label={t('processing.download.timeoutMs', 'Timeout (ms)')}
                   type="number"
                   value={baseRetryConfig.timeoutMs}
-                  onChange={(event) => {
-                    const timeoutMs = Number(event.target.value);
-                    onChange({
-                      ...baseRetryConfig,
-                      timeoutMs: Number.isFinite(timeoutMs) ? timeoutMs : baseRetryConfig.timeoutMs,
-                    });
-                  }}
+                  onChange={(event) => updateTimeoutMs(event.target.value)}
                   fullWidth
                   disabled={disabled}
                   inputProps={{ min: 0 }}
@@ -88,13 +82,7 @@ export const DownloadRetryControls: React.FC<Props> = ({
                   label={t('processing.download.retryDelay', 'Retry Delay (ms)')}
                   type="number"
                   value={baseRetryConfig.retryDelay}
-                  onChange={(event) => {
-                    const retryDelay = Number(event.target.value);
-                    onChange({
-                      ...baseRetryConfig,
-                      retryDelay: Number.isFinite(retryDelay) ? retryDelay : baseRetryConfig.retryDelay,
-                    });
-                  }}
+                  onChange={(event) => updateRetryDelay(event.target.value)}
                   fullWidth
                   disabled={disabled}
                   inputProps={{ min: 0 }}
@@ -108,17 +96,8 @@ export const DownloadRetryControls: React.FC<Props> = ({
                   </Typography>
                   <Rating
                     value={retryAttemptsValue}
-                    onChange={(_, value) => {
-                      const nextValue = value === null ? retryAttemptsValue : value;
-                      const retryAttempts = Math.min(nextValue, RETRY_ATTEMPTS_MAX);
-                      const retryLimit = Math.min(baseRetryConfig.retryLimit, retryAttempts);
-                      onChange({
-                        ...baseRetryConfig,
-                        retryAttempts,
-                        retryLimit,
-                      });
-                    }}
-                    max={RETRY_ATTEMPTS_MAX}
+                    onChange={(_, value) => updateRetryAttempts(value)}
+                    max={retryAttemptsMax}
                     disabled={disabled}
                     icon={<CheckCircleIcon fontSize="inherit" />}
                     emptyIcon={<RadioButtonUncheckedIcon fontSize="inherit" />}
@@ -137,13 +116,7 @@ export const DownloadRetryControls: React.FC<Props> = ({
                     labelId="fetch-retry-backoff-label"
                     value={baseRetryConfig.retryBackoff}
                     label={t('processing.download.retryBackoff', 'Retry Backoff')}
-                    onChange={(event) => {
-                      const retryBackoff = event.target.value as typeof baseRetryConfig.retryBackoff;
-                      onChange({
-                        ...baseRetryConfig,
-                        retryBackoff,
-                      });
-                    }}
+                    onChange={(event) => updateRetryBackoff(event.target.value as typeof baseRetryConfig.retryBackoff)}
                     disabled={disabled}
                   >
                     <MenuItem value="linear">

--- a/packages/ui/accordion-config/src/build-config/useDownloadRetryControlsView.ts
+++ b/packages/ui/accordion-config/src/build-config/useDownloadRetryControlsView.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import type { DownloadRetryConfig } from './DownloadRetryControls.js';
+
+const RETRY_ATTEMPTS_MAX = 8;
+
+export interface UseDownloadRetryControlsViewParams {
+  baseRetryConfig: DownloadRetryConfig;
+  onChange: (next: DownloadRetryConfig) => void;
+}
+
+export interface UseDownloadRetryControlsViewResult {
+  retryAttemptsMax: number;
+  retryAttemptsValue: number;
+  updateTimeoutMs: (rawValue: string) => void;
+  updateRetryDelay: (rawValue: string) => void;
+  updateRetryAttempts: (value: number | null) => void;
+  updateRetryBackoff: (value: DownloadRetryConfig['retryBackoff']) => void;
+}
+
+export function useDownloadRetryControlsView({
+  baseRetryConfig,
+  onChange,
+}: UseDownloadRetryControlsViewParams): UseDownloadRetryControlsViewResult {
+  const retryAttemptsValue = useMemo(
+    () => Math.min(baseRetryConfig.retryAttempts, RETRY_ATTEMPTS_MAX),
+    [baseRetryConfig.retryAttempts],
+  );
+
+  useEffect(() => {
+    if (baseRetryConfig.retryLimit === retryAttemptsValue) return;
+    onChange({
+      ...baseRetryConfig,
+      retryLimit: retryAttemptsValue,
+    });
+  }, [baseRetryConfig, onChange, retryAttemptsValue]);
+
+  const updateTimeoutMs = useCallback((rawValue: string) => {
+    const timeoutMs = Number(rawValue);
+    onChange({
+      ...baseRetryConfig,
+      timeoutMs: Number.isFinite(timeoutMs) ? timeoutMs : baseRetryConfig.timeoutMs,
+    });
+  }, [baseRetryConfig, onChange]);
+
+  const updateRetryDelay = useCallback((rawValue: string) => {
+    const retryDelay = Number(rawValue);
+    onChange({
+      ...baseRetryConfig,
+      retryDelay: Number.isFinite(retryDelay) ? retryDelay : baseRetryConfig.retryDelay,
+    });
+  }, [baseRetryConfig, onChange]);
+
+  const updateRetryAttempts = useCallback((value: number | null) => {
+    const nextValue = value === null ? retryAttemptsValue : value;
+    const retryAttempts = Math.min(nextValue, RETRY_ATTEMPTS_MAX);
+    const retryLimit = Math.min(baseRetryConfig.retryLimit, retryAttempts);
+    onChange({
+      ...baseRetryConfig,
+      retryAttempts,
+      retryLimit,
+    });
+  }, [baseRetryConfig, onChange, retryAttemptsValue]);
+
+  const updateRetryBackoff = useCallback((value: DownloadRetryConfig['retryBackoff']) => {
+    onChange({
+      ...baseRetryConfig,
+      retryBackoff: value,
+    });
+  }, [baseRetryConfig, onChange]);
+
+  return {
+    retryAttemptsMax: RETRY_ATTEMPTS_MAX,
+    retryAttemptsValue,
+    updateTimeoutMs,
+    updateRetryDelay,
+    updateRetryAttempts,
+    updateRetryBackoff,
+  };
+}

--- a/packages/ui/accordion-config/src/components/BaseAccordion.tsx
+++ b/packages/ui/accordion-config/src/components/BaseAccordion.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Accordion, AccordionDetails, AccordionSummary, Box, type SxProps, type Theme, Typography } from '@mui/material';
 import { ExpandMore } from '@mui/icons-material';
+import { useBaseAccordion } from './useBaseAccordion.js';
 
 export interface BaseAccordionProps {
   /** Unique identifier */
@@ -61,16 +62,14 @@ export const BaseAccordion: React.FC<BaseAccordionProps> = ({
                                                               expandIcon = <ExpandMore />,
                                                               expandIconPosition = 'end',
                                                               children,
-                                                              headerActions,
-                                                              showDivider = false,
-                                                              elevation = 1,
+                                                            headerActions,
+                                                            showDivider = false,
+                                                            elevation = 1,
                                                             }) => {
-  const [expanded, setExpanded] = React.useState(defaultExpanded);
-
-  const handleChange = (_event: React.SyntheticEvent, isExpanded: boolean) => {
-    setExpanded(isExpanded);
-    onExpansionChange?.(isExpanded);
-  };
+  const { expanded, handleChange } = useBaseAccordion({
+    defaultExpanded,
+    onExpansionChange,
+  });
 
   const headerContent = (
     <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', gap: 2 }}>

--- a/packages/ui/accordion-config/src/components/useBaseAccordion.ts
+++ b/packages/ui/accordion-config/src/components/useBaseAccordion.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from 'react';
+import type React from 'react';
+
+export interface UseBaseAccordionParams {
+  defaultExpanded: boolean;
+  onExpansionChange?: (expanded: boolean) => void;
+}
+
+export interface UseBaseAccordionResult {
+  expanded: boolean;
+  handleChange: (_event: React.SyntheticEvent, isExpanded: boolean) => void;
+}
+
+export function useBaseAccordion({
+  defaultExpanded,
+  onExpansionChange,
+}: UseBaseAccordionParams): UseBaseAccordionResult {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const handleChange = useCallback((_event: React.SyntheticEvent, isExpanded: boolean) => {
+    setExpanded(isExpanded);
+    onExpansionChange?.(isExpanded);
+  }, [onExpansionChange]);
+
+  return {
+    expanded,
+    handleChange,
+  };
+}

--- a/packages/ui/accordion-config/src/sections/CacheSection.tsx
+++ b/packages/ui/accordion-config/src/sections/CacheSection.tsx
@@ -11,7 +11,8 @@ import {
   Typography,
 } from '@mui/material';
 import { Delete as DeleteIcon, Info } from '@mui/icons-material';
-import { useId, useState } from 'react';
+import { useId } from 'react';
+import { useCacheSectionView } from './useCacheSectionView.js';
 
 export interface CacheStats {
   itemCount: number;
@@ -48,39 +49,16 @@ export function CacheSection({
                                severity = 'warning',
                              }: CacheSectionProps) {
   const switchId = useId();
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [deleteResult, setDeleteResult] = useState<{
-    success: boolean;
-    message: string;
-  } | null>(null);
-
-  const handleDeleteCache = async () => {
-    setIsDeleting(true);
-    setDeleteResult(null);
-
-    try {
-      const stats = await config.getStats(nodeId);
-      await config.deleteCache(nodeId);
-
-      const sizeInMB = (stats.totalSize / 1024 / 1024).toFixed(2);
-      const message = stats.details
-        ? `Successfully deleted ${stats.details} (${sizeInMB} MB)`
-        : `Successfully deleted ${stats.itemCount} items (${sizeInMB} MB)`;
-
-      setDeleteResult({
-        success: true,
-        message,
-      });
-    } catch (error) {
-      console.error(`Failed to delete cache:`, error);
-      setDeleteResult({
-        success: false,
-        message: 'Failed to delete cache',
-      });
-    } finally {
-      setIsDeleting(false);
-    }
-  };
+  const {
+    isDeleting,
+    deleteResult,
+    handleDeleteCache,
+    handleDeleteOnCompleteChange,
+  } = useCacheSectionView({
+    nodeId,
+    config,
+    onDeleteOnCompleteChange,
+  });
 
   return (
     <Box sx={sx}>
@@ -101,7 +79,7 @@ export function CacheSection({
             control={
               <Switch
                 checked={deleteOnComplete}
-                onChange={(e) => onDeleteOnCompleteChange(e.target.checked)}
+                onChange={(e) => handleDeleteOnCompleteChange(e.target.checked)}
                 size="small"
                 inputProps={{
                   id: `${switchId}-delete-on-complete`,

--- a/packages/ui/accordion-config/src/sections/ConcurrencySection.tsx
+++ b/packages/ui/accordion-config/src/sections/ConcurrencySection.tsx
@@ -2,6 +2,7 @@ import { Box, FormControlLabel, IconButton, Slider, Switch, Tooltip, Typography 
 import { Calculate, Info } from '@mui/icons-material';
 import { useId } from 'react';
 import type { ChangeEvent } from 'react';
+import { useConcurrencySectionView } from './useConcurrencySectionView.js';
 
 export interface ConcurrencyConfig {
   /** Label for the concurrency control */
@@ -35,27 +36,18 @@ export interface ConcurrencySectionProps {
   sx?: object;
 }
 
-const defaultConfig: ConcurrencyConfig = {
-  label: 'Max concurrent processing sessions',
-  tooltipText: 'Controls how many CPU cores are used for processing. Using hardware concurrency (auto-detect) is recommended. Higher values speed up processing but may cause browser instability.',
-  defaultLabel: 'Use hardware concurrency default',
-  icon: <Calculate />,
-  min: 1,
-  max: 16,
-  defaultConcurrency: typeof navigator !== 'undefined' ? navigator.hardwareConcurrency || 4 : 4,
-};
-
 export const ConcurrencySection = ({
                                      value,
                                      useDefault,
-                                     config = defaultConfig,
+                                     config,
                                      onValueChange,
                                      onUseDefaultChange,
                                      sx = {},
                                    }: ConcurrencySectionProps) => {
   const switchId = useId();
-  const finalConfig = { ...defaultConfig, ...config };
-  const { label, tooltipText, defaultLabel, icon, min, max, defaultConcurrency } = finalConfig;
+  const { resolvedConfig, sliderMarks } = useConcurrencySectionView({ config });
+  const { label, tooltipText, defaultLabel, min, max, defaultConcurrency } = resolvedConfig;
+  const icon = config?.icon ?? <Calculate />;
 
   return (
     <Box sx={sx}>
@@ -94,10 +86,7 @@ export const ConcurrencySection = ({
           disabled={useDefault}
           onChange={onValueChange}
           valueLabelDisplay="auto"
-          marks={[
-            { value: min!, label: min!.toString() },
-            { value: max!, label: max!.toString() },
-          ]}
+          marks={sliderMarks}
         />
       </Box>
     </Box>

--- a/packages/ui/accordion-config/src/sections/useCacheSectionView.ts
+++ b/packages/ui/accordion-config/src/sections/useCacheSectionView.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react';
+import type { CacheConfig } from './CacheSection.js';
+
+export interface UseCacheSectionViewParams {
+  nodeId: string;
+  config: CacheConfig;
+  onDeleteOnCompleteChange: (checked: boolean) => void;
+}
+
+export interface UseCacheSectionViewResult {
+  isDeleting: boolean;
+  deleteResult: { success: boolean; message: string } | null;
+  handleDeleteCache: () => Promise<void>;
+  handleDeleteOnCompleteChange: (checked: boolean) => void;
+}
+
+export function useCacheSectionView({
+  nodeId,
+  config,
+  onDeleteOnCompleteChange,
+}: UseCacheSectionViewParams): UseCacheSectionViewResult {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteResult, setDeleteResult] = useState<{
+    success: boolean;
+    message: string;
+  } | null>(null);
+
+  const handleDeleteCache = useCallback(async () => {
+    setIsDeleting(true);
+    setDeleteResult(null);
+    try {
+      const stats = await config.getStats(nodeId);
+      await config.deleteCache(nodeId);
+      const sizeInMB = (stats.totalSize / 1024 / 1024).toFixed(2);
+      const message = stats.details
+        ? `Successfully deleted ${stats.details} (${sizeInMB} MB)`
+        : `Successfully deleted ${stats.itemCount} items (${sizeInMB} MB)`;
+      setDeleteResult({
+        success: true,
+        message,
+      });
+    } catch (error) {
+      console.error('Failed to delete cache:', error);
+      setDeleteResult({
+        success: false,
+        message: 'Failed to delete cache',
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [config, nodeId]);
+
+  const handleDeleteOnCompleteChange = useCallback(
+    (checked: boolean) => {
+      onDeleteOnCompleteChange(checked);
+    },
+    [onDeleteOnCompleteChange],
+  );
+
+  return {
+    isDeleting,
+    deleteResult,
+    handleDeleteCache,
+    handleDeleteOnCompleteChange,
+  };
+}

--- a/packages/ui/accordion-config/src/sections/useConcurrencySectionView.ts
+++ b/packages/ui/accordion-config/src/sections/useConcurrencySectionView.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import type { ConcurrencyConfig } from './ConcurrencySection.js';
+
+interface ResolvedConcurrencyConfig {
+  label: string;
+  tooltipText: string;
+  defaultLabel: string;
+  min: number;
+  max: number;
+  defaultConcurrency: number;
+}
+
+export interface UseConcurrencySectionViewParams {
+  config?: ConcurrencyConfig;
+}
+
+export interface UseConcurrencySectionViewResult {
+  resolvedConfig: ResolvedConcurrencyConfig;
+  sliderMarks: Array<{ value: number; label: string }>;
+}
+
+const buildDefaultConfig = (): ResolvedConcurrencyConfig => ({
+  label: 'Max concurrent processing sessions',
+  tooltipText:
+    'Controls how many CPU cores are used for processing. Using hardware concurrency (auto-detect) is recommended. Higher values speed up processing but may cause browser instability.',
+  defaultLabel: 'Use hardware concurrency default',
+  min: 1,
+  max: 16,
+  defaultConcurrency: typeof navigator !== 'undefined' ? navigator.hardwareConcurrency || 4 : 4,
+});
+
+export function useConcurrencySectionView({
+  config,
+}: UseConcurrencySectionViewParams): UseConcurrencySectionViewResult {
+  const resolvedConfig = useMemo<ResolvedConcurrencyConfig>(() => {
+    const defaults = buildDefaultConfig();
+    return {
+      ...defaults,
+      ...config,
+      min: config?.min ?? defaults.min,
+      max: config?.max ?? defaults.max,
+      defaultConcurrency: config?.defaultConcurrency ?? defaults.defaultConcurrency,
+      label: config?.label ?? defaults.label,
+      tooltipText: config?.tooltipText ?? defaults.tooltipText,
+      defaultLabel: config?.defaultLabel ?? defaults.defaultLabel,
+    };
+  }, [config]);
+
+  const sliderMarks = useMemo(
+    () => [
+      { value: resolvedConfig.min, label: resolvedConfig.min.toString() },
+      { value: resolvedConfig.max, label: resolvedConfig.max.toString() },
+    ],
+    [resolvedConfig.max, resolvedConfig.min],
+  );
+
+  return {
+    resolvedConfig,
+    sliderMarks,
+  };
+}

--- a/packages/ui/dialog/src/components/CommonDialogActions.tsx
+++ b/packages/ui/dialog/src/components/CommonDialogActions.tsx
@@ -4,6 +4,7 @@
 
 import type React from 'react';
 import { Button, DialogActions, Stack } from '@mui/material';
+import { useCommonDialogActionsView } from './useCommonDialogActionsView.js';
 
 export interface CommonDialogActionsProps {
   mode: 'create' | 'edit' | 'preview';
@@ -24,7 +25,14 @@ export const CommonDialogActions: React.FC<CommonDialogActionsProps> = ({
                                                                           additionalActions,
                                                                           displayMode = 'normal',
                                                                         }) => {
-  if (displayMode !== 'full-screen') {
+  const { shouldRender, submitLabel, submitDisabled } = useCommonDialogActionsView({
+    displayMode,
+    mode,
+    isValid,
+    isSubmitting,
+  });
+
+  if (!shouldRender) {
     return null;
   }
   return (
@@ -41,9 +49,9 @@ export const CommonDialogActions: React.FC<CommonDialogActionsProps> = ({
             onClick={onSubmit}
             variant="contained"
             size="large"
-            disabled={!isValid || isSubmitting}
+            disabled={submitDisabled}
           >
-            {isSubmitting ? 'Saving...' : mode === 'create' ? 'Create' : 'Save'}
+            {submitLabel}
           </Button>
         </Stack>
       </Stack>

--- a/packages/ui/dialog/src/components/CommonDialogTitle.tsx
+++ b/packages/ui/dialog/src/components/CommonDialogTitle.tsx
@@ -10,12 +10,10 @@ import {
   FullscreenExit as FullscreenExitIcon,
 } from '@mui/icons-material';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
-
-const DISPLAY_MODE_LABELS: Record<'normal' | 'maximize' | 'full-screen', string> = {
-  normal: 'Normal (通常)',
-  maximize: 'Maximize (最大)',
-  'full-screen': 'Full-screen (全画面)',
-};
+import {
+  DISPLAY_MODE_LABELS,
+  useCommonDialogTitleView,
+} from './useCommonDialogTitleView.js';
 
 export interface CommonDialogTitleProps {
   title: string;
@@ -46,14 +44,21 @@ export const CommonDialogTitle: React.FC<CommonDialogTitleProps> = ({
   onChangeDisplayMode,
   showDisplayModeControls = true,
 }) => {
-  const [modeMenuAnchor, setModeMenuAnchor] = React.useState<null | HTMLElement>(null);
-  const openModeMenu = (event: React.MouseEvent<HTMLElement>) => setModeMenuAnchor(event.currentTarget);
-  const closeModeMenu = () => setModeMenuAnchor(null);
-
-  const selectDisplayMode = (next: 'normal' | 'maximize' | 'full-screen') => {
-    onChangeDisplayMode?.(next);
-    closeModeMenu();
-  };
+  const {
+    modeMenuAnchor,
+    isModeMenuOpen,
+    showMaximizeToggle,
+    maximizeToggleLabel,
+    fullscreenToggleLabel,
+    openModeMenu,
+    closeModeMenu,
+    selectDisplayMode,
+    toggleMaximize,
+    toggleFullscreen,
+  } = useCommonDialogTitleView({
+    displayMode,
+    onChangeDisplayMode,
+  });
 
   return (
     <DialogTitle>
@@ -75,7 +80,7 @@ export const CommonDialogTitle: React.FC<CommonDialogTitleProps> = ({
               <IconButton aria-label="Display mode" onClick={openModeMenu} size="small">
                 <OpenInFullIcon />
               </IconButton>
-              <Menu anchorEl={modeMenuAnchor} open={Boolean(modeMenuAnchor)} onClose={closeModeMenu} keepMounted>
+              <Menu anchorEl={modeMenuAnchor} open={isModeMenuOpen} onClose={closeModeMenu} keepMounted>
                 <MenuItem selected={displayMode === 'normal'} onClick={() => selectDisplayMode('normal')}>
                   <ListItemIcon>
                     <FullscreenExitIcon fontSize="small" />
@@ -95,18 +100,18 @@ export const CommonDialogTitle: React.FC<CommonDialogTitleProps> = ({
                   <ListItemText>{DISPLAY_MODE_LABELS['full-screen']}</ListItemText>
                 </MenuItem>
               </Menu>
-              {displayMode !== 'full-screen' && (
+              {showMaximizeToggle && (
                 <IconButton
-                  aria-label={displayMode === 'maximize' ? DISPLAY_MODE_LABELS.normal : DISPLAY_MODE_LABELS.maximize}
-                  onClick={() => selectDisplayMode(displayMode === 'maximize' ? 'normal' : 'maximize')}
+                  aria-label={maximizeToggleLabel}
+                  onClick={toggleMaximize}
                   size="small"
                 >
                   {displayMode === 'maximize' ? <FullscreenExitIcon /> : <OpenInFullIcon />}
                 </IconButton>
               )}
               <IconButton
-                aria-label={displayMode === 'full-screen' ? DISPLAY_MODE_LABELS.normal : DISPLAY_MODE_LABELS['full-screen']}
-                onClick={() => selectDisplayMode(displayMode === 'full-screen' ? 'normal' : 'full-screen')}
+                aria-label={fullscreenToggleLabel}
+                onClick={toggleFullscreen}
                 size="small"
               >
                 {displayMode === 'full-screen' ? <FullscreenExitIcon /> : <FullscreenIcon />}

--- a/packages/ui/dialog/src/components/UnsavedChangesDialog.tsx
+++ b/packages/ui/dialog/src/components/UnsavedChangesDialog.tsx
@@ -16,8 +16,8 @@ import {
 } from '@mui/material';
 import type { DialogProps } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useMemo } from 'react';
 import { Delete as DeleteIcon, Save as SaveIcon, Warning as WarningIcon } from '@mui/icons-material';
+import { useUnsavedChangesDialogView } from './useUnsavedChangesDialogView.js';
 
 export interface UnsavedChangesDialogProps {
   open: boolean;
@@ -65,24 +65,10 @@ export const UnsavedChangesDialog: React.FC<UnsavedChangesDialogProps> = ({
   container,
 }) => {
   const { t } = useTranslation('common');
-
-  const defaultContainer = useMemo<DialogProps['container']>(() => {
-    if (typeof document === 'undefined') return undefined;
-    return document.body;
-  }, []);
-
-  const dialogSlotProps: DialogProps['slotProps'] = slotProps ?? {
-    backdrop: {
-      sx: {
-        zIndex: (theme) => (theme?.zIndex?.modal ?? 1300) + 5000,
-      },
-    },
-    paper: {
-      sx: {
-        zIndex: (theme) => (theme?.zIndex?.modal ?? 1300) + 5001,
-      },
-    },
-  };
+  const { resolvedContainer, resolvedSlotProps } = useUnsavedChangesDialogView({
+    container,
+    slotProps,
+  });
 
   return (
     <Dialog
@@ -90,10 +76,10 @@ export const UnsavedChangesDialog: React.FC<UnsavedChangesDialogProps> = ({
       onClose={onCancel}
       maxWidth="sm"
       fullWidth
-      slotProps={dialogSlotProps}
+      slotProps={resolvedSlotProps}
       PaperProps={PaperProps}
       BackdropProps={BackdropProps}
-      container={container ?? defaultContainer}
+      container={resolvedContainer}
       disablePortal={false}
     >
       <DialogTitle>

--- a/packages/ui/dialog/src/components/useCommonDialogActionsView.ts
+++ b/packages/ui/dialog/src/components/useCommonDialogActionsView.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import type { CommonDialogActionsProps } from './CommonDialogActions.js';
+
+export interface UseCommonDialogActionsViewResult {
+  shouldRender: boolean;
+  submitLabel: string;
+  submitDisabled: boolean;
+}
+
+export function useCommonDialogActionsView({
+  displayMode = 'normal',
+  mode,
+  isValid = true,
+  isSubmitting = false,
+}: Pick<CommonDialogActionsProps, 'displayMode' | 'mode' | 'isValid' | 'isSubmitting'>): UseCommonDialogActionsViewResult {
+  const submitLabel = useMemo(() => {
+    if (isSubmitting) return 'Saving...';
+    return mode === 'create' ? 'Create' : 'Save';
+  }, [isSubmitting, mode]);
+
+  return {
+    shouldRender: displayMode === 'full-screen',
+    submitLabel,
+    submitDisabled: !isValid || isSubmitting,
+  };
+}

--- a/packages/ui/dialog/src/components/useCommonDialogTitleView.ts
+++ b/packages/ui/dialog/src/components/useCommonDialogTitleView.ts
@@ -1,0 +1,72 @@
+import { useCallback, useState } from 'react';
+
+export type DialogDisplayMode = 'normal' | 'maximize' | 'full-screen';
+
+export const DISPLAY_MODE_LABELS: Record<DialogDisplayMode, string> = {
+  normal: 'Normal (通常)',
+  maximize: 'Maximize (最大)',
+  'full-screen': 'Full-screen (全画面)',
+};
+
+export interface UseCommonDialogTitleViewParams {
+  displayMode: DialogDisplayMode;
+  onChangeDisplayMode?: (mode: DialogDisplayMode) => void;
+}
+
+export interface UseCommonDialogTitleViewResult {
+  modeMenuAnchor: HTMLElement | null;
+  isModeMenuOpen: boolean;
+  showMaximizeToggle: boolean;
+  maximizeToggleLabel: string;
+  fullscreenToggleLabel: string;
+  openModeMenu: (event: React.MouseEvent<HTMLElement>) => void;
+  closeModeMenu: () => void;
+  selectDisplayMode: (next: DialogDisplayMode) => void;
+  toggleMaximize: () => void;
+  toggleFullscreen: () => void;
+}
+
+export function useCommonDialogTitleView({
+  displayMode,
+  onChangeDisplayMode,
+}: UseCommonDialogTitleViewParams): UseCommonDialogTitleViewResult {
+  const [modeMenuAnchor, setModeMenuAnchor] = useState<HTMLElement | null>(null);
+
+  const closeModeMenu = useCallback(() => {
+    setModeMenuAnchor(null);
+  }, []);
+
+  const openModeMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setModeMenuAnchor(event.currentTarget);
+  }, []);
+
+  const selectDisplayMode = useCallback(
+    (next: DialogDisplayMode) => {
+      onChangeDisplayMode?.(next);
+      closeModeMenu();
+    },
+    [closeModeMenu, onChangeDisplayMode],
+  );
+
+  const toggleMaximize = useCallback(() => {
+    selectDisplayMode(displayMode === 'maximize' ? 'normal' : 'maximize');
+  }, [displayMode, selectDisplayMode]);
+
+  const toggleFullscreen = useCallback(() => {
+    selectDisplayMode(displayMode === 'full-screen' ? 'normal' : 'full-screen');
+  }, [displayMode, selectDisplayMode]);
+
+  return {
+    modeMenuAnchor,
+    isModeMenuOpen: Boolean(modeMenuAnchor),
+    showMaximizeToggle: displayMode !== 'full-screen',
+    maximizeToggleLabel: displayMode === 'maximize' ? DISPLAY_MODE_LABELS.normal : DISPLAY_MODE_LABELS.maximize,
+    fullscreenToggleLabel:
+      displayMode === 'full-screen' ? DISPLAY_MODE_LABELS.normal : DISPLAY_MODE_LABELS['full-screen'],
+    openModeMenu,
+    closeModeMenu,
+    selectDisplayMode,
+    toggleMaximize,
+    toggleFullscreen,
+  };
+}

--- a/packages/ui/dialog/src/components/useUnsavedChangesDialogView.ts
+++ b/packages/ui/dialog/src/components/useUnsavedChangesDialogView.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import type { DialogProps } from '@mui/material';
+
+export interface UseUnsavedChangesDialogViewParams {
+  container?: DialogProps['container'];
+  slotProps?: DialogProps['slotProps'];
+}
+
+export interface UseUnsavedChangesDialogViewResult {
+  resolvedContainer: DialogProps['container'];
+  resolvedSlotProps: DialogProps['slotProps'];
+}
+
+export function useUnsavedChangesDialogView({
+  container,
+  slotProps,
+}: UseUnsavedChangesDialogViewParams): UseUnsavedChangesDialogViewResult {
+  const defaultContainer = useMemo<DialogProps['container']>(() => {
+    if (typeof document === 'undefined') return undefined;
+    return document.body;
+  }, []);
+
+  const resolvedSlotProps: DialogProps['slotProps'] = useMemo(() => {
+    if (slotProps) return slotProps;
+    return {
+      backdrop: {
+        sx: {
+          zIndex: (theme) => (theme?.zIndex?.modal ?? 1300) + 5000,
+        },
+      },
+      paper: {
+        sx: {
+          zIndex: (theme) => (theme?.zIndex?.modal ?? 1300) + 5001,
+        },
+      },
+    };
+  }, [slotProps]);
+
+  return {
+    resolvedContainer: container ?? defaultContainer,
+    resolvedSlotProps,
+  };
+}

--- a/packages/ui/plugin-basic-info/src/components/BasicInfoFields.tsx
+++ b/packages/ui/plugin-basic-info/src/components/BasicInfoFields.tsx
@@ -3,8 +3,8 @@
  * Shared name/description form fields for Step1 across plugin-loader.
  */
 
-import { useMemo, useId } from 'react';
 import { Box, FormControl, TextField, Typography } from '@mui/material';
+import { useBasicInfoFieldsView } from './useBasicInfoFieldsView.js';
 
 export interface BasicInfoValue {
   name?: string;
@@ -47,20 +47,18 @@ export const BasicInfoFields: React.FC<BasicInfoFieldsProps> = ({
                                                                   title,
                                                                   subtitle,
 }) => {
-  const controlId = useId();
-  const nameInputId = `${controlId}-name`;
-  const descriptionInputId = `${controlId}-description`;
-  const texts = useMemo(() => ({
-    title: title ?? 'Basic Information',
-    subtitle: subtitle ?? 'Enter a name and optional description.',
-    nameLabel: nameLabel ?? 'Name',
-    nameHelperText: nameHelperText ?? 'Enter a descriptive name',
-    nameRequiredText: nameRequiredText ?? 'Name is required',
-    namePlaceholder: namePlaceholder ?? 'Enter name',
-    descriptionLabel: descriptionLabel ?? 'Description',
-    descriptionHelperText: descriptionHelperText ?? 'Describe the purpose or contents (optional)',
-    descriptionPlaceholder: descriptionPlaceholder ?? 'Enter description (optional)',
-  }), [
+  const {
+    nameInputId,
+    descriptionInputId,
+    texts,
+    name,
+    description,
+    nameError,
+    handleNameChange,
+    handleDescriptionChange,
+  } = useBasicInfoFieldsView({
+    value,
+    onChange,
     title,
     subtitle,
     nameLabel,
@@ -70,11 +68,7 @@ export const BasicInfoFields: React.FC<BasicInfoFieldsProps> = ({
     descriptionLabel,
     descriptionHelperText,
     descriptionPlaceholder,
-  ]);
-
-  const name = value.name ?? '';
-  const description = value.description ?? '';
-  const nameError = !name.trim();
+  });
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
@@ -99,7 +93,7 @@ export const BasicInfoFields: React.FC<BasicInfoFieldsProps> = ({
           id={nameInputId}
           name="name"
           value={name}
-          onChange={(e) => onChange({ name: e.target.value })}
+          onChange={(e) => handleNameChange(e.target.value)}
           required
           fullWidth
           disabled={disabled}
@@ -116,7 +110,7 @@ export const BasicInfoFields: React.FC<BasicInfoFieldsProps> = ({
           id={descriptionInputId}
           name="description"
           value={description}
-          onChange={(e) => onChange({ description: e.target.value })}
+          onChange={(e) => handleDescriptionChange(e.target.value)}
           multiline
           rows={3}
           fullWidth

--- a/packages/ui/plugin-basic-info/src/components/BasicInfoStep.tsx
+++ b/packages/ui/plugin-basic-info/src/components/BasicInfoStep.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useRef, useId, useState } from 'react';
-import type { ChangeEvent, FC } from 'react';
+import type { FC } from 'react';
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, FormControl, TextField, Typography } from '@mui/material';
 import { LocalOffer } from '@mui/icons-material';
 import { TagChipsInput } from './TagChipsInput.js';
 import { useTranslation } from 'react-i18next';
+import { useBasicInfoStepView } from './useBasicInfoStepView.js';
 
 export interface BasicInfoData {
   name: string;
@@ -51,105 +51,34 @@ export const BasicInfoStep: FC<BasicInfoStepProps> = ({
   confirmTagDelete = true,
 }) => {
   const { t } = useTranslation('plugin-basic-info');
-  const nameInputRef = useRef<HTMLInputElement | null>(null);
-  const [pendingTagDelete, setPendingTagDelete] = useState<string | null>(null);
-  const fieldId = useId();
-  const nameInputId = `${fieldId}-name`;
-  const descriptionInputId = `${fieldId}-description`;
-
-  const emitChange = useCallback(
-    (updates: Partial<BasicInfoData>) => {
-      onChange({
-        name,
-        description,
-        tags,
-        ...updates,
-      });
-    },
-    [description, name, onChange, tags],
-  );
-
-  const handleNameChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      emitChange({ name: event.target.value });
-    },
-    [emitChange],
-  );
-
-  const handleDescriptionChange = useCallback(
-    (event: ChangeEvent<HTMLTextAreaElement>) => {
-      emitChange({ description: event.target.value });
-    },
-    [emitChange],
-  );
-
-  const handleTagsChange = useCallback(
-    (nextTags: string[]) => {
-      emitChange({ tags: nextTags });
-    },
-    [emitChange],
-  );
-
-  const handleTagClick = useCallback(
-    (tag: string) => {
-      if (!onTagClick) return;
-      onTagClick(tag);
-    },
-    [onTagClick],
-  );
-
-  const removeTag = useCallback(
-    (tag: string) => {
-      const nextTags = tags.filter((t) => t !== tag);
-      emitChange({ tags: nextTags });
-    },
-    [emitChange, tags],
-  );
-
-  const handleTagDeleteRequest = useCallback(
-    (tag: string) => {
-      if (disabled) return;
-      if (!confirmTagDelete) {
-        removeTag(tag);
-        return;
-      }
-      setPendingTagDelete(tag);
-    },
-    [confirmTagDelete, disabled, removeTag],
-  );
-
-  const handleConfirmDelete = useCallback(() => {
-    if (!pendingTagDelete) return;
-    removeTag(pendingTagDelete);
-    setPendingTagDelete(null);
-  }, [pendingTagDelete, removeTag]);
-
-  const handleCancelDelete = useCallback(() => {
-    setPendingTagDelete(null);
-  }, []);
-
-  const normalizedName = typeof name === 'string' ? name : '';
-  const normalizedDescription = typeof description === 'string' ? description : '';
-  const validationError = validate?.({ name: normalizedName, description: normalizedDescription, tags });
-  const nameError = !normalizedName.trim() ? t('name.required', 'Name is required') : null;
-  const mergedNameError = validationError ?? nameError;
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined;
-    if (mode !== 'create') return undefined;
-
-    const input = nameInputRef.current;
-    if (!input) return undefined;
-
-    const timer = window.setTimeout(() => {
-      input.focus();
-      input.select();
-    }, 0);
-
-    return () => {
-      window.clearTimeout(timer);
-    };
-  }, [mode]);
+  const {
+    nameInputRef,
+    fieldId,
+    nameInputId,
+    descriptionInputId,
+    pendingTagDelete,
+    normalizedName,
+    normalizedDescription,
+    mergedNameError,
+    handleNameChange,
+    handleDescriptionChange,
+    handleTagsChange,
+    handleTagClick,
+    handleTagDeleteRequest,
+    handleConfirmDelete,
+    handleCancelDelete,
+  } = useBasicInfoStepView({
+    name,
+    description,
+    tags,
+    onChange,
+    mode,
+    validate,
+    disabled,
+    onTagClick,
+    confirmTagDelete,
+    requiredNameMessage: String(t('name.required', 'Name is required')),
+  });
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
@@ -165,7 +94,7 @@ export const BasicInfoStep: FC<BasicInfoStepProps> = ({
           id={nameInputId}
           name="name"
           value={normalizedName}
-          onChange={handleNameChange}
+          onChange={(event) => handleNameChange(event.target.value)}
           required
           error={!!mergedNameError}
           helperText={mergedNameError}
@@ -191,7 +120,7 @@ export const BasicInfoStep: FC<BasicInfoStepProps> = ({
           id={descriptionInputId}
           name="description"
           value={normalizedDescription}
-          onChange={handleDescriptionChange}
+          onChange={(event) => handleDescriptionChange(event.target.value)}
           multiline
           rows={4}
           placeholder={String(t('fields.description.placeholder', 'Enter an optional description'))}

--- a/packages/ui/plugin-basic-info/src/components/TagChipsInput.tsx
+++ b/packages/ui/plugin-basic-info/src/components/TagChipsInput.tsx
@@ -1,5 +1,6 @@
-import { type KeyboardEvent, useMemo, useState, useId, type ReactNode } from 'react'
+import { type KeyboardEvent, type ReactNode } from 'react';
 import { Box, Chip, Stack, TextField, Typography, useTheme } from '@mui/material';
+import { useTagChipsInput } from './useTagChipsInput.js';
 
 export interface TagChipsInputProps {
   value?: string[];
@@ -31,30 +32,26 @@ export const TagChipsInput: React.FC<TagChipsInputProps> = ({
   suggestions = [],
 }) => {
   const theme = useTheme();
-  const [input, setInput] = useState('');
-  const controlId = useId();
-  const inputId = `${controlId}-tags`;
-  const labelId = `${controlId}-label`;
-
-  const addTag = (tag: string) => {
-    const t = tag.trim();
-    if (!t || value.includes(t) || value.length >= maxTags) return;
-    onChange?.([...value, t]);
-    setInput('');
-  };
-
-  const removeTag = (tag: string) => {
-    onChange?.(value.filter((v) => v !== tag));
-  };
+  const {
+    input,
+    inputId,
+    labelId,
+    availableSuggestions,
+    setInputValue,
+    addTag,
+    removeTag,
+    handleEnterKey,
+  } = useTagChipsInput({
+    value,
+    onChange,
+    maxTags,
+    suggestions,
+  });
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      addTag(input);
-    }
+    if (!handleEnterKey(e.key)) return;
+    e.preventDefault();
   };
-
-  const availableSuggestions = useMemo(() => suggestions.filter((s) => s && !value.includes(s)), [suggestions, value]);
 
   return (
     <Box data-ui-core="TagChipsInput" sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
@@ -96,7 +93,7 @@ export const TagChipsInput: React.FC<TagChipsInputProps> = ({
         id={inputId}
         name="tags"
         value={input}
-        onChange={(e) => setInput(e.target.value)}
+        onChange={(e) => setInputValue(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         disabled={disabled || value.length >= maxTags}

--- a/packages/ui/plugin-basic-info/src/components/useBasicInfoFieldsView.ts
+++ b/packages/ui/plugin-basic-info/src/components/useBasicInfoFieldsView.ts
@@ -1,0 +1,99 @@
+import { useCallback, useId, useMemo } from 'react';
+import type { BasicInfoFieldsProps } from './BasicInfoFields.js';
+
+export interface UseBasicInfoFieldsViewResult {
+  nameInputId: string;
+  descriptionInputId: string;
+  texts: {
+    title: string;
+    subtitle: string;
+    nameLabel: string;
+    nameHelperText: string;
+    nameRequiredText: string;
+    namePlaceholder: string;
+    descriptionLabel: string;
+    descriptionHelperText: string;
+    descriptionPlaceholder: string;
+  };
+  name: string;
+  description: string;
+  nameError: boolean;
+  handleNameChange: (nextValue: string) => void;
+  handleDescriptionChange: (nextValue: string) => void;
+}
+
+export function useBasicInfoFieldsView({
+  value,
+  onChange,
+  title,
+  subtitle,
+  nameLabel,
+  nameHelperText,
+  nameRequiredText,
+  namePlaceholder,
+  descriptionLabel,
+  descriptionHelperText,
+  descriptionPlaceholder,
+}: Pick<
+  BasicInfoFieldsProps,
+  | 'value'
+  | 'onChange'
+  | 'title'
+  | 'subtitle'
+  | 'nameLabel'
+  | 'nameHelperText'
+  | 'nameRequiredText'
+  | 'namePlaceholder'
+  | 'descriptionLabel'
+  | 'descriptionHelperText'
+  | 'descriptionPlaceholder'
+>): UseBasicInfoFieldsViewResult {
+  const controlId = useId();
+  const nameInputId = `${controlId}-name`;
+  const descriptionInputId = `${controlId}-description`;
+
+  const texts = useMemo(() => ({
+    title: title ?? 'Basic Information',
+    subtitle: subtitle ?? 'Enter a name and optional description.',
+    nameLabel: nameLabel ?? 'Name',
+    nameHelperText: nameHelperText ?? 'Enter a descriptive name',
+    nameRequiredText: nameRequiredText ?? 'Name is required',
+    namePlaceholder: namePlaceholder ?? 'Enter name',
+    descriptionLabel: descriptionLabel ?? 'Description',
+    descriptionHelperText: descriptionHelperText ?? 'Describe the purpose or contents (optional)',
+    descriptionPlaceholder: descriptionPlaceholder ?? 'Enter description (optional)',
+  }), [
+    title,
+    subtitle,
+    nameLabel,
+    nameHelperText,
+    nameRequiredText,
+    namePlaceholder,
+    descriptionLabel,
+    descriptionHelperText,
+    descriptionPlaceholder,
+  ]);
+
+  const name = value.name ?? '';
+  const description = value.description ?? '';
+  const nameError = !name.trim();
+
+  const handleNameChange = useCallback((nextValue: string) => {
+    onChange({ name: nextValue });
+  }, [onChange]);
+
+  const handleDescriptionChange = useCallback((nextValue: string) => {
+    onChange({ description: nextValue });
+  }, [onChange]);
+
+  return {
+    nameInputId,
+    descriptionInputId,
+    texts,
+    name,
+    description,
+    nameError,
+    handleNameChange,
+    handleDescriptionChange,
+  };
+}

--- a/packages/ui/plugin-basic-info/src/components/useBasicInfoStepView.ts
+++ b/packages/ui/plugin-basic-info/src/components/useBasicInfoStepView.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { BasicInfoData, BasicInfoStepProps } from './BasicInfoStep.js';
+
+export interface UseBasicInfoStepViewParams {
+  name: BasicInfoStepProps['name'];
+  description: BasicInfoStepProps['description'];
+  tags: string[];
+  onChange: BasicInfoStepProps['onChange'];
+  mode: BasicInfoStepProps['mode'];
+  validate: BasicInfoStepProps['validate'];
+  disabled: boolean;
+  onTagClick: BasicInfoStepProps['onTagClick'];
+  confirmTagDelete: boolean;
+  requiredNameMessage: string;
+}
+
+export interface UseBasicInfoStepViewResult {
+  nameInputRef: React.RefObject<HTMLInputElement | null>;
+  fieldId: string;
+  nameInputId: string;
+  descriptionInputId: string;
+  pendingTagDelete: string | null;
+  normalizedName: string;
+  normalizedDescription: string;
+  mergedNameError: string | null;
+  handleNameChange: (value: string) => void;
+  handleDescriptionChange: (value: string) => void;
+  handleTagsChange: (nextTags: string[]) => void;
+  handleTagClick: (tag: string) => void;
+  handleTagDeleteRequest: (tag: string) => void;
+  handleConfirmDelete: () => void;
+  handleCancelDelete: () => void;
+}
+
+export function useBasicInfoStepView({
+  name,
+  description,
+  tags,
+  onChange,
+  mode,
+  validate,
+  disabled,
+  onTagClick,
+  confirmTagDelete,
+  requiredNameMessage,
+}: UseBasicInfoStepViewParams): UseBasicInfoStepViewResult {
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
+  const [pendingTagDelete, setPendingTagDelete] = useState<string | null>(null);
+  const fieldId = useId();
+  const nameInputId = `${fieldId}-name`;
+  const descriptionInputId = `${fieldId}-description`;
+
+  const emitChange = useCallback((updates: Partial<BasicInfoData>) => {
+    onChange({
+      name,
+      description,
+      tags,
+      ...updates,
+    });
+  }, [description, name, onChange, tags]);
+
+  const removeTag = useCallback((tag: string) => {
+    const nextTags = tags.filter((currentTag) => currentTag !== tag);
+    emitChange({ tags: nextTags });
+  }, [emitChange, tags]);
+
+  const handleNameChange = useCallback((value: string) => {
+    emitChange({ name: value });
+  }, [emitChange]);
+
+  const handleDescriptionChange = useCallback((value: string) => {
+    emitChange({ description: value });
+  }, [emitChange]);
+
+  const handleTagsChange = useCallback((nextTags: string[]) => {
+    emitChange({ tags: nextTags });
+  }, [emitChange]);
+
+  const handleTagClick = useCallback((tag: string) => {
+    if (!onTagClick) return;
+    onTagClick(tag);
+  }, [onTagClick]);
+
+  const handleTagDeleteRequest = useCallback((tag: string) => {
+    if (disabled) return;
+    if (!confirmTagDelete) {
+      removeTag(tag);
+      return;
+    }
+    setPendingTagDelete(tag);
+  }, [confirmTagDelete, disabled, removeTag]);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!pendingTagDelete) return;
+    removeTag(pendingTagDelete);
+    setPendingTagDelete(null);
+  }, [pendingTagDelete, removeTag]);
+
+  const handleCancelDelete = useCallback(() => {
+    setPendingTagDelete(null);
+  }, []);
+
+  const normalizedName = typeof name === 'string' ? name : '';
+  const normalizedDescription = typeof description === 'string' ? description : '';
+  const validationError = validate?.({ name: normalizedName, description: normalizedDescription, tags });
+  const nameError = !normalizedName.trim() ? requiredNameMessage : null;
+  const mergedNameError = validationError ?? nameError;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    if (mode !== 'create') return undefined;
+
+    const input = nameInputRef.current;
+    if (!input) return undefined;
+
+    const timer = window.setTimeout(() => {
+      input.focus();
+      input.select();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [mode]);
+
+  return {
+    nameInputRef,
+    fieldId,
+    nameInputId,
+    descriptionInputId,
+    pendingTagDelete,
+    normalizedName,
+    normalizedDescription,
+    mergedNameError,
+    handleNameChange,
+    handleDescriptionChange,
+    handleTagsChange,
+    handleTagClick,
+    handleTagDeleteRequest,
+    handleConfirmDelete,
+    handleCancelDelete,
+  };
+}

--- a/packages/ui/plugin-basic-info/src/components/useTagChipsInput.ts
+++ b/packages/ui/plugin-basic-info/src/components/useTagChipsInput.ts
@@ -1,0 +1,68 @@
+import { useCallback, useId, useMemo, useState } from 'react';
+
+export interface UseTagChipsInputParams {
+  value: string[];
+  onChange?: (tags: string[]) => void;
+  maxTags: number;
+  suggestions: string[];
+}
+
+export interface UseTagChipsInputResult {
+  input: string;
+  inputId: string;
+  labelId: string;
+  availableSuggestions: string[];
+  setInputValue: (value: string) => void;
+  addTag: (tag: string) => void;
+  removeTag: (tag: string) => void;
+  handleEnterKey: (key: string) => boolean;
+}
+
+export function useTagChipsInput({
+  value,
+  onChange,
+  maxTags,
+  suggestions,
+}: UseTagChipsInputParams): UseTagChipsInputResult {
+  const [input, setInput] = useState('');
+  const controlId = useId();
+  const inputId = `${controlId}-tags`;
+  const labelId = `${controlId}-label`;
+
+  const addTag = useCallback((tag: string) => {
+    const normalized = tag.trim();
+    if (!normalized || value.includes(normalized) || value.length >= maxTags) return;
+    onChange?.([...value, normalized]);
+    setInput('');
+  }, [maxTags, onChange, value]);
+
+  const removeTag = useCallback((tag: string) => {
+    onChange?.(value.filter((currentTag) => currentTag !== tag));
+  }, [onChange, value]);
+
+  const handleEnterKey = useCallback((key: string): boolean => {
+    if (key !== 'Enter') return false;
+    addTag(input);
+    return true;
+  }, [addTag, input]);
+
+  const availableSuggestions = useMemo(
+    () => suggestions.filter((suggestion) => suggestion && !value.includes(suggestion)),
+    [suggestions, value],
+  );
+
+  const setInputValue = useCallback((nextValue: string) => {
+    setInput(nextValue);
+  }, []);
+
+  return {
+    input,
+    inputId,
+    labelId,
+    availableSuggestions,
+    setInputValue,
+    addTag,
+    removeTag,
+    handleEnterKey,
+  };
+}


### PR DESCRIPTION
## Summary\n- extract mixed UI logic from  components into  custom hooks\n- keep JSX out of hooks to enforce presentation/logic separation\n- continue refactors in accordion-config, dialog, and plugin-basic-info components\n- update TASKS.md operation log for Issue #705 progress\n\n## Validation\n- pnpm check:ui-hooks-tsx\n- pnpm -w turbo run typecheck --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/ui-plugin-basic-info\n- pnpm -w turbo run build --filter @hierarchidb/ui-accordion-config\n- pnpm -w turbo run build --filter @hierarchidb/ui-plugin-basic-info\n