### PR TITLE
refactor(ui): continue extracting view logic hooks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -66,6 +66,9 @@
 - 2026-03-04: Issue #705 進捗 - `ui-accordion-config` の `ConcurrencySection`/`DownloadRetryControls`/`BaseAccordion` を `useConcurrencySectionView`/`useDownloadRetryControlsView`/`useBaseAccordion` へ分離し、`ui-plugin-basic-info` の `TagChipsInput` を `useTagChipsInput` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
 - 2026-03-04: Issue #705 進捗 - `ui-plugin-basic-info` の `BasicInfoFields` で ID生成/文言解決/入力ハンドラを `useBasicInfoFieldsView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
 - 2026-03-04: Issue #705 進捗 - `ui-plugin-basic-info` の `BasicInfoStep` で入力更新/タグ削除確認/初期フォーカス/validation 合成を `useBasicInfoStepView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-accordion-config` の `SettingsAccordion`/`WorkflowAccordion` でアクション状態・イベント処理・ステップ表示解決ロジックを `useSettingsAccordionView`/`useWorkflowAccordionView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-theme` の `ThemeProvider` で mode保持/保存・system theme 監視・context値構築を `useThemeProviderView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-tour` の `GuidedTourDemo` で run state と start/finish 操作を `useGuidedTourDemoView` へ分離し、`ui-navigation` の `MenuListItemLinkButton` でメニュー開閉・path/style・key解決を `useMenuListItemLinkButtonView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
 - 2026-03-03: blocked - `gh issue comment 705` 実行時に `error connecting to api.github.com`（ネットワーク復旧待ち）
 - 2026-03-03: Issue #703 完了 - Shape Plugin Pauseボタン状態管理とセッション復元の修正
   - Pauseボタンが「Pausing」状態で固まる問題を修正

--- a/packages/ui/accordion-config/src/presets/SettingsAccordion.tsx
+++ b/packages/ui/accordion-config/src/presets/SettingsAccordion.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { StyledAccordion, type StyledAccordionProps } from '~/components/StyledAccordion';
 import { Restore, Save, Settings } from '@mui/icons-material';
 import { Box, IconButton, Tooltip } from '@mui/material';
