### PR TITLE
docs: add repository-wide src/*.ts naming guideline

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #724 / codex/docs/ts-file-naming-guideline / 2026-03-04 07:19
 - #722 / codex/refactor/shape-plugin-tsx-hook-separation / 2026-03-04 02:24
 - #705 / codex/refactor/ui-p2-p3-hook-extract-batch / 2026-03-04 01:18
 - #705 / codex/refactor/ui-p1-hook-extract-batch / 2026-03-04 00:52
@@ -13,6 +14,8 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #724 進捗 - `docs/ts-file-naming-guideline.md` を新規作成し、`pnpm lint` と `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` の成功を確認
+- 2026-03-04: Issue #724 開始 - `src` 配下全体を対象に `*.ts` 命名指針ドキュメント（適用範囲・必須/禁止規約・例示・改名移行手順）を作成
 - 2026-03-04: Issue #722 進捗 - shape-plugin で 12 ファイルをフック分離し、`use*.tsx` 命名違反（実装コード側）を解消。残りは `SimplifyToleranceByAdminLevelCard.tsx` と `TaskItemDetailWindow.tsx`
 - 2026-03-04: blocked - `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` で既存失敗を確認（`useShapeBuildTaskSnapshotProgressState.unit.test.tsx` の stage count 期待差分、`TaskItemCardListCard.unit.test.tsx` の summary text 期待差分、`taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` および `TaskItemCard/__tests__/i18n-*` 系）
 - 2026-03-04: Issue #722 開始 - shape-plugin 配下 TSX のロジック分離（カスタムフック化、use*.tsx→use*.ts を含む）に着手

--- a/docs/ts-file-naming-guideline.md
+++ b/docs/ts-file-naming-guideline.md
@@ -1,0 +1,117 @@
+# `src/**/*.ts` ファイル命名指針
+
+本ドキュメントは、リポジトリ全体の `src` 配下にある `*.ts` ファイル名を、役割から一意に推測できる状態へ揃えるための指針です。
+
+## 対象範囲
+
+- `app/src/**/*.ts`
+- `packages/*/src/**/*.ts`
+- `plugins/*-plugin/src/**/*.ts`
+
+除外:
+
+- `*.tsx`（別ガイドの対象）
+- `dist/**` など生成物
+- `*.d.ts`（型宣言ポリシーは `docs/developer-guidelines.md` を参照）
+
+## 命名の基本原則
+
+1. ファイル名だけで「主責務」を推測できること。
+2. 1ファイル1主役（primary export）を原則とし、ファイル名と主役シンボル名を一致させること。
+3. 汎用名（`helper.ts`, `common.ts`, `misc.ts`, `temp.ts`）を禁止すること。
+4. 省略語はドメインで定着したものだけ許可し、任意短縮を避けること。
+
+## 必須ルール
+
+### 1. 主エクスポート一致
+
+- 主エクスポートが関数/クラス/オブジェクトなら、`camelCase` または `PascalCase` でシンボル名と同名にする。
+- 例: `useShapeBuildCacheActions` を主に export するなら `useShapeBuildCacheActions.ts`。
+
+### 2. Hook ファイル
+
+- Hook は必ず `use*.ts` とする。
+- `use*.tsx` は禁止（JSX を hook に持ち込まない）。
+- Hook の配下ロジックは `useXxx/` ディレクトリに分割し、親 hook からのみ公開する。
+
+### 3. 役割サフィックス
+
+- 型定義の集約: `types.ts`
+- 定数の集約: `constants.ts`
+- 純関数ユーティリティ: `utils.ts`
+- バリデーション: `validation.ts` / `validators.ts`
+
+補足:
+
+- `types.ts` / `utils.ts` / `constants.ts` は「そのディレクトリ境界内で責務が明確」な場合のみ許可する。
+- 境界が曖昧になる場合は、`<domain>Types.ts` などドメイン名を付与する。
+
+### 4. `index.ts` の例外
+
+- `index.ts` は再エクスポート専用入口としてのみ許可する。
+- 実ロジックを `index.ts` に書かない。
+
+### 5. 実装詳細ファイルの扱い
+
+- `*.internal.ts`: 同一ディレクトリ内 private 実装であることを明示する場合のみ使用可。
+- `*.impl.ts`: インターフェース実装差し替え点を表す場合のみ使用可。
+- `*.core.ts`: アルゴリズム中核を切り出す場合のみ使用可。
+
+上記サフィックスは乱用禁止。理由なく使う場合は、より具体的なドメイン名へ改名する。
+
+## 禁止パターン
+
+- 意味が広すぎる名前: `common.ts`, `shared.ts`, `helper.ts`, `util.ts`, `tmp.ts`
+- 役割と不一致な名前: `formatDate.ts` に stateful 処理や I/O を含める
+- 逆方向依存を隠す名前: 実態が UI 専用なのに `core.ts` と命名する
+
+## Good / Bad 例
+
+### packages 配下
+
+- Good: `packages/runtime-worker/src/services/buildSessionBroadcast.ts`
+  - 理由: ドメイン（build session）と責務（broadcast）が明確。
+- Bad: `packages/runtime-worker/src/services/helper.ts`
+  - 理由: 何を補助する helper なのか判別できず、責務が推測できない。
+
+- Good: `packages/plugin-registry/src/index.ts`
+  - 理由: 入口ファイルであることが明確で、`index.ts` 例外ルールに一致。
+- Bad: `packages/plugin-registry/src/common.ts`
+  - 理由: 利用範囲が肥大化しやすく、責務が不明瞭。
+
+### plugins 配下
+
+- Good: `plugins/shape-plugin/src/ui/hooks/useShapeBuildCacheActions.ts`
+  - 理由: plugin 固有ドメイン + hook 名が一致している。
+- Bad: `plugins/shape-plugin/src/ui/hooks/useCache.ts`
+  - 理由: キャッシュ種別・責務境界が不明。
+
+- Good: `plugins/location-plugin/src/common/hooks/useLocationProgress.ts`
+  - 理由: レイヤ（common/hooks）と責務（location progress）が明確。
+- Bad: `plugins/location-plugin/src/worker/internal.ts`
+  - 理由: 実体を示さず、検索性が低い。
+
+## 改名の判断基準
+
+次を1つでも満たすなら改名候補とする。
+
+1. ファイル名から主エクスポートを推測できない。
+2. ファイル名と実装責務が一致しない。
+3. `utils.ts` など汎用名が複数ドメインの処理を抱えている。
+4. `internal/impl/core` サフィックスが「理由なし」で使われている。
+
+## 改名手順（運用）
+
+1. 変更前に Issue へ対象ファイルと改名理由を記載する。
+2. `git mv` で rename し、同一PRで import を全更新する。
+3. 旧名ファイルを残さない（段階移行しない）。
+4. `pnpm lint && pnpm typecheck && pnpm test`（必要フィルタ付き）で回帰確認する。
+5. PR には「命名理由」と「ロールバック方法（rename 戻し）」を明記する。
+
+## レビュー観点（チェックリスト）
+
+- [ ] ファイル名と主エクスポート名は一致しているか
+- [ ] 汎用名ファイルに責務が混在していないか
+- [ ] `index.ts` に実装ロジックが入っていないか
+- [ ] `use*.ts` 以外の hook 命名違反がないか
+- [ ] `internal/impl/core` の使用理由が説明可能か


### PR DESCRIPTION
## Summary
- add a repository-wide naming guideline document for `src/**/*.ts`
- define scope, required rules, prohibited patterns, and rename procedure
- add TASKS.md operation-log entries for issue #724

## Verification
- pnpm lint
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin

Closes #724
