### PR TITLE
refactor(ui): continue component logic extraction

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -69,6 +69,8 @@
 - 2026-03-04: Issue #705 進捗 - `ui-accordion-config` の `SettingsAccordion`/`WorkflowAccordion` でアクション状態・イベント処理・ステップ表示解決ロジックを `useSettingsAccordionView`/`useWorkflowAccordionView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
 - 2026-03-04: Issue #705 進捗 - `ui-theme` の `ThemeProvider` で mode保持/保存・system theme 監視・context値構築を `useThemeProviderView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
 - 2026-03-04: Issue #705 進捗 - `ui-tour` の `GuidedTourDemo` で run state と start/finish 操作を `useGuidedTourDemoView` へ分離し、`ui-navigation` の `MenuListItemLinkButton` でメニュー開閉・path/style・key解決を `useMenuListItemLinkButtonView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-country-select` の `CountryMatrixStep` で matrix config 正規化/統計算出/column set info 解決を `useCountryMatrixStepView` へ分離し、`ui-navigation` の `NavLinkMenu` でリンクスタイル/表示モデル解決を `useNavLinkMenuView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
+- 2026-03-04: Issue #705 進捗 - `ui-session-coordinator` の `SessionCoordinatorProvider` で coordinator 初期化を `useTabSessionCoordinatorProviderView` へ分離し、`ui-worker-provider` の `WorkerSingletonProvider` で Worker 初期化/retry/ready 判定を `useWorkerSingletonProviderView` へ分離（`typecheck/build` と `pnpm check:ui-hooks-tsx` 成功）
 - 2026-03-03: blocked - `gh issue comment 705` 実行時に `error connecting to api.github.com`（ネットワーク復旧待ち）
 - 2026-03-03: Issue #703 完了 - Shape Plugin Pauseボタン状態管理とセッション復元の修正
   - Pauseボタンが「Pausing」状態で固まる問題を修正

--- a/packages/ui/country-select/src/components/CountryMatrixStep.tsx
+++ b/packages/ui/country-select/src/components/CountryMatrixStep.tsx
@@ -4,11 +4,11 @@
  */
 
 import type React from 'react';
-import { useMemo } from 'react';
 import { Accordion, AccordionDetails, AccordionSummary, Alert, Box, Chip, Stack, Typography } from '@mui/material';
 import { ExpandMore as ExpandMoreIcon, Info as InfoIcon } from '@mui/icons-material';
 
 import { CountryMatrixSelector } from './CountryMatrixSelector.js';
+import { useCountryMatrixStepView } from './useCountryMatrixStepView.js';
 import type { Country } from '~/types/Country';
 import type { ColumnSet, MatrixConfig, MatrixSelection } from '~/types/MatrixColumn';
 