+import { useSettingsAccordionView } from './useSettingsAccordionView.js';
 
 export interface SettingsAccordionProps extends Omit<StyledAccordionProps, 'headerActions'> {
   /** Whether to show settings icon */
@@ -35,61 +36,53 @@ export const SettingsAccordion: React.FC<SettingsAccordionProps> = ({
                                                                       icon,
                                                                       ...accordionProps
                                                                     }) => {
-  const headerActions = React.useMemo(() => {
-    const actions = [];
-
-    if (onSave) {
-      actions.push(
-        <Tooltip key="save" title={saveTooltip}>
+  const {
+    showDefaultSettingsIcon,
+    hasChanges: hasPendingChanges,
+    hasSaveAction,
+    hasResetAction,
+    hasHeaderActions,
+    isSaveDisabled,
+    handleSaveClick,
+    handleResetClick,
+  } = useSettingsAccordionView({
+    icon,
+    showSettingsIcon,
+    hasChanges,
+    customActions,
+    onSave,
+    onReset,
+  });
+  const settingsIcon = showDefaultSettingsIcon ? <Settings /> : icon;
+  const headerActions = hasHeaderActions ? (
+    <Box sx={{ display: 'flex', gap: 0.5 }}>
+      {hasSaveAction ? (
+        <Tooltip title={saveTooltip}>
           <span>
             <IconButton
               size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                onSave();
-              }}
-              disabled={!hasChanges}
-              color={hasChanges ? 'primary' : 'default'}
+              onClick={handleSaveClick}
+              disabled={isSaveDisabled}
+              color={hasPendingChanges ? 'primary' : 'default'}
             >
               <Save fontSize="small" />
             </IconButton>
           </span>
-        </Tooltip>,
-      );
-    }
-
-    if (onReset) {
-      actions.push(
-        <Tooltip key="reset" title={resetTooltip}>
+        </Tooltip>
+      ) : null}
+      {hasResetAction ? (
+        <Tooltip title={resetTooltip}>
           <IconButton
             size="small"
-            onClick={(e) => {
-              e.stopPropagation();
-              onReset();
-            }}
+            onClick={handleResetClick}
           >
             <Restore fontSize="small" />
           </IconButton>
-        </Tooltip>,
-      );
-    }
-
-    if (customActions) {
-      actions.push(
-        <React.Fragment key="custom">
-          {customActions}
-        </React.Fragment>,
-      );
-    }
-
-    return actions.length > 0 ? (
-      <Box sx={{ display: 'flex', gap: 0.5 }}>
-        {actions}
-      </Box>
-    ) : null;
-  }, [hasChanges, onSave, onReset, customActions, saveTooltip, resetTooltip]);
-
-  const settingsIcon = showSettingsIcon && !icon ? <Settings /> : icon;
+        </Tooltip>
+      ) : null}
+      {customActions ?? null}
+    </Box>
+  ) : null;
 
   return (
     <StyledAccordion
@@ -97,7 +90,7 @@ export const SettingsAccordion: React.FC<SettingsAccordionProps> = ({
       icon={settingsIcon}
       headerActions={headerActions}
       sx={{
-        ...(hasChanges && {
+        ...(hasPendingChanges && {
           borderLeft: '3px solid',
           borderLeftColor: 'warning.main',
         }),

--- a/packages/ui/accordion-config/src/presets/WorkflowAccordion.tsx
+++ b/packages/ui/accordion-config/src/presets/WorkflowAccordion.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyledAccordion, type StyledAccordionProps } from '~/components/StyledAccordion';
 import { Chip } from '@mui/material';
-import type { ChipProps } from '@mui/material';
+import { useWorkflowAccordionView } from './useWorkflowAccordionView.js';
 
 export interface WorkflowStep {
   /** Step number or identifier */
@@ -23,21 +23,6 @@ export interface WorkflowAccordionProps extends Omit<StyledAccordionProps, 'icon
   renderStep?: (step: WorkflowStep) => React.ReactNode;
 }
 
-const getStatusColor = (status?: WorkflowStep['status']) => {
-  switch (status) {
-    case 'completed':
-      return 'success';
-    case 'active':
-      return 'primary';
-    case 'error':
-      return 'error';
-    case 'skipped':
-      return 'default';
-    default:
-      return 'default';
-  }
-};
-
 /**
  * Accordion designed for workflow/process steps
  * Can be used for wizards, multi-step forms, build processes, etc.
@@ -48,34 +33,27 @@ export const WorkflowAccordion: React.FC<WorkflowAccordionProps> = ({
                                                                       renderStep,
                                                                       ...accordionProps
                                                                     }) => {
-  const stepElement = React.useMemo(() => {
-    if (!step || !showStepBadge) return null;
-
-    if (renderStep) {
-      return renderStep(step);
-    }
-
-    const label = step.label || `Step ${step.id}`;
-    const color = step.badgeColor || getStatusColor(step.status);
-    const muiColors: Array<ChipProps['color']> = ['default', 'primary', 'secondary', 'error', 'info', 'success', 'warning'];
-    const muiColor = muiColors.includes(color as ChipProps['color']) ? (color as ChipProps['color']) : undefined;
-    const chipSx = muiColor
-      ? undefined
-      : {
-        backgroundColor: color,
-        color: '#fff',
-      };
-
-    return (
+  const {
+    shouldRenderStepBadge,
+    label,
+    color,
+    chipSx,
+    variant,
+  } = useWorkflowAccordionView({
+    step,
+    showStepBadge,
+  });
+  const stepElement = step && shouldRenderStepBadge
+    ? (renderStep?.(step) ?? (
       <Chip
         label={label}
-        color={muiColor}
+        color={color}
         size="small"
-        variant={step.status === 'active' ? 'filled' : 'outlined'}
+        variant={variant}
         sx={chipSx}
       />
-    );
-  }, [step, showStepBadge, renderStep]);
+    ))
+    : null;
 
   return (
     <StyledAccordion

--- a/packages/ui/accordion-config/src/presets/useSettingsAccordionView.ts
+++ b/packages/ui/accordion-config/src/presets/useSettingsAccordionView.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import type React from 'react';
+
+interface UseSettingsAccordionViewParams {
+  icon: React.ReactNode;
+  showSettingsIcon: boolean;
+  hasChanges: boolean;
+  customActions?: React.ReactNode;
+  onSave?: () => void;
+  onReset?: () => void;
+}
+
+interface UseSettingsAccordionViewResult {
+  showDefaultSettingsIcon: boolean;
+  hasChanges: boolean;
+  hasSaveAction: boolean;
+  hasResetAction: boolean;
+  hasHeaderActions: boolean;
+  isSaveDisabled: boolean;
+  handleSaveClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  handleResetClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export function useSettingsAccordionView({
+  icon,
+  showSettingsIcon,
+  hasChanges,
+  customActions,
+  onSave,
+  onReset,
+}: UseSettingsAccordionViewParams): UseSettingsAccordionViewResult {
+  const handleSaveClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onSave?.();
+  }, [onSave]);
+
+  const handleResetClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onReset?.();
+  }, [onReset]);
+
+  return {
+    showDefaultSettingsIcon: showSettingsIcon && !icon,
+    hasChanges,
+    hasSaveAction: Boolean(onSave),
+    hasResetAction: Boolean(onReset),
+    hasHeaderActions: Boolean(onSave || onReset || customActions),
+    isSaveDisabled: !hasChanges,
+    handleSaveClick,
+    handleResetClick,
+  };
+}

--- a/packages/ui/accordion-config/src/presets/useWorkflowAccordionView.ts
+++ b/packages/ui/accordion-config/src/presets/useWorkflowAccordionView.ts
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import type { ChipProps } from '@mui/material';
+import type { WorkflowStep } from './WorkflowAccordion.js';
+
+interface UseWorkflowAccordionViewParams {
+  step?: WorkflowStep;
+  showStepBadge: boolean;
+}
+
+interface UseWorkflowAccordionViewResult {
+  shouldRenderStepBadge: boolean;
+  label: string;
+  color?: ChipProps['color'];
+  chipSx?: {
+    backgroundColor: string;
+    color: string;
+  };
+  variant: 'filled' | 'outlined';
+}
+
+const MUI_COLORS: Array<ChipProps['color']> = ['default', 'primary', 'secondary', 'error', 'info', 'success', 'warning'];
+
+function resolveStatusColor(status?: WorkflowStep['status']): string {
+  switch (status) {
+    case 'completed':
+      return 'success';
+    case 'active':
+      return 'primary';
+    case 'error':
+      return 'error';
+    case 'skipped':
+      return 'default';
+    default:
+      return 'default';
+  }
+}
+
+export function useWorkflowAccordionView({
+  step,
+  showStepBadge,
+}: UseWorkflowAccordionViewParams): UseWorkflowAccordionViewResult {
+  return useMemo(() => {
+    if (!step || !showStepBadge) {
+      return {
+        shouldRenderStepBadge: false,
+        label: '',
+        color: undefined,
+        chipSx: undefined,
+        variant: 'outlined' as const,
+      };
+    }
+
+    const label = step.label ?? `Step ${step.id}`;
+    const resolvedColor = step.badgeColor ?? resolveStatusColor(step.status);
+    const color = MUI_COLORS.includes(resolvedColor as ChipProps['color'])
+      ? (resolvedColor as ChipProps['color'])
+      : undefined;
+
+    return {
+      shouldRenderStepBadge: true,
+      label,
+      color,
+      chipSx: color
+        ? undefined
+        : {
+          backgroundColor: resolvedColor,
+          color: '#fff',
+        },
+      variant: step.status === 'active' ? 'filled' : 'outlined',
+    };
+  }, [showStepBadge, step]);
+}

--- a/packages/ui/navigation/src/components/MenuListItemButton/MenuListItemLinkButton.tsx
+++ b/packages/ui/navigation/src/components/MenuListItemButton/MenuListItemLinkButton.tsx
@@ -1,15 +1,9 @@
 // Local implementation - using provider-router-dom directly
 import { IconButton, ListItemIcon, ListItemText, Menu, MenuItem } from '@mui/material';
 import SpeedDialIcon from '@mui/material/SpeedDialIcon';
-import { Link, useLocation } from '@tanstack/react-router';
-import {
-  type CSSProperties,
-  type MouseEvent,
-  type ReactNode,
-  useCallback,
-  useMemo,
-  useState,
-} from 'react';
+import { Link } from '@tanstack/react-router';
+import type { ReactNode } from 'react';
+import { useMenuListItemLinkButtonView } from './useMenuListItemLinkButtonView.js';
 
 export type MenuItemLinkType = {
   name: string;
@@ -24,32 +18,19 @@ export const MenuListItemLinkButton = ({
   id: string;
   items: Array<MenuItemLinkType | null>;
 }) => {
-  const location = useLocation();
-  const [anchorElem, setAnchorElem] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorElem);
-
-  const handleMenuOpenButtonClick = (event: MouseEvent<HTMLButtonElement>) => {
-    setAnchorElem(event.currentTarget);
-  };
-
-  const handleMenuItemClick = useCallback((_url: string) => {
-    setAnchorElem(null);
-  }, []);
-
-  const currentPath = location.pathname ?? '';
-  const baseLinkStyle = useMemo<CSSProperties>(
-    () => ({
-      textDecoration: 'none',
-      whiteSpace: 'nowrap',
-      display: 'flex',
-      flexDirection: 'row',
-      justifyContent: 'flex-start',
-      color: 'inherit',
-    }),
-    []
-  );
-
-  let dividerKeyCounter = 0;
+  const {
+    anchorElem,
+    open,
+    currentPath,
+    baseLinkStyle,
+    itemKeys,
+    handleMenuOpenButtonClick,
+    handleMenuClose,
+    handleMenuItemClick,
+  } = useMenuListItemLinkButtonView({
+    id,
+    items,
+  });
 
   return (
     <>
@@ -60,11 +41,11 @@ export const MenuListItemLinkButton = ({
       >
         <SpeedDialIcon />
       </IconButton>
-      <Menu id={`${id}-menu`} anchorEl={anchorElem} open={open} onClose={() => setAnchorElem(null)}>
-        {items.map((item: MenuItemLinkType | null) => {
+      <Menu id={`${id}-menu`} anchorEl={anchorElem} open={open} onClose={handleMenuClose}>
+        {items.map((item: MenuItemLinkType | null, index) => {
           if (item) {
             const targetPath = `${currentPath}/${item.url}`;
-            const itemKey = item.url || `${item.name}-${id}`;
+            const itemKey = itemKeys[index];
             return (
               <MenuItem
                 key={itemKey}
@@ -78,8 +59,7 @@ export const MenuListItemLinkButton = ({
               </MenuItem>
             );
           }
-          dividerKeyCounter += 1;
-          return <MenuItem key={`${id}-divider-${dividerKeyCounter}`} divider />;
+          return <MenuItem key={itemKeys[index]} divider />;
         })}
       </Menu>
     </>

--- a/packages/ui/navigation/src/components/MenuListItemButton/useMenuListItemLinkButtonView.ts
+++ b/packages/ui/navigation/src/components/MenuListItemButton/useMenuListItemLinkButtonView.ts
@@ -1,0 +1,80 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { CSSProperties, MouseEvent } from 'react';
+import { useLocation } from '@tanstack/react-router';
+
+export interface MenuItemLinkItem {
+  name: string;
+  url: string;
+}
+
+export interface UseMenuListItemLinkButtonViewParams {
+  id: string;
+  items: Array<MenuItemLinkItem | null>;
+}
+
+export interface UseMenuListItemLinkButtonViewResult {
+  anchorElem: null | HTMLElement;
+  open: boolean;
+  currentPath: string;
+  baseLinkStyle: CSSProperties;
+  itemKeys: string[];
+  handleMenuOpenButtonClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  handleMenuClose: () => void;
+  handleMenuItemClick: (_url: string) => void;
+}
+
+export function useMenuListItemLinkButtonView({
+  id,
+  items,
+}: UseMenuListItemLinkButtonViewParams): UseMenuListItemLinkButtonViewResult {
+  const location = useLocation();
+  const [anchorElem, setAnchorElem] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorElem);
+
+  const handleMenuOpenButtonClick = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorElem(event.currentTarget);
+  }, []);
+
+  const handleMenuClose = useCallback(() => {
+    setAnchorElem(null);
+  }, []);
+
+  const handleMenuItemClick = useCallback((_url: string) => {
+    setAnchorElem(null);
+  }, []);
+
+  const currentPath = location.pathname ?? '';
+  const baseLinkStyle = useMemo<CSSProperties>(
+    () => ({
+      textDecoration: 'none',
+      whiteSpace: 'nowrap',
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'flex-start',
+      color: 'inherit',
+    }),
+    [],
+  );
+
+  const itemKeys = useMemo(() => {
+    let dividerKeyCounter = 0;
+    return items.map((item) => {
+      if (item) {
+        return item.url || `${item.name}-${id}`;
+      }
+      dividerKeyCounter += 1;
+      return `${id}-divider-${dividerKeyCounter}`;
+    });
+  }, [id, items]);
+
+  return {
+    anchorElem,
+    open,
+    currentPath,
+    baseLinkStyle,
+    itemKeys,
+    handleMenuOpenButtonClick,
+    handleMenuClose,
+    handleMenuItemClick,
+  };
+}

--- a/packages/ui/theme/src/components/ThemeProvider.tsx
+++ b/packages/ui/theme/src/components/ThemeProvider.tsx
@@ -1,8 +1,8 @@
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode } from 'react';
 
 import { ThemeContext } from '~/components/ThemeContext';
-import type { ThemeContextType, ThemeMode } from '~/types';
-import { getStoredThemeMode, getSystemTheme, storeThemeMode } from '~/utils/storage';
+import type { ThemeMode } from '~/types';
+import { useThemeProviderView } from './useThemeProviderView';
 
 export interface ThemeProviderProps {
   children: ReactNode;
@@ -10,39 +10,7 @@ export interface ThemeProviderProps {
 }
 
 export const ThemeProvider = ({ children, defaultMode = 'system' }: ThemeProviderProps) => {
-  const [themeMode, setThemeModeState] = useState<ThemeMode>(
-    () => getStoredThemeMode() || defaultMode,
-  );
-  const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(getSystemTheme);
-
-  const setThemeMode = (mode: ThemeMode) => {
-    setThemeModeState(mode);
-    storeThemeMode(mode);
-  };
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-
-    const handleChange = (e: MediaQueryListEvent) => {
-      setSystemTheme(e.matches ? 'dark' : 'light');
-    };
-
-    mediaQuery.addEventListener('change', handleChange);
-
-    return () => {
-      mediaQuery.removeEventListener('change', handleChange);
-    };
-  }, []);
-
-  const actualTheme = themeMode === 'system' ? systemTheme : themeMode;
-
-  const value: ThemeContextType = {
-    mode: themeMode,
-    actualTheme,
-    setMode: setThemeMode,
-  };
+  const { value } = useThemeProviderView({ defaultMode });
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 };

--- a/packages/ui/theme/src/components/useThemeProviderView.ts
+++ b/packages/ui/theme/src/components/useThemeProviderView.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ThemeContextType, ThemeMode } from '~/types';
+import { getStoredThemeMode, getSystemTheme, storeThemeMode } from '~/utils/storage';
+
+export interface UseThemeProviderViewParams {
+  defaultMode: ThemeMode;
+}
+
+export interface UseThemeProviderViewResult {
+  value: ThemeContextType;
+}
+
+export function useThemeProviderView({
+  defaultMode,
+}: UseThemeProviderViewParams): UseThemeProviderViewResult {
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(
+    () => getStoredThemeMode() || defaultMode,
+  );
+  const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(getSystemTheme);
+
+  const setThemeMode = useCallback((mode: ThemeMode) => {
+    setThemeModeState(mode);
+    storeThemeMode(mode);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? 'dark' : 'light');
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  const actualTheme = themeMode === 'system' ? systemTheme : themeMode;
+  const value = useMemo<ThemeContextType>(() => ({
+    mode: themeMode,
+    actualTheme,
+    setMode: setThemeMode,
+  }), [actualTheme, setThemeMode, themeMode]);
+
+  return {
+    value,
+  };
+}

--- a/packages/ui/tour/src/components/GuidedTourDemo.tsx
+++ b/packages/ui/tour/src/components/GuidedTourDemo.tsx
@@ -3,9 +3,10 @@
  */
 
 import { Box, Button, Typography } from '@mui/material';
-import { useId, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import type { Step } from 'react-joyride';
 import { GenericGuidedTour } from './GenericGuidedTour.js';
+import { useGuidedTourDemoView } from './useGuidedTourDemoView.js';
 
 const createDemoSteps = (buttonId: string, contentId: string): Step[] => [
   {
@@ -45,9 +46,7 @@ const createDemoSteps = (buttonId: string, contentId: string): Step[] => [
 ];
 
 export const GuidedTourDemo = () => {
-  const [runTour, setRunTour] = useState(true);
-  const buttonId = useId();
-  const contentId = useId();
+  const { runTour, buttonId, contentId, startTour, finishTour } = useGuidedTourDemoView();
   const demoSteps = useMemo(() => createDemoSteps(buttonId, contentId), [buttonId, contentId]);
 
   return (
@@ -56,7 +55,7 @@ export const GuidedTourDemo = () => {
         GuidedTour Demo
       </Typography>
 
-      <Button id={buttonId} variant="contained" onClick={() => setRunTour(true)} sx={{ mb: 4 }}>
+      <Button id={buttonId} variant="contained" onClick={startTour} sx={{ mb: 4 }}>
         Start Tour
       </Button>
 
@@ -79,7 +78,7 @@ export const GuidedTourDemo = () => {
         run={runTour}
         steps={demoSteps}
         tourType="mainTour"
-        onFinish={() => setRunTour(false)}
+        onFinish={finishTour}
       />
     </Box>
   );

--- a/packages/ui/tour/src/components/useGuidedTourDemoView.ts
+++ b/packages/ui/tour/src/components/useGuidedTourDemoView.ts
@@ -1,0 +1,31 @@
+import { useCallback, useId, useState } from 'react';
+
+export interface UseGuidedTourDemoViewResult {
+  runTour: boolean;
+  buttonId: string;
+  contentId: string;
+  startTour: () => void;
+  finishTour: () => void;
+}
+
+export function useGuidedTourDemoView(): UseGuidedTourDemoViewResult {
+  const [runTour, setRunTour] = useState(true);
+  const buttonId = useId();
+  const contentId = useId();
+
+  const startTour = useCallback(() => {
+    setRunTour(true);
+  }, []);
+
+  const finishTour = useCallback(() => {
+    setRunTour(false);
+  }, []);
+
+  return {
+    runTour,
+    buttonId,
+    contentId,
+    startTour,
+    finishTour,
+  };
+}


### PR DESCRIPTION
## Summary
- continue refactoring mixed component/view logic into custom hooks under `packages/ui`
- split logic from SettingsAccordion, WorkflowAccordion, ThemeProvider, GuidedTourDemo, and MenuListItemLinkButton
- keep hooks free from JSX and leave rendering concerns in components
- update TASKS.md progress log for Issue #705

## Validation
- pnpm -w turbo run typecheck --filter @hierarchidb/ui-accordion-config
- pnpm -w turbo run build --filter @hierarchidb/ui-accordion-config
- pnpm -w turbo run typecheck --filter @hierarchidb/ui-theme
- pnpm -w turbo run build --filter @hierarchidb/ui-theme
- pnpm -w turbo run typecheck --filter @hierarchidb/ui-tour --filter @hierarchidb/ui-navigation
- pnpm -w turbo run build --filter @hierarchidb/ui-tour --filter @hierarchidb/ui-navigation
- pnpm check:ui-hooks-tsx
