### PR TITLE
fix(runtime-worker): repair stale running build sessions

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #753 / codex/fix/session/archive-build-session-consistency / 2026-03-04 11:23
 - #750 / codex/fix/shape-plugin/geometry-retrymax-contract / 2026-03-04 11:08
 - #747 / fix/shape-plugin/taskitemcard-status-narrowing / 2026-03-04 10:48
 - #745 / fix/shape/step5-preview-metrics / 2026-03-04 10:58
@@ -28,6 +29,8 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #753 進捗 - `runtime-worker` に stale running build session 整合化を追加（アーカイブガード時の self-heal + Worker 起動時検査）。`pnpm -w turbo run build --filter @hierarchidb/runtime-worker` / `pnpm -w turbo run typecheck --filter @hierarchidb/runtime-worker` / `pnpm -w turbo run test --filter @hierarchidb/runtime-worker` は成功（exit 0）。
+- 2026-03-04: Issue #753 開始 - ノードアーカイブ時に「ビルドセッション実行中」誤判定が出る問題について、永続 sessions 不整合の発生経路修正と初期化時自己修復の要否検討に着手
 - 2026-03-04: Issue #750 進捗 - `pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` はすべて成功（exit 0）。受け側 message 復元ロジックを撤去し、出し側 metadata (`retryMax`) 契約で統一。
 - 2026-03-04: Issue #750 開始 - shape-plugin geometry terminal task の `retryMax` 欠損クラッシュについて、受け側フォールバックを排除し出し側（vt-orchestrator）の metadata 契約修正に着手
 - 2026-03-04: Issue #747 進捗 - `TaskItemCard.tsx` の status 分岐を確認し、報告されていた到達不能比較（`task.status === 'failed'` in completed branch）は現行コード上で解消済みであることを確認。`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` と `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --force` はいずれも成功（exit 0）。

--- a/packages/runtime-worker/src/WorkerService.ts
+++ b/packages/runtime-worker/src/WorkerService.ts
@@ -40,7 +40,7 @@ import { TreeQueryService } from './services/TreeQueryService.js';
 import { TreeSubscriptionService } from './services/TreeSubscriptionService.js';
 import { TreeTableExpandedService } from './services/TreeTableExpandedService.js';
 import { UIStateDB } from './services/UIStateDB.js';
