### PR TITLE
fix: build session永続テーブル不整合でアーカイブ誤判定になる問題を修正 (#755)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #755 / codex/fix/session/worker-state-consistency-755 / 2026-03-04 11:34
 - #753 / codex/fix/session/archive-build-session-consistency / 2026-03-04 11:23
 - #750 / codex/fix/shape-plugin/geometry-retrymax-contract / 2026-03-04 11:08
 - #747 / fix/shape-plugin/taskitemcard-status-narrowing / 2026-03-04 10:48
@@ -29,6 +30,8 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #755 進捗 - セッション4テーブル整合性の欠損経路を修正（status/stage を `update` から `get+put` upsert へ変更、stale 判定を running task 基準へ是正）。回帰テストを追加/更新し、`pnpm -w turbo run test --filter @hierarchidb/runtime-worker -- --run src/services/__tests__/unit/tree-mutation-archive-build-session-guard.unit.test.ts src/services/utils/__tests__/reconcileStaleBuildSessions.unit.test.ts src/services/__tests__/unit/shape-mutation-session-upsert.unit.test.ts` と `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/shapeBuildApiClient.updateBuildSession.unit.test.ts` は成功（exit 0）。
+- 2026-03-04: Issue #755 開始 - Worker session 4テーブル整合性と通知4系統（全体/snapshot/progress/heartbeat）を対象に、アーカイブ誤判定・リロード復元/リセット不整合・停止即時反映不具合の再現テスト追加と原因修正に着手
 - 2026-03-04: Issue #753 進捗 - `runtime-worker` に stale running build session 整合化を追加（アーカイブガード時の self-heal + Worker 起動時検査）。`pnpm -w turbo run build --filter @hierarchidb/runtime-worker` / `pnpm -w turbo run typecheck --filter @hierarchidb/runtime-worker` / `pnpm -w turbo run test --filter @hierarchidb/runtime-worker` は成功（exit 0）。
 - 2026-03-04: Issue #753 開始 - ノードアーカイブ時に「ビルドセッション実行中」誤判定が出る問題について、永続 sessions 不整合の発生経路修正と初期化時自己修復の要否検討に着手
 - 2026-03-04: Issue #750 進捗 - `pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` はすべて成功（exit 0）。受け側 message 復元ロジックを撤去し、出し側 metadata (`retryMax`) 契約で統一。

--- a/packages/runtime-worker/src/services/ShapeMutationService.ts
+++ b/packages/runtime-worker/src/services/ShapeMutationService.ts
@@ -172,14 +172,16 @@ export class ShapeMutationService implements ShapeMutationAPI {
     const statusFields = ['status', 'stopReason', 'completedAt'] as const;
     const hasStatusUpdate = statusFields.some(field => updates[field] !== undefined);
     if (hasStatusUpdate) {
-      const statusUpdate: Partial<BuildSessionStatus> = { nodeId };
-      if (updates.status !== undefined) statusUpdate.status = updates.status;
-      if (updates.stopReason !== undefined) statusUpdate.stopReason = updates.stopReason;
-      if (updates.completedAt !== undefined) statusUpdate.completedAt = updates.completedAt;
-      
-      updatePromises.push(
-        ephemeralDB.buildSessionStatuses.update(nodeId, statusUpdate)
-      );
+      updatePromises.push((async () => {
+        const currentStatus = await ephemeralDB.buildSessionStatuses.get(nodeId);
+        const nextStatus: BuildSessionStatus = {
+          nodeId,
+          status: updates.status ?? currentStatus?.status ?? 'idle',
+          stopReason: updates.stopReason ?? currentStatus?.stopReason,
+          completedAt: updates.completedAt ?? currentStatus?.completedAt,
+        };
+        await ephemeralDB.buildSessionStatuses.put(nextStatus);
+      })());
     }
     
     // Stage update - update buildStageStatuses table
@@ -205,15 +207,20 @@ export class ShapeMutationService implements ShapeMutationAPI {
       
       if (currentStage) {
         const stageId = `${nodeId}:${currentStage}`;
-        const stageUpdate: Partial<BuildStageStatus> = {};
-        
-        if (updates.stageInactiveMs !== undefined) stageUpdate.inactiveMs = updates.stageInactiveMs;
-        if (updates.stageStartedAt !== undefined) stageUpdate.startedAt = updates.stageStartedAt;
-        if (updates.stageId !== undefined) stageUpdate.stageId = updates.stageId;
-        
-        updatePromises.push(
-          ephemeralDB.buildStageStatuses.update(stageId, stageUpdate)
-        );
+        updatePromises.push((async () => {
+          const currentStageStatus = await ephemeralDB.buildStageStatuses.get(stageId);
+          const nextStageStatus: BuildStageStatus = {
+            id: stageId,
+            nodeId,
+            stage: currentStage,
+            status: currentStageStatus?.status ?? 'running',
+            startedAt: updates.stageStartedAt ?? currentStageStatus?.startedAt ?? Date.now(),
+            inactiveMs: updates.stageInactiveMs ?? currentStageStatus?.inactiveMs,
+            stageId: updates.stageId ?? currentStageStatus?.stageId,
+            completedAt: currentStageStatus?.completedAt,
+          };
+          await ephemeralDB.buildStageStatuses.put(nextStageStatus);
+        })());
       }
     }
     

--- a/packages/runtime-worker/src/services/__tests__/unit/shape-mutation-session-upsert.unit.test.ts
+++ b/packages/runtime-worker/src/services/__tests__/unit/shape-mutation-session-upsert.unit.test.ts
@@ -1,0 +1,86 @@
+import type { NodeId } from '@hierarchidb/core-types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ShapeMutationService } from '../../ShapeMutationService';
+
+const openMock = vi.hoisted(() => vi.fn(async () => undefined));
+const heartbeatPutMock = vi.hoisted(() => vi.fn(async () => undefined));
+const statusGetMock = vi.hoisted(() => vi.fn(async () => undefined));
+const statusPutMock = vi.hoisted(() => vi.fn(async () => undefined));
+const stageGetMock = vi.hoisted(() => vi.fn(async () => undefined));
+const stagePutMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('@hierarchidb/gis-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hierarchidb/gis-sdk')>();
+  return {
+    ...actual,
+    ephemeralDB: {
+      ...actual.ephemeralDB,
+      open: openMock,
+      buildSessionHeartbeats: {
+        ...actual.ephemeralDB.buildSessionHeartbeats,
+        put: heartbeatPutMock,
+      },
+      buildSessionStatuses: {
+        ...actual.ephemeralDB.buildSessionStatuses,
+        get: statusGetMock,
+        put: statusPutMock,
+      },
+      buildStageStatuses: {
+        ...actual.ephemeralDB.buildStageStatuses,
+        get: stageGetMock,
+        put: stagePutMock,
+      },
+    },
+  };
+});
+
+const asNodeId = (value: string): NodeId => value as NodeId;
+
+describe('ShapeMutationService.updateBuildSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-04T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('upserts session status row when status row is missing', async () => {
+    const service = new ShapeMutationService({ open: openMock } as never);
+    statusGetMock.mockResolvedValue(undefined);
+
+    await service.updateBuildSession(asNodeId('shape-1'), {
+      status: 'paused',
+      stopReason: 'user-pause',
+    } as never);
+
+    expect(statusPutMock).toHaveBeenCalledWith({
+      nodeId: asNodeId('shape-1'),
+      status: 'paused',
+      stopReason: 'user-pause',
+      completedAt: undefined,
+    });
+  });
+
+  it('upserts stage row when stage row is missing', async () => {
+    const service = new ShapeMutationService({ open: openMock } as never);
+    stageGetMock.mockResolvedValue(undefined);
+
+    await service.updateBuildSession(asNodeId('shape-1'), {
+      stages: {
+        geometry: { status: 'running' },
+      },
+      stageId: 'geometry:run',
+    } as never);
+
+    expect(stagePutMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'shape-1:geometry',
+      nodeId: asNodeId('shape-1'),
+      stage: 'geometry',
+      status: 'running',
+      stageId: 'geometry:run',
+    }));
+  });
+});

