### PR TITLE
fix(ui): follow-up hook review findings

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #718 / codex/fix/ui/hook-review-followups / 2026-03-04 00:46
 - #713 / codex/refactor/ui/hook-cleanup-followup / 2026-03-04 00:01
 - #711 / codex/fix/shape/pause-session-ref-sync / 2026-03-03 23:45
 - #705 / codex/refactor/ui-extract-logic-hooks / 2026-03-03 20:25
@@ -10,6 +11,8 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #718 開始 - hook抽出フォローアップ指摘（error再送出・未使用API削除・型重複/死蔵コード整理）に着手
+- 2026-03-04: Issue #718 進捗 - `useCommonDialogView` の submit/saveDraft で error 再送出を追加し、`useMenuListItemLinkButtonView` は `MenuItemLinkType` へ型統合（`pnpm -w turbo run typecheck --filter @hierarchidb/ui-dialog --filter @hierarchidb/ui-navigation --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/ui-search-result-window` / `pnpm -w turbo run test --filter @hierarchidb/ui-dialog --filter @hierarchidb/ui-navigation --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/ui-search-result-window` 成功）
 - 2026-03-04: Issue #713 開始 - `useCollapsibleSection`/`useSearchResultTable` の未使用APIと死蔵コードを整理
 - 2026-03-04: Issue #713 進捗 - `showHeader` と `selectedResults` フォールバックを削除し、不要 import/atom 参照を整理（`pnpm -w turbo run typecheck --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/ui-search-result-window` 成功）
 - 2026-03-03: Issue #711 開始 - pause同期判定の stale closure 問題を `sessionRecordRef` で修正

--- a/packages/ui/dialog/src/components/useCommonDialogView.ts
+++ b/packages/ui/dialog/src/components/useCommonDialogView.ts
@@ -53,6 +53,7 @@ export function useCommonDialogView({
       await onSubmit();
     } catch (error) {
       console.error('Dialog submission failed:', error);
+      throw error;
     } finally {
       setIsSubmitting(false);
     }
@@ -66,6 +67,7 @@ export function useCommonDialogView({
       onCancel();
     } catch (error) {
       console.error('Save draft failed:', error);
+      throw error;
     }
   }, [onCancel, onSaveDraft]);
 

--- a/packages/ui/navigation/src/components/MenuListItemButton/useMenuListItemLinkButtonView.ts
+++ b/packages/ui/navigation/src/components/MenuListItemButton/useMenuListItemLinkButtonView.ts
@@ -1,15 +1,11 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { CSSProperties, MouseEvent } from 'react';
 import { useLocation } from '@tanstack/react-router';
-
-export interface MenuItemLinkItem {
-  name: string;
-  url: string;
-}
+import type { MenuItemLinkType } from './MenuListItemLinkButton.js';
 
 export interface UseMenuListItemLinkButtonViewParams {
   id: string;
-  items: Array<MenuItemLinkItem | null>;
+  items: Array<MenuItemLinkType | null>;
 }
 
 export interface UseMenuListItemLinkButtonViewResult {


### PR DESCRIPTION
## Summary
- rethrow errors in `useCommonDialogView` async handlers (`handleSubmit`, `handleSaveDraft`) after logging
- remove duplicate `MenuItemLinkItem` type in `useMenuListItemLinkButtonView` and reuse `MenuItemLinkType`
- sync `TASKS.md` operation hub for Issue #718 start/progress logs

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/ui-dialog --filter @hierarchidb/ui-navigation --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/ui-search-result-window` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/ui-dialog --filter @hierarchidb/ui-navigation --filter @hierarchidb/ui-accordion-config --filter @hierarchidb/ui-search-result-window` (exit 0)

Closes #718