-import { ephemeralDB } from '@hierarchidb/gis-sdk';
+import { reconcileRunningBuildSessions } from './services/utils/reconcileStaleBuildSessions.js';
 import type { RuntimePluginDefinition } from './types/RuntimePluginDefinition.js';
 
 interface PerformanceMemoryStats {
@@ -190,11 +190,13 @@ export class WorkerService {
 
   private static async recoverBuildSessionRuntimeRecordsOnWarmStart(): Promise<void> {
     try {
-      await ephemeralDB.open?.();
-      const sessions = await ephemeralDB.buildSessions.toArray();
-      if (sessions.length === 0) return;
-      // Keep session records for resume/recovery flow; runtime state can be reconstructed.
-      return;
+      const result = await reconcileRunningBuildSessions();
+      if (result.repairedNodeIds.length > 0) {
+        console.warn('[WorkerService] Repaired stale running build sessions on startup', {
+          repairedNodeIds: result.repairedNodeIds,
+          checkedCount: result.checkedNodeIds.length,
+        });
+      }
     } catch (error) {
       console.error('[WorkerService] Failed to recover persisted build sessions', error);
     }

--- a/packages/runtime-worker/src/services/TreeMutationService.ts
+++ b/packages/runtime-worker/src/services/TreeMutationService.ts
@@ -11,7 +11,6 @@ import type {
   UndoPayload,
 } from '@hierarchidb/tree-api';
 import { DEFAULT_BUILD_CONFIG, DEFAULT_PROCESSING_CONFIG } from '@hierarchidb/shape-api';
-import { ephemeralDB } from '@hierarchidb/gis-sdk';
 import { SingletonMixin } from '@hierarchidb/util';
 import { EntityLifecycleManager } from '~/entity/EntityLifecycleManager';
 import { resolveDefaultNodeName } from '~/utils/resolveDefaultNodeName';
@@ -21,6 +20,7 @@ import type { CoreDB } from './CoreDB.js';
 import { createNewName } from './DraftTreeNodeOperations.js';
 import { generateNodeId } from './generateNodeId.js';
 import { sanitizeMessageText } from './utils/error-adapter.js';
+import { reconcileRunningBuildSessions } from './utils/reconcileStaleBuildSessions.js';
 import { hasRouteReferencesToLocations } from '@hierarchidb/route-store';
 import { hasLocationReferencesToShapes } from '@hierarchidb/location-store';
 
@@ -29,8 +29,6 @@ const getCommandError = (result: CoreCommandResult, fallback = 'Unknown error'):
   const failure = result as Extract<CoreCommandResult, { success: false }>;
   return failure.error;
 };
-
-const RUNNING_BUILD_SESSION_STATUS = 'running';
 
 export class TreeMutationService implements TreeMutationAPI {
   // Note: Implementation now routes all mutating operations via CommandProcessor.
@@ -163,8 +161,6 @@ export class TreeMutationService implements TreeMutationAPI {
   ): Promise<{ blocked: boolean; message?: string }> {
     if (nodeIds.length === 0) return { blocked: false };
 
-    await ephemeralDB.open?.();
-
     const nodes = await Promise.all(nodeIds.map(async (id) => this.coreDB.getNode?.(id)));
     const shapeNodeIds = Array.from(
       new Set(
@@ -177,8 +173,8 @@ export class TreeMutationService implements TreeMutationAPI {
       return { blocked: false };
     }
 
-    const sessions = await ephemeralDB.buildSessionStatuses.bulkGet(shapeNodeIds);
-    if (sessions.some((session) => session?.status === RUNNING_BUILD_SESSION_STATUS)) {
+    const consistency = await reconcileRunningBuildSessions({ nodeIds: shapeNodeIds });
+    if (consistency.activeNodeIds.length > 0) {
       return {
         blocked: true,
         message: 'TRASH_BUILD_SESSION_RUNNING',

--- a/packages/runtime-worker/src/services/__tests__/unit/tree-mutation-archive-build-session-guard.unit.test.ts
+++ b/packages/runtime-worker/src/services/__tests__/unit/tree-mutation-archive-build-session-guard.unit.test.ts
@@ -4,23 +4,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CommandProcessor } from '../../CommandProcessor';
 import type { CoreDB } from '../../CoreDB';
 
-const buildSessionStatusesBulkGetMock = vi.hoisted(() => vi.fn());
-const sessionsOpenMock = vi.hoisted(() => vi.fn(async () => undefined));
+const reconcileRunningBuildSessionsMock = vi.hoisted(() => vi.fn(async () => ({
+  checkedNodeIds: [],
+  activeNodeIds: [],
+  repairedNodeIds: [],
+})));
 const hasRouteReferencesToLocationsMock = vi.hoisted(() => vi.fn(async () => false));
 const hasLocationReferencesToShapesMock = vi.hoisted(() => vi.fn(async () => false));
 
-vi.mock('@hierarchidb/gis-sdk', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@hierarchidb/gis-sdk')>();
+vi.mock('../../utils/reconcileStaleBuildSessions.js', () => {
   return {
-    ...actual,
-    ephemeralDB: {
-      ...actual.ephemeralDB,
-      open: sessionsOpenMock,
-      buildSessionStatuses: {
-        ...actual.ephemeralDB.buildSessionStatuses,
-        bulkGet: buildSessionStatusesBulkGetMock,
-      },
-    },
+    reconcileRunningBuildSessions: reconcileRunningBuildSessionsMock,
   };
 });
 
@@ -90,8 +84,11 @@ describe('TreeMutationService moveNodesToArchive running session guard', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    sessionsOpenMock.mockResolvedValue(undefined);
-    buildSessionStatusesBulkGetMock.mockResolvedValue([]);
+    reconcileRunningBuildSessionsMock.mockResolvedValue({
+      checkedNodeIds: [],
+      activeNodeIds: [],
+      repairedNodeIds: [],
+    });
     hasRouteReferencesToLocationsMock.mockResolvedValue(false);
     hasLocationReferencesToShapesMock.mockResolvedValue(false);
   });
@@ -103,7 +100,11 @@ describe('TreeMutationService moveNodesToArchive running session guard', () => {
     ]);
     const core = createCoreMock(nodes) as Partial<CoreDB> as CoreDB;
     const processor = createCommandProcessorMock(core);
-    buildSessionStatusesBulkGetMock.mockResolvedValue([{ nodeId: 'shape-1', status: 'running' }]);
+    reconcileRunningBuildSessionsMock.mockResolvedValue({
+      checkedNodeIds: [asNodeId('shape-1')],
+      activeNodeIds: [asNodeId('shape-1')],
+      repairedNodeIds: [],
+    });
 
     const { TreeMutationService } = await import('../../TreeMutationService');
     const service = new TreeMutationService(
@@ -114,7 +115,7 @@ describe('TreeMutationService moveNodesToArchive running session guard', () => {
     const result = await service.moveNodesToArchive([asNodeId('shape-1')]);
 
     expect(result).toEqual({ success: false, error: 'TRASH_BUILD_SESSION_RUNNING' });
-    expect(buildSessionStatusesBulkGetMock).toHaveBeenCalledWith([asNodeId('shape-1')]);
+    expect(reconcileRunningBuildSessionsMock).toHaveBeenCalledWith({ nodeIds: [asNodeId('shape-1')] });
     expect(processor.processCommand).not.toHaveBeenCalled();
   });
 
@@ -125,7 +126,11 @@ describe('TreeMutationService moveNodesToArchive running session guard', () => {
     ]);
     const core = createCoreMock(nodes) as Partial<CoreDB> as CoreDB;
     const processor = createCommandProcessorMock(core);
-    buildSessionStatusesBulkGetMock.mockResolvedValue([{ nodeId: 'shape-1', status: 'completed' }]);
+    reconcileRunningBuildSessionsMock.mockResolvedValue({
+      checkedNodeIds: [asNodeId('shape-1')],
+      activeNodeIds: [],
+      repairedNodeIds: [],
+    });
 
     const { TreeMutationService } = await import('../../TreeMutationService');
     const service = new TreeMutationService(
@@ -136,7 +141,7 @@ describe('TreeMutationService moveNodesToArchive running session guard', () => {
     const result = await service.moveNodesToArchive([asNodeId('shape-1')]);
 
     expect(result).toEqual({ success: true });
-    expect(buildSessionStatusesBulkGetMock).toHaveBeenCalledWith([asNodeId('shape-1')]);
+    expect(reconcileRunningBuildSessionsMock).toHaveBeenCalledWith({ nodeIds: [asNodeId('shape-1')] });
     expect(processor.processCommand).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/runtime-worker/src/services/utils/__tests__/reconcileStaleBuildSessions.unit.test.ts
+++ b/packages/runtime-worker/src/services/utils/__tests__/reconcileStaleBuildSessions.unit.test.ts
@@ -1,0 +1,155 @@
+import type { NodeId } from '@hierarchidb/core-types';
+import { describe, expect, it, vi } from 'vitest';
+import { reconcileRunningBuildSessions } from '../reconcileStaleBuildSessions.js';
+
+const asNodeId = (value: string): NodeId => value as NodeId;
+
+type MockDb = {
+  open: ReturnType<typeof vi.fn>;
+  buildSessionStatuses: {
+    bulkGet: ReturnType<typeof vi.fn>;
+    where: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  buildSessionHeartbeats: {
+    bulkGet: ReturnType<typeof vi.fn>;
+  };
+  buildSessions: {
+    bulkGet: ReturnType<typeof vi.fn>;
+  };
+  buildTasks: {
+    where: ReturnType<typeof vi.fn>;
+  };
+};
+
+const createDbMock = (params?: {
+  statuses?: Array<{ nodeId: NodeId; status: string } | undefined>;
+  heartbeatByNode?: Record<string, number | undefined>;
+  startedAtByNode?: Record<string, number | undefined>;
+  activeTaskCountByNode?: Record<string, number>;
+}) => {
+  const statuses = params?.statuses ?? [];
+  const heartbeatByNode = params?.heartbeatByNode ?? {};
+  const startedAtByNode = params?.startedAtByNode ?? {};
+  const activeTaskCountByNode = params?.activeTaskCountByNode ?? {};
+
+  const update = vi.fn(async () => 1);
+  const bulkGetStatuses = vi.fn(async (nodeIds: NodeId[]) => (
+    nodeIds.map((nodeId) => statuses.find((status) => status?.nodeId === nodeId))
+  ));
+  const statusWhere = vi.fn(() => ({
+    equals: vi.fn(() => ({
+      toArray: vi.fn(async () => statuses.filter((status): status is { nodeId: NodeId; status: string } => Boolean(status))),
+    })),
+  }));
+  const bulkGetHeartbeats = vi.fn(async (nodeIds: NodeId[]) => (
+    nodeIds.map((nodeId) => {
+      const value = heartbeatByNode[String(nodeId)];
+      return typeof value === 'number' ? { nodeId, lastHeartbeatAt: value } : undefined;
+    })
+  ));
+  const bulkGetConfigs = vi.fn(async (nodeIds: NodeId[]) => (
+    nodeIds.map((nodeId) => {
+      const value = startedAtByNode[String(nodeId)];
+      return typeof value === 'number' ? { nodeId, startedAt: value } : undefined;
+    })
+  ));
+  const whereTasks = vi.fn((_index: '[nodeId+status]') => ({
+    anyOf: (keys: Array<[NodeId, 'running' | 'queued']>) => {
+      const nodeId = keys[0]?.[0];
+      return {
+        count: vi.fn(async () => activeTaskCountByNode[String(nodeId)] ?? 0),
+      };
+    },
+  }));
+
+  const db: MockDb = {
+    open: vi.fn(async () => undefined),
+    buildSessionStatuses: {
+      bulkGet: bulkGetStatuses,
+      where: statusWhere,
+      update,
+    },
+    buildSessionHeartbeats: {
+      bulkGet: bulkGetHeartbeats,
+    },
+    buildSessions: {
+      bulkGet: bulkGetConfigs,
+    },
+    buildTasks: {
+      where: whereTasks,
+    },
+  };
+
+  return { db, update, whereTasks };
+};
+
+describe('reconcileRunningBuildSessions', () => {
+  it('keeps active running session when running tasks exist', async () => {
+    const nodeId = asNodeId('shape-1');
+    const now = 1_000_000;
+    const { db, update } = createDbMock({
+      statuses: [{ nodeId, status: 'running' }],
+      heartbeatByNode: { 'shape-1': now - 500_000 },
+      startedAtByNode: { 'shape-1': now - 500_000 },
+      activeTaskCountByNode: { 'shape-1': 2 },
+    });
+
+    const result = await reconcileRunningBuildSessions({
+      db: db as never,
+      nodeIds: [nodeId],
+      now,
+      staleTimeoutMs: 1_000,
+    });
+
+    expect(result.activeNodeIds).toEqual([nodeId]);
+    expect(result.repairedNodeIds).toEqual([]);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('repairs stale running session when no active tasks and heartbeat is stale', async () => {
+    const nodeId = asNodeId('shape-1');
+    const now = 1_000_000;
+    const { db, update } = createDbMock({
+      statuses: [{ nodeId, status: 'running' }],
+      heartbeatByNode: { 'shape-1': now - 10_000 },
+      startedAtByNode: { 'shape-1': now - 50_000 },
+      activeTaskCountByNode: { 'shape-1': 0 },
+    });
+
+    const result = await reconcileRunningBuildSessions({
+      db: db as never,
+      nodeIds: [nodeId],
+      now,
+      staleTimeoutMs: 1_000,
+    });
+
+    expect(result.activeNodeIds).toEqual([]);
+    expect(result.repairedNodeIds).toEqual([nodeId]);
+    expect(update).toHaveBeenCalledWith(nodeId, {
+      status: 'failed',
+      stopReason: 'unknown',
+      completedAt: now,
+    });
+  });
+
+  it('repairs running session without heartbeat/config and no active tasks', async () => {
+    const nodeId = asNodeId('shape-1');
+    const now = 1_000_000;
+    const { db, update } = createDbMock({
+      statuses: [{ nodeId, status: 'running' }],
+      activeTaskCountByNode: { 'shape-1': 0 },
+    });
+
+    const result = await reconcileRunningBuildSessions({
+      db: db as never,
+      nodeIds: [nodeId],
+      now,
+      staleTimeoutMs: 30_000,
+    });
+
+    expect(result.activeNodeIds).toEqual([]);
+    expect(result.repairedNodeIds).toEqual([nodeId]);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/runtime-worker/src/services/utils/reconcileStaleBuildSessions.ts
+++ b/packages/runtime-worker/src/services/utils/reconcileStaleBuildSessions.ts
@@ -1,0 +1,151 @@
+import type { NodeId } from '@hierarchidb/core-types';
+import { ephemeralDB } from '@hierarchidb/gis-sdk';
+
+type BuildSessionStatusRow = {
+  nodeId: NodeId;
+  status: string;
+};
+
+type BuildSessionHeartbeatRow = {
+  nodeId: NodeId;
+  lastHeartbeatAt: number;
+};
+
+type BuildSessionConfigRow = {
+  nodeId: NodeId;
+  startedAt: number;
+};
+
+interface BuildSessionConsistencyDB {
+  open?: () => Promise<unknown>;
+  buildSessionStatuses: {
+    bulkGet: (keys: NodeId[]) => Promise<Array<BuildSessionStatusRow | undefined>>;
+    where: (index: 'status') => {
+      equals: (value: string) => {
+        toArray: () => Promise<BuildSessionStatusRow[]>;
+      };
+    };
+    update: (
+      key: NodeId,
+      changes: Partial<{ status: string; stopReason: string; completedAt: number }>
+    ) => Promise<unknown>;
+  };
+  buildSessionHeartbeats: {
+    bulkGet: (keys: NodeId[]) => Promise<Array<BuildSessionHeartbeatRow | undefined>>;
+  };
+  buildSessions: {
+    bulkGet: (keys: NodeId[]) => Promise<Array<BuildSessionConfigRow | undefined>>;
+  };
+  buildTasks: {
+    where: (index: '[nodeId+status]') => {
+      anyOf: (keys: Array<[NodeId, 'running' | 'queued']>) => {
+        count: () => Promise<number>;
+      };
+    };
+  };
+}
+
+const DEFAULT_STALE_TIMEOUT_MS = 120_000;
+
+export type ReconcileRunningBuildSessionsResult = {
+  checkedNodeIds: NodeId[];
+  activeNodeIds: NodeId[];
+  repairedNodeIds: NodeId[];
+};
+
+const resolveLastActivityAt = (
+  heartbeat: BuildSessionHeartbeatRow | undefined,
+  config: BuildSessionConfigRow | undefined
+): number | null => {
+  if (typeof heartbeat?.lastHeartbeatAt === 'number' && Number.isFinite(heartbeat.lastHeartbeatAt)) {
+    return heartbeat.lastHeartbeatAt;
+  }
+  if (typeof config?.startedAt === 'number' && Number.isFinite(config.startedAt)) {
+    return config.startedAt;
+  }
+  return null;
+};
+
+const isStaleInactiveRunningSession = (params: {
+  activeTaskCount: number;
+  now: number;
+  lastActivityAt: number | null;
+  staleTimeoutMs: number;
+}): boolean => {
+  if (params.activeTaskCount > 0) return false;
+  if (params.lastActivityAt === null) return true;
+  return (params.now - params.lastActivityAt) > params.staleTimeoutMs;
+};
+
+export const reconcileRunningBuildSessions = async (params?: {
+  nodeIds?: NodeId[];
+  now?: number;
+  staleTimeoutMs?: number;
+  db?: BuildSessionConsistencyDB;
+}): Promise<ReconcileRunningBuildSessionsResult> => {
+  const db = params?.db ?? (ephemeralDB as unknown as BuildSessionConsistencyDB);
+  const now = params?.now ?? Date.now();
+  const staleTimeoutMs = params?.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS;
+
+  await db.open?.();
+
+  const candidateStatuses = params?.nodeIds && params.nodeIds.length > 0
+    ? await db.buildSessionStatuses.bulkGet(params.nodeIds)
+    : await db.buildSessionStatuses.where('status').equals('running').toArray();
+
+  const runningStatuses = candidateStatuses.filter(
+    (status): status is BuildSessionStatusRow => Boolean(status && status.status === 'running')
+  );
+  const runningNodeIds = runningStatuses.map((status) => status.nodeId);
+  if (runningNodeIds.length === 0) {
+    return {
+      checkedNodeIds: [],
+      activeNodeIds: [],
+      repairedNodeIds: [],
+    };
+  }
+
+  const [heartbeats, configs, activeTaskCounts] = await Promise.all([
+    db.buildSessionHeartbeats.bulkGet(runningNodeIds),
+    db.buildSessions.bulkGet(runningNodeIds),
+    Promise.all(
+      runningNodeIds.map((nodeId) =>
+        db.buildTasks.where('[nodeId+status]').anyOf([
+          [nodeId, 'running'],
+          [nodeId, 'queued'],
+        ]).count()
+      )
+    ),
+  ]);
+
+  const activeNodeIds: NodeId[] = [];
+  const repairedNodeIds: NodeId[] = [];
+  await Promise.all(
+    runningNodeIds.map(async (nodeId, index) => {
+      const activeTaskCount = activeTaskCounts[index] ?? 0;
+      const lastActivityAt = resolveLastActivityAt(heartbeats[index], configs[index]);
+      const isStale = isStaleInactiveRunningSession({
+        activeTaskCount,
+        now,
+        lastActivityAt,
+        staleTimeoutMs,
+      });
+      if (!isStale) {
+        activeNodeIds.push(nodeId);
+        return;
+      }
+      await db.buildSessionStatuses.update(nodeId, {
+        status: 'failed',
+        stopReason: 'unknown',
+        completedAt: now,
+      });
+      repairedNodeIds.push(nodeId);
+    })
+  );
+
+  return {
+    checkedNodeIds: runningNodeIds,
+    activeNodeIds,
+    repairedNodeIds,
+  };
+};


### PR DESCRIPTION
## Summary
- add `reconcileRunningBuildSessions` to detect/repair stale `buildSessionStatuses=running`
- use the reconciler in `TreeMutationService` archive guard to avoid false positives from stale persisted sessions
- run the same reconciliation on worker startup in `recoverBuildSessionRuntimeRecordsOnWarmStart`
- add unit tests for stale-session reconciliation and update archive-guard unit tests

## Root Cause
- archive guard checked only persisted `buildSessionStatuses.status === running`
- stale running records (no active build tasks) could remain and block archive operations

## Verification
- pnpm -w turbo run build --filter @hierarchidb/runtime-worker
- pnpm -w turbo run typecheck --filter @hierarchidb/runtime-worker
- pnpm -w turbo run test --filter @hierarchidb/runtime-worker

Fixes #753