--- a/packages/runtime-worker/src/services/utils/__tests__/reconcileStaleBuildSessions.unit.test.ts
+++ b/packages/runtime-worker/src/services/utils/__tests__/reconcileStaleBuildSessions.unit.test.ts
@@ -55,7 +55,7 @@ const createDbMock = (params?: {
     })
   ));
   const whereTasks = vi.fn((_index: '[nodeId+status]') => ({
-    anyOf: (keys: Array<[NodeId, 'running' | 'queued']>) => {
+    anyOf: (keys: Array<[NodeId, 'running']>) => {
       const nodeId = keys[0]?.[0];
       return {
         count: vi.fn(async () => activeTaskCountByNode[String(nodeId)] ?? 0),
@@ -131,6 +131,28 @@ describe('reconcileRunningBuildSessions', () => {
       stopReason: 'unknown',
       completedAt: now,
     });
+  });
+
+  it('repairs running session when only queued tasks remain and no running task exists', async () => {
+    const nodeId = asNodeId('shape-1');
+    const now = 1_000_000;
+    const { db, update } = createDbMock({
+      statuses: [{ nodeId, status: 'running' }],
+      heartbeatByNode: { 'shape-1': now - 20_000 },
+      startedAtByNode: { 'shape-1': now - 20_000 },
+      activeTaskCountByNode: { 'shape-1': 0 },
+    });
+
+    const result = await reconcileRunningBuildSessions({
+      db: db as never,
+      nodeIds: [nodeId],
+      now,
+      staleTimeoutMs: 1_000,
+    });
+
+    expect(result.activeNodeIds).toEqual([]);
+    expect(result.repairedNodeIds).toEqual([nodeId]);
+    expect(update).toHaveBeenCalledTimes(1);
   });
 
   it('repairs running session without heartbeat/config and no active tasks', async () => {

--- a/packages/runtime-worker/src/services/utils/reconcileStaleBuildSessions.ts
+++ b/packages/runtime-worker/src/services/utils/reconcileStaleBuildSessions.ts
@@ -38,7 +38,7 @@ interface BuildSessionConsistencyDB {
   };
   buildTasks: {
     where: (index: '[nodeId+status]') => {
-      anyOf: (keys: Array<[NodeId, 'running' | 'queued']>) => {
+      anyOf: (keys: Array<[NodeId, 'running']>) => {
         count: () => Promise<number>;
       };
     };
@@ -112,7 +112,6 @@ export const reconcileRunningBuildSessions = async (params?: {
       runningNodeIds.map((nodeId) =>
         db.buildTasks.where('[nodeId+status]').anyOf([
           [nodeId, 'running'],
-          [nodeId, 'queued'],
         ]).count()
       )
     ),

--- a/plugins/shape-plugin/src/__tests__/unit/shapeBuildApiClient.updateBuildSession.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/shapeBuildApiClient.updateBuildSession.unit.test.ts
@@ -1,0 +1,44 @@
+import type { NodeId } from '@hierarchidb/core-types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const statusGetMock = vi.hoisted(() => vi.fn(async () => undefined));
+const statusPutMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('@hierarchidb/gis-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hierarchidb/gis-sdk')>();
+  return {
+    ...actual,
+    ephemeralDB: {
+      ...actual.ephemeralDB,
+      buildSessionStatuses: {
+        ...actual.ephemeralDB.buildSessionStatuses,
+        get: statusGetMock,
+        put: statusPutMock,
+      },
+    },
+  };
+});
+
+const asNodeId = (value: string): NodeId => value as NodeId;
+
+describe('ShapeBuildAPIClient.updateBuildSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('upserts status row when status row is missing', async () => {
+    const { shapeMutationAPIImpl } = await import('../../services/build/ShapeBuildAPIClient');
+
+    await shapeMutationAPIImpl.updateBuildSession(asNodeId('shape-1'), {
+      status: 'paused',
+      stopReason: 'user-pause',
+    } as never);
+
+    expect(statusPutMock).toHaveBeenCalledWith({
+      nodeId: asNodeId('shape-1'),
+      status: 'paused',
+      stopReason: 'user-pause',
+      completedAt: undefined,
+    });
+  });
+});

--- a/plugins/shape-plugin/src/services/build/ShapeBuildAPIClient.ts
+++ b/plugins/shape-plugin/src/services/build/ShapeBuildAPIClient.ts
@@ -676,16 +676,14 @@ export class ShapeMutationAPIImpl implements ShapeMutationAPI {
     // Status updates
     if (patch.status !== undefined || patch.stopReason !== undefined || patch.completedAt !== undefined) {
       const currentStatus = await ephemeralDB.buildSessionStatuses.get(nodeId);
-      if (currentStatus) {
-        updatePromises.push(
-          ephemeralDB.buildSessionStatuses.put({
-            nodeId,
-            status: patch.status ?? currentStatus.status,
-            stopReason: patch.stopReason ?? currentStatus.stopReason,
-            completedAt: patch.completedAt ?? currentStatus.completedAt,
-          })
-        );
-      }
+      updatePromises.push(
+        ephemeralDB.buildSessionStatuses.put({
+          nodeId,
+          status: patch.status ?? currentStatus?.status ?? 'idle',
+          stopReason: patch.stopReason ?? currentStatus?.stopReason,
+          completedAt: patch.completedAt ?? currentStatus?.completedAt,
+        })
+      );
     }
 
     // Stage updates


### PR DESCRIPTION
## 概要
- build session 更新で status/stage 行が欠損している場合に update が no-op となり、不整合が残る経路を修正
- stale running session の再調停で active task 判定を running のみに絞り、queued だけ残るケースを自己修復可能に変更
- runtime-worker / shape-plugin の更新経路に対する回帰テストを追加

## 主な変更
- ShapeMutationService.updateBuildSession の status/stage 更新を get + put の upsert に変更
- ShapeBuildAPIClient.updateBuildSession の status 更新を欠損時も upsert するよう変更
- reconcileRunningBuildSessions の active task 判定から queued を除外

## 検証
- pnpm -w turbo run test --filter @hierarchidb/runtime-worker -- --run src/services/__tests__/unit/tree-mutation-archive-build-session-guard.unit.test.ts src/services/utils/__tests__/reconcileStaleBuildSessions.unit.test.ts src/services/__tests__/unit/shape-mutation-session-upsert.unit.test.ts
- pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/shapeBuildApiClient.updateBuildSession.unit.test.ts

Closes #755