@@ -53,51 +53,12 @@ export const CountryMatrixStep: React.FC<CountryMatrixStepProps> = ({
                                                                       minSelections = 1,
                                                                       showConfiguration = false,
                                                                     }) => {
-  // Convert ColumnSet to MatrixConfig if needed
-  const matrixConfig: MatrixConfig = useMemo(() => {
-    if ('type' in rawMatrixConfig) {
-      // It's a ColumnSet, convert to MatrixConfig
-      return {
-        columns: rawMatrixConfig.columns,
-        allowBulkSelect: true,
-        showColumnHeaders: true,
-        showFilters: true,
-        virtualization: {
-          rowHeight: 56,
-          overscan: 5,
-        },
-      };
-    }
-    return rawMatrixConfig;
-  }, [rawMatrixConfig]);
-
-  // Calculate selection statistics
-  const stats = useMemo(() => {
-    const totalCountries = countries.length;
-    const selectedCountries = selections.length;
-    const totalSelections = selections.reduce((sum, selection) => {
-      return sum + Object.values(selection.selections).filter(Boolean).length;
-    }, 0);
-
-    return {
-      totalCountries,
-      selectedCountries,
-      totalSelections,
-      isValid: selectedCountries >= minSelections,
-    };
-  }, [countries, selections, minSelections]);
-
-  // Get column set info if available
-  const columnSetInfo = useMemo(() => {
-    if ('type' in rawMatrixConfig) {
-      return {
-        name: rawMatrixConfig.name,
-        description: rawMatrixConfig.description,
-        type: rawMatrixConfig.type,
-      };
-    }
-    return null;
-  }, [rawMatrixConfig]);
+  const { matrixConfig, stats, columnSetInfo, validationMessage } = useCountryMatrixStepView({
+    countries,
+    matrixConfig: rawMatrixConfig,
+    selections,
+    minSelections,
+  });
 
   return (
     <Box>
@@ -204,7 +165,7 @@ export const CountryMatrixStep: React.FC<CountryMatrixStepProps> = ({
       {/* Validation message */}
       {showValidationInfo && !stats.isValid && (
         <Alert severity="warning" sx={{ mt: 2 }}>
-          Please select at least {minSelections} {minSelections === 1 ? 'country' : 'countries'} to continue.
+          {validationMessage}
         </Alert>
       )}
     </Box>

--- a/packages/ui/country-select/src/components/useCountryMatrixStepView.ts
+++ b/packages/ui/country-select/src/components/useCountryMatrixStepView.ts
@@ -1,0 +1,84 @@
+import { useMemo } from 'react';
+import type { Country } from '~/types/Country';
+import type { ColumnSet, MatrixConfig, MatrixSelection } from '~/types/MatrixColumn';
+
+export interface UseCountryMatrixStepViewParams {
+  countries: Country[];
+  matrixConfig: MatrixConfig | ColumnSet;
+  selections: MatrixSelection[];
+  minSelections: number;
+}
+
+export interface UseCountryMatrixStepViewResult {
+  matrixConfig: MatrixConfig;
+  stats: {
+    totalCountries: number;
+    selectedCountries: number;
+    totalSelections: number;
+    isValid: boolean;
+  };
+  columnSetInfo: {
+    name: string;
+    description: string;
+    type: ColumnSet['type'];
+  } | null;
+  validationMessage: string;
+}
+
+export function useCountryMatrixStepView({
+  countries,
+  matrixConfig: rawMatrixConfig,
+  selections,
+  minSelections,
+}: UseCountryMatrixStepViewParams): UseCountryMatrixStepViewResult {
+  const matrixConfig: MatrixConfig = useMemo(() => {
+    if ('type' in rawMatrixConfig) {
+      return {
+        columns: rawMatrixConfig.columns,
+        allowBulkSelect: true,
+        showColumnHeaders: true,
+        showFilters: true,
+        virtualization: {
+          rowHeight: 56,
+          overscan: 5,
+        },
+      };
+    }
+    return rawMatrixConfig;
+  }, [rawMatrixConfig]);
+
+  const stats = useMemo(() => {
+    const totalCountries = countries.length;
+    const selectedCountries = selections.length;
+    const totalSelections = selections.reduce((sum, selection) => (
+      sum + Object.values(selection.selections).filter(Boolean).length
+    ), 0);
+
+    return {
+      totalCountries,
+      selectedCountries,
+      totalSelections,
+      isValid: selectedCountries >= minSelections,
+    };
+  }, [countries.length, minSelections, selections]);
+
+  const columnSetInfo = useMemo(() => {
+    if ('type' in rawMatrixConfig) {
+      return {
+        name: rawMatrixConfig.name,
+        description: rawMatrixConfig.description,
+        type: rawMatrixConfig.type,
+      };
+    }
+    return null;
+  }, [rawMatrixConfig]);
+
+  const validationMessage = `Please select at least ${minSelections} ${minSelections === 1 ? 'country' : 'countries'} to continue.`;
+
+  return {
+    matrixConfig,
+    stats,
+    columnSetInfo,
+    validationMessage,
+  };
+}

--- a/packages/ui/navigation/src/components/NavLinkMenu/NavLinkMenu.tsx
+++ b/packages/ui/navigation/src/components/NavLinkMenu/NavLinkMenu.tsx
@@ -1,6 +1,7 @@
 import { MenuItem, MenuList, Typography } from '@mui/material';
 import { Link } from '@tanstack/react-router';
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import { useNavLinkMenuView } from './useNavLinkMenuView.js';
 
 // InlineIcon should be imported from @hierarchidb/ui package
 // For now, we'll create a simple inline version
@@ -14,25 +15,34 @@ export type NavLinkItemType = {
   url: string;
 };
 
-const baseLinkStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  width: '100%',
-  textDecoration: 'none',
-};
-
 export const NavLinkMenu = ({ items }: { items: NavLinkItemType[] }) => {
-  if (items.length === 0) return null;
+  const {
+    hasItems,
+    activeLinkStyle,
+    inactiveLinkStyle,
+    itemViewModels,
+  } = useNavLinkMenuView(items.map((item) => ({
+    name: item.name,
+    url: item.url,
+  })));
+  if (!hasItems) return null;
 
   return (
     <MenuList sx={{ marginBottom: '30px', backgroundColor: 'red' }}>
-      {items.map((item) => (
-        <MenuItem key={item.url || item.name} sx={{ padding: 0, margin: 0 }} aria-label={item.name}>
+      {itemViewModels.map((viewModel, index) => {
+        const item = items[index];
+        if (!item) return null;
+        return (
+        <MenuItem
+          key={viewModel.key}
+          sx={{ padding: 0, margin: 0 }}
+          aria-label={viewModel.name}
+        >
           <Link
-            to={item.url}
+            to={viewModel.target}
             preload="intent"
-            activeProps={{ style: { ...baseLinkStyle, color: '#c34' } }}
-            inactiveProps={{ style: { ...baseLinkStyle, color: '#545e6f' } }}
+            activeProps={{ style: activeLinkStyle }}
+            inactiveProps={{ style: inactiveLinkStyle }}
           >
             <InlineIcon icon={item.icon} />
             <Typography sx={{ marginLeft: 1 }} component="span">
@@ -40,7 +50,7 @@ export const NavLinkMenu = ({ items }: { items: NavLinkItemType[] }) => {
             </Typography>
           </Link>
         </MenuItem>
-      ))}
+      )})}
     </MenuList>
   );
 };

--- a/packages/ui/navigation/src/components/NavLinkMenu/useNavLinkMenuView.ts
+++ b/packages/ui/navigation/src/components/NavLinkMenu/useNavLinkMenuView.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import type { CSSProperties } from 'react';
+
+export interface NavLinkMenuItemViewModel {
+  key: string;
+  target: string;
+  name: string;
+  isEmpty: boolean;
+}
+
+export interface UseNavLinkMenuViewResult {
+  hasItems: boolean;
+  baseLinkStyle: CSSProperties;
+  activeLinkStyle: CSSProperties;
+  inactiveLinkStyle: CSSProperties;
+  itemViewModels: NavLinkMenuItemViewModel[];
+}
+
+export function useNavLinkMenuView(
+  items: Array<{ name: string; url: string }>,
+): UseNavLinkMenuViewResult {
+  const baseLinkStyle = useMemo<CSSProperties>(() => ({
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    textDecoration: 'none',
+  }), []);
+
+  const activeLinkStyle = useMemo<CSSProperties>(
+    () => ({ ...baseLinkStyle, color: '#c34' }),
+    [baseLinkStyle],
+  );
+
+  const inactiveLinkStyle = useMemo<CSSProperties>(
+    () => ({ ...baseLinkStyle, color: '#545e6f' }),
+    [baseLinkStyle],
+  );
+
+  const itemViewModels = useMemo<NavLinkMenuItemViewModel[]>(() => (
+    items.map((item) => ({
+      key: item.url || item.name,
+      target: item.url,
+      name: item.name,
+      isEmpty: !item.url && !item.name,
+    }))
+  ), [items]);
+
+  return {
+    hasItems: items.length > 0,
+    baseLinkStyle,
+    activeLinkStyle,
+    inactiveLinkStyle,
+    itemViewModels,
+  };
+}

--- a/packages/ui/session-coordinator/src/SessionCoordinatorProvider.tsx
+++ b/packages/ui/session-coordinator/src/SessionCoordinatorProvider.tsx
@@ -1,9 +1,9 @@
-import { createContext, useContext, useMemo, type PropsWithChildren } from 'react';
+import { createContext, useContext, type PropsWithChildren } from 'react';
 import {
-  createTabSessionCoordinator,
   type TabSessionCoordinator,
   type TabSessionCoordinatorOptions,
 } from '@hierarchidb/session-coordinator';
+import { useTabSessionCoordinatorProviderView } from './useTabSessionCoordinatorProviderView.js';
 
 type TabSessionCoordinatorProviderProps = PropsWithChildren<{
   options?: TabSessionCoordinatorOptions;
@@ -12,16 +12,7 @@ type TabSessionCoordinatorProviderProps = PropsWithChildren<{
 const TabSessionCoordinatorContext = createContext<TabSessionCoordinator | null>(null);
 
 export const TabSessionCoordinatorProvider = ({ children, options }: TabSessionCoordinatorProviderProps) => {
-  const coordinator = useMemo(() => (
-    createTabSessionCoordinator(options)
-  ), [
-    options?.channelName,
-    options?.pollIntervalTimeout,
-    options?.quietThresholdTimeout,
-    options?.storage,
-    options?.storageKeys,
-    options?.now,
-  ]);
+  const { coordinator } = useTabSessionCoordinatorProviderView({ options });
   return (
     <TabSessionCoordinatorContext.Provider value={coordinator}>
       {children}

--- a/packages/ui/session-coordinator/src/useTabSessionCoordinatorProviderView.ts
+++ b/packages/ui/session-coordinator/src/useTabSessionCoordinatorProviderView.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import {
+  createTabSessionCoordinator,
+  type TabSessionCoordinator,
+  type TabSessionCoordinatorOptions,
+} from '@hierarchidb/session-coordinator';
+
+export interface UseTabSessionCoordinatorProviderViewParams {
+  options?: TabSessionCoordinatorOptions;
+}
+
+export interface UseTabSessionCoordinatorProviderViewResult {
+  coordinator: TabSessionCoordinator;
+}
+
+export function useTabSessionCoordinatorProviderView({
+  options,
+}: UseTabSessionCoordinatorProviderViewParams): UseTabSessionCoordinatorProviderViewResult {
+  const coordinator = useMemo(
+    () => createTabSessionCoordinator(options),
+    [
+      options?.channelName,
+      options?.pollIntervalTimeout,
+      options?.quietThresholdTimeout,
+      options?.storage,
+      options?.storageKeys,
+      options?.now,
+    ],
+  );
+
+  return {
+    coordinator,
+  };
+}

--- a/packages/ui/worker-provider/src/provider/WorkerSingletonProvider.tsx
+++ b/packages/ui/worker-provider/src/provider/WorkerSingletonProvider.tsx
@@ -7,19 +7,14 @@
  */
 
 import type { WorkerAPI } from '@hierarchidb/worker-api';
-import { WorkerInitializationChannel } from '@hierarchidb/ui-worker-client';
 import type React from 'react';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext } from 'react';
+import {
+  useWorkerSingletonProviderView,
+  type WorkerSingletonProviderState as WorkerState,
+} from './useWorkerSingletonProviderView.js';
 
 type WorkerClient = WorkerAPI<Record<string, unknown>>;
-
-interface WorkerState {
-  client: WorkerClient | null;
-  isReady: boolean;
-  error: Error | null;
-  progress: number;
-  message: string;
-}
 
 interface WorkerProviderProps {
   children: React.ReactNode;
@@ -38,98 +33,10 @@ export const WorkerSingletonProvider: React.FC<WorkerProviderProps> = ({
   getWorkerClient,
   getRawWorker,
 }) => {
-  const [state, setState] = useState<WorkerState>({
-    client: null,
-    isReady: false,
-    error: null,
-    progress: 0,
-    message: 'Initializing...',
+  const { state } = useWorkerSingletonProviderView({
+    getWorkerClient,
+    getRawWorker,
   });
-
-  useEffect(() => {
-    let mounted = true;
-    let retryCount = 0;
-    const maxRetries = 3;
-    const retryDelay = 1000;
-
-    const initializeWorker = async () => {
-      while (retryCount < maxRetries && mounted) {
-        try {
-          // Get the Worker client
-          const client = await getWorkerClient();
-
-          // Get the raw Worker instance for initialization detection
-          const workerInstance = getRawWorker();
-          if (!workerInstance) {
-            throw new Error('Raw Worker instance not accessible');
-          }
-
-          const initChannel = new WorkerInitializationChannel();
-
-          // Wait for Worker-side initialization to complete
-          const initResult = await initChannel.waitForInitialization({
-            worker: workerInstance,
-            timeout: 10000,
-            debug: false,
-          });
-
-          if (!initResult.success) {
-            const errorMessage =
-              typeof initResult.error === 'string'
-                ? initResult.error
-                : initResult.error instanceof Error
-                  ? initResult.error.message
-                  : 'Worker initialization failed';
-            throw new Error(errorMessage);
-          }
-
-          // Now verify Comlink communication is working
-          const pingable = client as WorkerClient & { ping?: () => Promise<unknown> };
-          if (typeof pingable.ping === 'function') {
-            try {
-              await pingable.ping();
-            } catch (verifyError) {
-              throw new Error(`Comlink verification failed: ${verifyError}`);
-            }
-          }
-
-          if (mounted) {
-            setState({
-              client,
-              isReady: true,
-              error: null,
-              progress: 100,
-              message: 'Ready',
-            });
-          }
-          return;
-        } catch (error) {
-          retryCount++;
-
-          if (retryCount >= maxRetries) {
-            if (mounted) {
-              setState({
-                client: null,
-                isReady: false,
-                error: error instanceof Error ? error : new Error('Failed to initialize Worker'),
-                progress: 0,
-                message: 'Failed to initialize',
-              });
-            }
-            return;
-          }
-
-          await new Promise((resolve) => setTimeout(resolve, retryDelay));
-        }
-      }
-    };
-
-    initializeWorker();
-
-    return () => {
-      mounted = false;
-    };
-  }, [getWorkerClient, getRawWorker]);
 
   // Show loading screen while initializing
   if (!state.isReady && !state.error) {

--- a/packages/ui/worker-provider/src/provider/useWorkerSingletonProviderView.ts
+++ b/packages/ui/worker-provider/src/provider/useWorkerSingletonProviderView.ts
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import { WorkerInitializationChannel } from '@hierarchidb/ui-worker-client';
+import type { WorkerAPI } from '@hierarchidb/worker-api';
+
+type WorkerClient = WorkerAPI<Record<string, unknown>>;
+
+export interface WorkerSingletonProviderState {
+  client: WorkerClient | null;
+  isReady: boolean;
+  error: Error | null;
+  progress: number;
+  message: string;
+}
+
+export interface UseWorkerSingletonProviderViewParams {
+  getWorkerClient: () => Promise<WorkerClient>;
+  getRawWorker: () => Worker | MessagePort | null;
+}
+
+export interface UseWorkerSingletonProviderViewResult {
+  state: WorkerSingletonProviderState;
+}
+
+const INITIAL_STATE: WorkerSingletonProviderState = {
+  client: null,
+  isReady: false,
+  error: null,
+  progress: 0,
+  message: 'Initializing...',
+};
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+export function useWorkerSingletonProviderView({
+  getWorkerClient,
+  getRawWorker,
+}: UseWorkerSingletonProviderViewParams): UseWorkerSingletonProviderViewResult {
+  const [state, setState] = useState<WorkerSingletonProviderState>(INITIAL_STATE);
+
+  useEffect(() => {
+    let mounted = true;
+    let retryCount = 0;
+    const maxRetries = 3;
+    const retryDelayMs = 1000;
+
+    const initializeWorker = async () => {
+      while (retryCount < maxRetries && mounted) {
+        try {
+          const client = await getWorkerClient();
+          const workerInstance = getRawWorker();
+          if (!workerInstance) {
+            throw new Error('Raw Worker instance not accessible');
+          }
+
+          const initChannel = new WorkerInitializationChannel();
+          const initResult = await initChannel.waitForInitialization({
+            worker: workerInstance,
+            timeout: 10000,
+            debug: false,
+          });
+
+          if (!initResult.success) {
+            const errorMessage =
+              typeof initResult.error === 'string'
+                ? initResult.error
+                : initResult.error instanceof Error
+                  ? initResult.error.message
+                  : 'Worker initialization failed';
+            throw new Error(errorMessage);
+          }
+
+          const pingable = client as WorkerClient & { ping?: () => Promise<unknown> };
+          if (typeof pingable.ping === 'function') {
+            await pingable.ping();
+          }
+
+          if (!mounted) return;
+
+          setState({
+            client,
+            isReady: true,
+            error: null,
+            progress: 100,
+            message: 'Ready',
+          });
+          return;
+        } catch (error) {
+          retryCount += 1;
+
+          if (retryCount >= maxRetries) {
+            if (!mounted) return;
+            setState({
+              client: null,
+              isReady: false,
+              error: error instanceof Error ? error : new Error('Failed to initialize Worker'),
+              progress: 0,
+              message: 'Failed to initialize',
+            });
+            return;
+          }
+
+          await sleep(retryDelayMs);
+        }
+      }
+    };
+
+    void initializeWorker();
+
+    return () => {
+      mounted = false;
+    };
+  }, [getRawWorker, getWorkerClient]);
+
+  return {
+    state,
+  };
+}


### PR DESCRIPTION
## Summary
- continue refactoring mixed component logic into `use*.ts` hooks under `packages/ui`
- extract view logic from CountryMatrixStep, NavLinkMenu, SessionCoordinatorProvider, and WorkerSingletonProvider
- keep hooks JSX-free and components focused on rendering
- update TASKS.md operation log for Issue #705

## Validation
- pnpm -w turbo run typecheck --filter @hierarchidb/ui-country-select
- pnpm -w turbo run build --filter @hierarchidb/ui-country-select
- pnpm -w turbo run typecheck --filter @hierarchidb/ui-navigation --filter @hierarchidb/ui-country-select
- pnpm -w turbo run build --filter @hierarchidb/ui-navigation --filter @hierarchidb/ui-country-select
- pnpm -w turbo run typecheck --filter @hierarchidb/ui-session-coordinator --filter @hierarchidb/ui-worker-provider
- pnpm -w turbo run build --filter @hierarchidb/ui-session-coordinator --filter @hierarchidb/ui-worker-provider
- pnpm check:ui-hooks-tsx
