### PR TITLE
feat(shape-plugin): session-driven base tolerance in shape pipeline

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #757 / codex/feat/shape/session-driven-base-tolerance-757 / 2026-03-04 11:52
 - #755 / codex/fix/session/worker-state-consistency-755 / 2026-03-04 11:34
 - #753 / codex/fix/session/archive-build-session-consistency / 2026-03-04 11:23
 - #750 / codex/fix/shape-plugin/geometry-retrymax-contract / 2026-03-04 11:08
@@ -30,6 +31,7 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #757 開始 - Source終了時の代表ポリゴン `t_base`（<=6553）をセッションへ保持し、Geometryで再利用する仕様ドキュメント化と実装修正に着手
 - 2026-03-04: Issue #755 進捗 - セッション4テーブル整合性の欠損経路を修正（status/stage を `update` から `get+put` upsert へ変更、stale 判定を running task 基準へ是正）。回帰テストを追加/更新し、`pnpm -w turbo run test --filter @hierarchidb/runtime-worker -- --run src/services/__tests__/unit/tree-mutation-archive-build-session-guard.unit.test.ts src/services/utils/__tests__/reconcileStaleBuildSessions.unit.test.ts src/services/__tests__/unit/shape-mutation-session-upsert.unit.test.ts` と `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/__tests__/unit/shapeBuildApiClient.updateBuildSession.unit.test.ts` は成功（exit 0）。
 - 2026-03-04: Issue #755 開始 - Worker session 4テーブル整合性と通知4系統（全体/snapshot/progress/heartbeat）を対象に、アーカイブ誤判定・リロード復元/リセット不整合・停止即時反映不具合の再現テスト追加と原因修正に着手
 - 2026-03-04: Issue #753 進捗 - `runtime-worker` に stale running build session 整合化を追加（アーカイブガード時の self-heal + Worker 起動時検査）。`pnpm -w turbo run build --filter @hierarchidb/runtime-worker` / `pnpm -w turbo run typecheck --filter @hierarchidb/runtime-worker` / `pnpm -w turbo run test --filter @hierarchidb/runtime-worker` は成功（exit 0）。
@@ -153,3 +155,4 @@
   - Worker側でセッション状態変化時の自動イベント発火を実装
   - UI側で新しい `useShapeBuildSessionState` フックを作成し、ポーリングベースの `useShapeBuildSessionRecord` を置き換え
   - `typecheck && build` が成功し、実装完了
+- 2026-03-04: Issue #757 進捗 - Source→Geometry の session駆動 baseTolerance（t_base）探索・保存・利用を実装し、仕様書更新と build/typecheck/test（対象）を完了

--- a/docs/spec/shape4-geometry-tolerance-bisection-spec.md
+++ b/docs/spec/shape4-geometry-tolerance-bisection-spec.md
@@ -1,178 +1,98 @@
-# Shape4 Geometry Tolerance 新方式仕様（t_base 2分法 + multiplier/min/max）
+# Shape4 Geometry Tolerance 新方式仕様（Session 駆動 `t_base`）
 
 ## 目的
 
-Shape4 の Geometry ステージで、従来の「tolerance を増分で段階的に上げる再試行」を置き換える。新方式は Source ステージで既に保持している頂点統計を利用し、`turf.simplify` の基準 tolerance（`t_base`）を 2 分法で求める。これにより、巨大国と小国の複雑性差を吸収しつつ、頂点上限（`6553`）を満たすための試行回数を削減する。
+Shape4 の Geometry ステージで使用する tolerance を、Source ステージで計算した基準値 `t_base` を起点に決定する。巨大国と小国の形状複雑性差を吸収しつつ、頂点上限制約を満たすまでの再試行回数を削減する。
 
-## 背景と課題
+## 適用範囲
 
-現行方式は `retryToleranceByBand` と `retryCount` に依存し、オーバーしたフィーチャーごとに tolerance を増やしながら再簡略化する。これは次の課題を持つ。
+- 対象: Shape build pipeline（`source` → `geometry`）
+- 頂点上限基準: `6553`（`SOURCE_BASE_TOLERANCE_VERTEX_LIMIT`）
+- 基準探索: `turf.simplify`（`geometrySimplify` 経由）
 
-- 元ポリゴン複雑性が極端に異なるデータセットで、必要試行回数が読みにくい。
-- 「どの tolerance を目標にするか」が事前に定義されず、失敗条件が相対的になりやすい。
-- UI 設定が「初期値・増分・回数」に分かれており、調整意図が読み取りづらい。
+## 用語
 
-## 適用対象
+- `vertexLimit`: システム上限頂点数（既定 `6553`）
+- `maxPolygonVertexCount`: Source 出力での「1ポリゴンあたり頂点数最大値」
+- `t_base`: `maxPolygonVertexCount` の代表ポリゴンを `vertexLimit` 以下にする最小 tolerance
+- `multiplier/minRatio/maxRatio`: `t_base` をズーム帯ごとに補正する係数
+- `t_final`: Geometry 初回 simplify に使う tolerance
 
-- 対象ステージ: Shape4 Geometry（`createTransformByBandHandler` 経路）
-- 対象アルゴリズム: `turf.simplify` を使う geojson simplify 系処理
-- 頂点制約: 1 フィーチャーあたり `6553` 以下（現行制約を維持）
+## データモデル
 
-## 用語定義
+`sourceStageMaxima`（session record）に次を保存する。
 
-- `vertexLimit`: システム上限頂点数。既定 `6553`。
-- `maxSourcePolygonVertices`: Source ステージ統計から得る「1 ポリゴン頂点数最大値」。
-- `t_base`: 最大頂点ポリゴンを `vertexLimit` 以下にする最小 tolerance。
-- `multiplier`: `t_base` に掛ける係数（中心値）。
-- `minRatio` / `maxRatio`: `t_base` 比の下限・上限。
-- `t_final`: 実際に簡略化へ渡す tolerance。
-
-## 方式概要
-
-1. Source ステージ統計（sessions 保存済み）から、最大頂点ポリゴンを代表サンプルとして選ぶ。  
-2. 代表サンプルに対して `turf.simplify` を適用し、`maxVertices <= 6553` を満たす最小 tolerance を 2 分法で探索する。  
-3. 得られた `t_base` を基準に、自治体レベル × ズームの設定 `multiplier/minRatio/maxRatio` を適用する。  
-4. 各フィーチャーの複雑性に応じて `t_base` より小さい初期推定値を生成し、必要な場合のみ少回数の補正探索を行う。  
-
-## 2 分法探索仕様
-
-### 入力
-
-- `polygon`: 最大頂点ポリゴン（Source 統計で選定）
-- `vertexLimit`: 6553
-- `toleranceLow`: 0
-- `toleranceHigh`: 初期上限（推奨 `t_baseUpperStart = 1.0`）
-- `eps`: 収束閾値（推奨 `1e-7`）
-- `maxIterations`: 反復上限（推奨 24）
-
-### 上限拡張
-
-`toleranceHigh` で条件を満たさない場合は、`toleranceHigh *= 2` で段階拡張する。上限 `toleranceHighCap`（推奨 12.0）に達しても満たせない場合は探索失敗とし、従来失敗ハンドリングへ移行する。
-
-### 判定関数
-
-`f(t) = simplify(polygon, t).vertexCount - vertexLimit`
-
-- `f(t) <= 0` なら条件達成
-- `f(t) > 0` なら未達
-
-### 収束
-
-- ループごとに `mid = (low + high) / 2` を評価
-- `f(mid) <= 0` なら `high = mid`
-- `f(mid) > 0` なら `low = mid`
-- `|high - low| < eps` または `iteration == maxIterations` で終了
-- 終了値 `t_base = high`
-
-## tolerance 決定式
-
-### 正規化レンジ
-
-`multiplier`, `minRatio`, `maxRatio` はすべて `0.0..2.0` の範囲で定義する。
-
-### 制約
-
-- `0.0 <= minRatio <= maxRatio <= 2.0`
-- `multiplier` も `0.0..2.0` にクランプ
-
-### 実効値
-
-`candidate = t_base * multiplier`  
-`t_final = clamp(candidate, t_base * minRatio, t_base * maxRatio)`
-
-## 複雑性ベース初期推定（後段最適化）
-
-各フィーチャーの頂点数 `v` と、代表サンプル頂点数 `v_max` から比率を作る。
-
-- `r = clamp(log(v) / log(v_max), 0, 1)`
-- `t_est = t_base * (r ^ gamma)`（推奨 `gamma=1.4` 初期）
-
-`r` が小さい（小規模形状）ほど低い tolerance で開始し、上限超過時のみ少回数の補正探索を行う。
-
-## 設定モデル（新旧）
-
-### 新モデル（主系）
-
-- `simplifyToleranceByAdminLevel.<admin>.multiplierByBand[]`
-- `simplifyToleranceByAdminLevel.<admin>.minRatioByBand[]`
-- `simplifyToleranceByAdminLevel.<admin>.maxRatioByBand[]`
-- `simplifyToleranceByAdminLevel.<admin>.usePrevious`
-- `geometryConfig.toleranceSearchMaxIterations`（全体共通）
-
-### 旧モデル（移行期間）
-
-- `toleranceByBand`
-- `retryToleranceByBand`
-- `retryCount`
-
-旧モデルは読み取り互換のみ残し、内部評価は新モデル優先とする。互換期間終了後に削除する。
-
-## UI 仕様（ToneCurveEditor）
-
-- 線 1（青実線）: `multiplier`
-- 線 2（灰点線）: `minRatio`
-- 線 3（赤点線）: `maxRatio`
-
-UI ルール:
-
-- 値域は `0.0..2.0` 固定
-- 常に `minRatio <= multiplier <= maxRatio` を維持（ドラッグ時自動クランプ）
-- Admin0 変更は既存仕様どおりベース `geometryConfig` へ同期
-- 旧設定読み込み時は `multiplier` へ寄せ、`minRatio/maxRatio` は安全デフォルトで補完
-
-## デフォルト値方針
-
-初期デフォルト（共通）:
-
-- `multiplier = 1.0`
-- `minRatio = 0.0`
-- `maxRatio = 2.0`
-- `toleranceSearchMaxIterations = 24`
-
-運用初期はズーム帯で `multiplier` のみ段階補正し、`min/max` は安全ガードとして広めに維持する。
-
-## 失敗時挙動
-
-次の場合は `geometry failed` を返す。
-
-- `t_base` 探索で上限拡張後も `vertexLimit` を満たせない
-- 補正探索の上限反復で `vertexLimit` 未達
-- simplify 処理自体が例外終了
-
-エラーメッセージには最低限以下を含める。
-
-- `vertexLimit`
-- `baseTolerance`（`t_base`）
-- `finalTolerance`
-- `attempts`
-- `maxVertices`
-
-## 観測性（ログ・メタデータ）
-
-Geometry 結果メタデータに次を保存する。
-
+- `featureMax`
+- `polygonMax`
+- `maxPolygonVertexCount`
 - `baseTolerance`
-- `effectiveTolerance`
-- `multiplier/minRatio/maxRatio`
 - `vertexLimit`
-- `searchIterations`
-- `searchOutcome`（`converged` / `failed`）
 
-## 段階移行方針
+型定義は以下に反映する。
 
-1. 新方式を feature toggle（既定 ON/OFF は Issue で明示）で導入  
-2. 旧設定を読み取り互換で保持しつつ UI では `deprecated` 表示  
-3. 安定確認後、旧 `retryToleranceByBand/retryCount` を撤去  
-4. 互換削除時に migration note を残す  
+- `packages/shape-api/src/shapeDbTypes.ts`
+- `packages/shape-store/src/VectorTileRecord.ts`
+- `packages/gis-sdk/src/ephemeral/EphemeralDBRecordTypes.ts`
 
-## 受け入れ基準（仕様レベル）
+## Source ステージ仕様
 
-- `t_base` の探索手順と停止条件が明文化されている。
-- `multiplier/minRatio/maxRatio` の定義と計算式が一意である。
-- ToneCurveEditor の 3 線 UI 仕様と制約が定義されている。
-- 旧方式からの移行・ロールバック方針が記載されている。
+1. フィルタ後 FeatureCollection から以下を集計する。
+- feature 数
+- polygon 数
+- vertex 数
+- `maxPolygonPerFeature`
+- `maxPolygonVertexCount`
 
-## 非目標
+2. `maxPolygonVertexCount` を持つ代表ポリゴンを 1 つ選ぶ。
 
-- 本仕様書では実装コード変更を行わない。
-- 本仕様書では DB マイグレーション実装詳細を固定しない（実装計画で確定）。
+3. 代表ポリゴンに対し 2 分法で `t_base` を求める。
+- 初期: `low=0`, `high=0.1`
+- `high` で未達なら倍々で拡張（上限 `12`）
+- 収束条件: `high-low < 1e-7` または `maxIterations=32`
+
+4. Source task の `metadata.fetchDetail` に下記を保存する。
+- `maxPolygonVertexCount.{input,output}`
+- `baseTolerance`
+- `baseToleranceVertexLimit`
+
+5. `shapePipelineSourceStage` で全 Source task を集約し、`maxPolygonVertexCount` が最大の task に対応する `baseTolerance` を session の `sourceStageMaxima` に保存する。
+
+## Geometry ステージ仕様
+
+1. Geometry stage 開始時に session を読み、`sourceStageMaxima.baseTolerance` を取得する。
+
+2. `baseTolerance` がある場合:
+- task 内で代表 feature の再探索をしない
+- `t_final = clamp(t_base * multiplier, t_base * minRatio, t_base * maxRatio)` を初回 tolerance とする
+
+3. `baseTolerance` が無い場合:
+- 既存の task 内代表 feature 探索 + 2 分法をフォールバックとして使用する
+
+4. 初回 simplify 後に頂点上限未達の feature がある場合:
+- 既存の `retrySimplifyFeatureWithinVertexLimit` を用いて規定回数内で再試行する
+
+## 設定値方針
+
+`multiplier/minRatio/maxRatio` はすべて `t_base=1.0` 基準の比率として扱い、範囲は `0.0..2.0` とする。
+
+- `multiplier`: 中心値
+- `minRatio`: 下限
+- `maxRatio`: 上限
+
+デフォルトは次を推奨する。
+
+- `multiplier=1.0`
+- `minRatio=0.0`
+- `maxRatio=2.0`
+
+## 旧方式・互換方針
+
+- 旧設定（初期値 + 増分 + 試行回数）の互換読み込みは行わない。
+- 新方式を唯一の有効仕様として扱う。
+
+## 受け入れ基準
+
+- Source 完了時に session へ `baseTolerance` が保存される。
+- Geometry で session `baseTolerance` が優先利用される。
+- `baseTolerance` 不在時は既存フォールバックで動作継続する。
+- 既存 retry 処理で頂点上限制約を満たす。

--- a/packages/gis-sdk/src/ephemeral/EphemeralDBRecordTypes.ts
+++ b/packages/gis-sdk/src/ephemeral/EphemeralDBRecordTypes.ts
@@ -42,6 +42,9 @@ export interface EphemeralStageStatus {
 export interface EphemeralSourceStageMaxima {
   featureMax: number;
   polygonMax: number;
+  maxPolygonVertexCount?: number;
+  baseTolerance?: number;
+  vertexLimit?: number;
 }
 
 export interface EphemeralBuildSessionRecord {

--- a/packages/shape-api/src/shapeDbTypes.ts
+++ b/packages/shape-api/src/shapeDbTypes.ts
@@ -7,6 +7,9 @@ import type { ShapeBuildProgressSummary, ShapeTileLayerInfo } from './shapeTypes
 export interface ShapeSourceStageMaxima {
   featureMax: number;
   polygonMax: number;
+  maxPolygonVertexCount?: number;
+  baseTolerance?: number;
+  vertexLimit?: number;
 }
 
 export interface ShapeBuildSessionRecord<

--- a/packages/shape-store/src/VectorTileRecord.ts
+++ b/packages/shape-store/src/VectorTileRecord.ts
@@ -91,6 +91,9 @@ export interface LayerInfo {
 export interface SourceStageMaxima {
   featureMax: number;
   polygonMax: number;
+  maxPolygonVertexCount?: number;
+  baseTolerance?: number;
+  vertexLimit?: number;
 }
 
 /**

--- a/packages/vt-orchestrator/src/contexts.ts
+++ b/packages/vt-orchestrator/src/contexts.ts
@@ -6,6 +6,7 @@ export type TransformByBandStageContext = {
   ephemeralDB: EphemeralDB;
   geometryConfig: GeometryConfig;
   bands: BandConfig[];
+  sourceBaseTolerance?: number;
   featureIdAllowlist?: Set<string>;
   abortSignal?: AbortSignal;
 };

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler/createTransformByBandHandler.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler/createTransformByBandHandler.ts
@@ -68,6 +68,7 @@ export const createTransformByBandHandler = (
     ephemeralDB,
     geometryConfig,
     bands,
+    sourceBaseTolerance,
     abortSignal,
     featureIdAllowlist,
   } = context;
@@ -885,38 +886,13 @@ export const createTransformByBandHandler = (
           limit: memory.jsHeapSizeLimit ?? null,
         };
       };
-      const representativeFeature = selectMaxVertexFeature(inputCollection, countVerticesFromGeometry);
-      if (representativeFeature) {
-        const runBaseSimplifyAttempt = async (nextTolerance: number): Promise<Feature | null> => {
-          const retryCollection = await runStageWithLabel('simplify-only:base-search', () => (
-            simplifyOnlyCollection(
-              { type: 'FeatureCollection', features: [representativeFeature.feature] },
-              band.zMax,
-              nextTolerance,
-              geometryOps,
-            )
-          ));
-          const firstFeature = retryCollection.features[0];
-          return firstFeature ?? null;
-        };
-        const baseSearch = await findBaseToleranceByBisection({
-          feature: representativeFeature.feature,
-          retryVertexLimit,
-          maxIterations: toleranceSearchMaxIterations,
-          initialLow: 0,
-          initialHigh: Math.max(0.1, fallbackTolerance),
-          highCap: 12,
-          runSimplifyAttempt: runBaseSimplifyAttempt,
-          countVerticesFromGeometry,
-        });
-        baseToleranceSummary = baseSearch.tolerance;
-        toleranceSearchIterationsSummary = baseSearch.iterations;
-        toleranceSearchConvergedSummary = baseSearch.converged;
-        if (baseSearch.converged && Number.isFinite(baseSearch.tolerance)) {
-          tolerance = resolveAppliedTolerance(baseSearch.tolerance);
-        } else {
-          tolerance = fallbackTolerance;
-        }
+      const hasSessionBaseTolerance = Number.isFinite(sourceBaseTolerance) && (sourceBaseTolerance ?? 0) >= 0;
+      if (hasSessionBaseTolerance) {
+        const sessionBaseTolerance = sourceBaseTolerance ?? fallbackTolerance;
+        baseToleranceSummary = sessionBaseTolerance;
+        toleranceSearchIterationsSummary = 0;
+        toleranceSearchConvergedSummary = true;
+        tolerance = resolveAppliedTolerance(sessionBaseTolerance);
         finalToleranceSummary = tolerance;
         updateFinalEffectiveTolerance(tolerance);
         console.info('[ShapeGeometry][Tolerance]', JSON.stringify({
@@ -932,16 +908,68 @@ export const createTransformByBandHandler = (
           multiplier: resolvedMultiplier,
           minRatio: resolvedMinRatio,
           maxRatio: resolvedMaxRatio,
-          searchIterations: baseSearch.iterations,
-          searchConverged: baseSearch.converged,
-          representativeVertexCount: representativeFeature.vertexCount,
-          representativeFeatureIndex: representativeFeature.featureIndex + 1,
-          representativeFinalVertexCount: baseSearch.finalVertexCount,
+          source: 'session',
         }));
       } else {
-        tolerance = fallbackTolerance;
-        finalToleranceSummary = tolerance;
-        updateFinalEffectiveTolerance(tolerance);
+        const representativeFeature = selectMaxVertexFeature(inputCollection, countVerticesFromGeometry);
+        if (representativeFeature) {
+          const runBaseSimplifyAttempt = async (nextTolerance: number): Promise<Feature | null> => {
+            const retryCollection = await runStageWithLabel('simplify-only:base-search', () => (
+              simplifyOnlyCollection(
+                { type: 'FeatureCollection', features: [representativeFeature.feature] },
+                band.zMax,
+                nextTolerance,
+                geometryOps,
+              )
+            ));
+            const firstFeature = retryCollection.features[0];
+            return firstFeature ?? null;
+          };
+          const baseSearch = await findBaseToleranceByBisection({
+            feature: representativeFeature.feature,
+            retryVertexLimit,
+            maxIterations: toleranceSearchMaxIterations,
+            initialLow: 0,
+            initialHigh: Math.max(0.1, fallbackTolerance),
+            highCap: 12,
+            runSimplifyAttempt: runBaseSimplifyAttempt,
+            countVerticesFromGeometry,
+          });
+          baseToleranceSummary = baseSearch.tolerance;
+          toleranceSearchIterationsSummary = baseSearch.iterations;
+          toleranceSearchConvergedSummary = baseSearch.converged;
+          if (baseSearch.converged && Number.isFinite(baseSearch.tolerance)) {
+            tolerance = resolveAppliedTolerance(baseSearch.tolerance);
+          } else {
+            tolerance = fallbackTolerance;
+          }
+          finalToleranceSummary = tolerance;
+          updateFinalEffectiveTolerance(tolerance);
+          console.info('[ShapeGeometry][Tolerance]', JSON.stringify({
+            nodeId: task.nodeId,
+            taskId,
+            sourceKey: input.sourceKey,
+            adminLevel: input.adminLevel,
+            bandIndex: input.bandIndex,
+            zTarget: band.zMax,
+            baseTolerance: baseToleranceSummary,
+            appliedTolerance: tolerance,
+            fallbackTolerance,
+            multiplier: resolvedMultiplier,
+            minRatio: resolvedMinRatio,
+            maxRatio: resolvedMaxRatio,
+            searchIterations: baseSearch.iterations,
+            searchConverged: baseSearch.converged,
+            representativeVertexCount: representativeFeature.vertexCount,
+            representativeFeatureIndex: representativeFeature.featureIndex + 1,
+            representativeFinalVertexCount: baseSearch.finalVertexCount,
+            source: 'task',
+          }));
+        } else {
+          tolerance = fallbackTolerance;
+          finalToleranceSummary = tolerance;
+          updateFinalEffectiveTolerance(tolerance);
+        }
       }
       const summarizeVertexLimit = (collection: FeatureCollection | null): {
         featureCount: number;

--- a/plugins/shape-plugin/src/services/build/ShapeBuildAPIClient.ts
+++ b/plugins/shape-plugin/src/services/build/ShapeBuildAPIClient.ts
@@ -137,9 +137,21 @@ const readSourceStageMaxima = (value: unknown): SourceStageMaxima | undefined =>
   if (!isRecord(value)) return undefined;
   if (!isNumber(value.featureMax) || !isNumber(value.polygonMax)) return undefined;
   if (value.featureMax < 0 || value.polygonMax < 0) return undefined;
+  const maxPolygonVertexCount = isNumber(value.maxPolygonVertexCount) && value.maxPolygonVertexCount >= 0
+    ? value.maxPolygonVertexCount
+    : undefined;
+  const baseTolerance = isNumber(value.baseTolerance) && value.baseTolerance >= 0
+    ? value.baseTolerance
+    : undefined;
+  const vertexLimit = isNumber(value.vertexLimit) && value.vertexLimit > 0
+    ? Math.round(value.vertexLimit)
+    : undefined;
   return {
     featureMax: value.featureMax,
     polygonMax: value.polygonMax,
+    maxPolygonVertexCount,
+    baseTolerance,
+    vertexLimit,
   };
 };
 

--- a/plugins/shape-plugin/src/services/build/shapeSessionMappers.ts
+++ b/plugins/shape-plugin/src/services/build/shapeSessionMappers.ts
@@ -24,10 +24,22 @@ const isNumber = (value: unknown): value is number =>
 
 const isSourceStageMaxima = (value: unknown): value is SourceStageMaxima => {
   if (!isRecord(value)) return false;
-  return isNumber(value.featureMax)
-    && isNumber(value.polygonMax)
-    && value.featureMax >= 0
-    && value.polygonMax >= 0;
+  if (!isNumber(value.featureMax)
+    || !isNumber(value.polygonMax)
+    || value.featureMax < 0
+    || value.polygonMax < 0) {
+    return false;
+  }
+  if (value.maxPolygonVertexCount !== undefined && (!isNumber(value.maxPolygonVertexCount) || value.maxPolygonVertexCount < 0)) {
+    return false;
+  }
+  if (value.baseTolerance !== undefined && (!isNumber(value.baseTolerance) || value.baseTolerance < 0)) {
+    return false;
+  }
+  if (value.vertexLimit !== undefined && (!isNumber(value.vertexLimit) || value.vertexLimit <= 0)) {
+    return false;
+  }
+  return true;
 };
 
 const isTaskStatus = (value: unknown): value is StageStatus['status'] =>

--- a/plugins/shape-plugin/src/services/vt/runShapeGeometryStageSection.ts
+++ b/plugins/shape-plugin/src/services/vt/runShapeGeometryStageSection.ts
@@ -25,6 +25,7 @@ import { clearStagePlan, setGeometryPlannedTotal } from './shapeProgressPlan.ts'
 import type { EphemeralDB } from '@hierarchidb/gis-sdk';
 import { buildGeometryTaskCacheIdentity } from './shapeTaskCacheIdentity.ts';
 import { resolveSourceArtifactHashById } from './shapeSourceArtifactHash.ts';
+import { shapeQueryAPIImpl } from '~/services/build/ShapeBuildAPIClient';
 
 export type ShapeGeometryStageParams = {
   nodeId: NodeId;
@@ -86,6 +87,13 @@ const readString = (value: unknown): string | null => (
 const readNumber = (value: unknown): number | null => (
   typeof value === 'number' && Number.isFinite(value) ? value : null
 );
+
+const readSourceBaseTolerance = (value: unknown): number | undefined => {
+  if (!isRecord(value)) return undefined;
+  const baseTolerance = readNumber(value.baseTolerance);
+  if (baseTolerance === null || baseTolerance < 0) return undefined;
+  return baseTolerance;
+};
 
 const toMemoryValue = (value: number | undefined): number | null => (
   typeof value === 'number' && Number.isFinite(value) ? value : null
@@ -202,6 +210,10 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
     fetchTasks: fetchTasks.length,
     existingGeometryTasks: existingGeometryByBandTasks.length,
   }));
+  const sessionRecord = await runGeometryStep(params, 'load-build-session', async () => (
+    shapeQueryAPIImpl.getBuildSessionRecord(params.nodeId)
+  ));
+  const sourceBaseTolerance = readSourceBaseTolerance(sessionRecord?.sourceStageMaxima);
   const buffers = await runGeometryStep(params, 'build-geometry-buffer-metadata', async () => {
     const next: GeometryBufferMeta[] = [];
     for (const task of fetchTasks) {
@@ -457,6 +469,7 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
         ephemeralDB: params.ephemeralStore,
         geometryConfig,
         bands: params.bands,
+        sourceBaseTolerance,
         featureIdAllowlist: params.diffBuildEnabled ? params.recyclingAllowlist : undefined,
         abortSignal: geometryByBandAbortController.signal,
       })

--- a/plugins/shape-plugin/src/services/vt/runShapeSourceStage.ts
+++ b/plugins/shape-plugin/src/services/vt/runShapeSourceStage.ts
@@ -1,6 +1,11 @@
-import type { Feature, FeatureCollection, Geometry } from 'geojson';
+import type { Feature, FeatureCollection, Geometry, MultiPolygon, Polygon } from 'geojson';
 import type { ISO2, NodeId } from '@hierarchidb/core-types';
-import { encodeFlatGeobufFromFeatureCollection, geometryBbox, type GeometryEngine } from '@hierarchidb/gis-sdk';
+import {
+  encodeFlatGeobufFromFeatureCollection,
+  geometryBbox,
+  geometrySimplify,
+  type GeometryEngine,
+} from '@hierarchidb/gis-sdk';
 import type { StageHandler, TaskQueueRecord } from '@hierarchidb/build-api';
 import type { ShapeRuntimeBuildConfig } from '~/common/types/index';
 import {
@@ -434,6 +439,10 @@ const buildSourceCacheMetadata = (params: {
   inputPolygonCount?: number;
   polygonPerFeatureMax?: number;
   inputPolygonPerFeatureMax?: number;
+  maxPolygonVertexCount?: number;
+  inputMaxPolygonVertexCount?: number;
+  baseTolerance?: number;
+  baseToleranceVertexLimit?: number;
   retryAttempt?: number;
 }): Record<string, unknown> => ({
   stage: 'source',
@@ -450,6 +459,10 @@ const buildSourceCacheMetadata = (params: {
   inputPolygonCount: params.inputPolygonCount,
   polygonPerFeatureMax: params.polygonPerFeatureMax,
   inputPolygonPerFeatureMax: params.inputPolygonPerFeatureMax,
+  maxPolygonVertexCount: params.maxPolygonVertexCount,
+  inputMaxPolygonVertexCount: params.inputMaxPolygonVertexCount,
+  baseTolerance: params.baseTolerance,
+  baseToleranceVertexLimit: params.baseToleranceVertexLimit,
   retryAttempt: Number.isFinite(params.retryAttempt ?? NaN)
     ? Math.trunc(params.retryAttempt!)
     : undefined,
@@ -711,6 +724,159 @@ const countPolygonsFromGeometry = (geometry: Feature['geometry']): number => {
   return 0;
 };
 
+const SOURCE_BASE_TOLERANCE_VERTEX_LIMIT = 6553;
+const SOURCE_BASE_TOLERANCE_MAX_ITERATIONS = 32;
+const SOURCE_BASE_TOLERANCE_INITIAL_HIGH = 0.1;
+const SOURCE_BASE_TOLERANCE_HIGH_CAP = 12;
+const SOURCE_BASE_TOLERANCE_EPSILON = 1e-7;
+
+const countPolygonVertices = (coordinates: unknown): number => {
+  if (!Array.isArray(coordinates)) return 0;
+  return countVertices(coordinates);
+};
+
+const visitPolygons = (
+  geometry: Geometry | null | undefined,
+  visit: (polygon: {
+    vertexCount: number;
+    geometry: Polygon;
+  }) => void,
+): void => {
+  if (!geometry) return;
+  if (geometry.type === 'Polygon') {
+    const polygonGeometry = geometry as Polygon;
+    visit({
+      vertexCount: countPolygonVertices(polygonGeometry.coordinates),
+      geometry: polygonGeometry,
+    });
+    return;
+  }
+  if (geometry.type === 'MultiPolygon') {
+    const multiPolygonGeometry = geometry as MultiPolygon;
+    for (const polygonCoords of multiPolygonGeometry.coordinates) {
+      visit({
+        vertexCount: countPolygonVertices(polygonCoords),
+        geometry: { type: 'Polygon', coordinates: polygonCoords },
+      });
+    }
+    return;
+  }
+  if (geometry.type === 'GeometryCollection') {
+    for (const child of geometry.geometries ?? []) {
+      visitPolygons(child, visit);
+    }
+  }
+};
+
+const findMaxVertexPolygon = (
+  collection: FeatureCollection,
+): {
+  vertexCount: number;
+  featureIndex: number;
+  polygon: Feature<Polygon>;
+} | null => {
+  let maxVertexCount = 0;
+  let selectedFeatureIndex = -1;
+  let selectedPolygon: Feature<Polygon> | null = null;
+  collection.features.forEach((feature, featureIndex) => {
+    visitPolygons(feature?.geometry, ({ vertexCount, geometry }) => {
+      if (vertexCount <= maxVertexCount) return;
+      maxVertexCount = vertexCount;
+      selectedFeatureIndex = featureIndex;
+      selectedPolygon = {
+        type: 'Feature',
+        properties: { ...(feature?.properties ?? {}) },
+        geometry,
+      };
+    });
+  });
+  if (!selectedPolygon || selectedFeatureIndex < 0) {
+    return null;
+  }
+  return {
+    vertexCount: maxVertexCount,
+    featureIndex: selectedFeatureIndex,
+    polygon: selectedPolygon,
+  };
+};
+
+const findSourceBaseToleranceByBisection = async (params: {
+  feature: Feature<Polygon>;
+  geometryEngine: GeometryEngine;
+  vertexLimit: number;
+  maxIterations: number;
+  initialHigh: number;
+  highCap: number;
+  epsilon: number;
+}): Promise<{
+  tolerance: number;
+  converged: boolean;
+  iterations: number;
+  finalVertexCount: number;
+}> => {
+  const sourceVertexCount = countVerticesFromGeometry(params.feature.geometry);
+  if (sourceVertexCount <= params.vertexLimit) {
+    return {
+      tolerance: 0,
+      converged: true,
+      iterations: 0,
+      finalVertexCount: sourceVertexCount,
+    };
+  }
+
+  const evaluate = (tolerance: number): number => {
+    const simplified = geometrySimplify(params.feature, params.geometryEngine, {
+      tolerance,
+      highQuality: true,
+      mutate: false,
+      preserveTopology: true,
+    });
+    return countVerticesFromGeometry(simplified.geometry);
+  };
+
+  let iterations = 0;
+  let low = 0;
+  let high = Math.max(0, params.initialHigh);
+  let highVertexCount = evaluate(high);
+  iterations += 1;
+  while (highVertexCount > params.vertexLimit && high < params.highCap && iterations < params.maxIterations) {
+    low = high;
+    high = Math.min(params.highCap, high * 2);
+    highVertexCount = evaluate(high);
+    iterations += 1;
+  }
+  if (highVertexCount > params.vertexLimit) {
+    return {
+      tolerance: high,
+      converged: false,
+      iterations,
+      finalVertexCount: highVertexCount,
+    };
+  }
+
+  let bestTolerance = high;
+  let bestVertexCount = highVertexCount;
+  while (iterations < params.maxIterations && (high - low) > params.epsilon) {
+    const mid = (low + high) / 2;
+    const midVertexCount = evaluate(mid);
+    iterations += 1;
+    if (midVertexCount <= params.vertexLimit) {
+      bestTolerance = mid;
+      bestVertexCount = midVertexCount;
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return {
+    tolerance: bestTolerance,
+    converged: true,
+    iterations,
+    finalVertexCount: bestVertexCount,
+  };
+};
+
 const applyOriginPropertiesToCollection = (collection: FeatureCollection, originKey: string): FeatureCollection => {
   const features = collection.features.map((feature) => {
     const properties = { ...(feature.properties ?? {}) } as Record<string, unknown>;
@@ -742,12 +908,14 @@ const summarizeFeatureCollection = async (
   vertexCount: number;
   polygonCount: number;
   maxPolygonPerFeature: number;
+  maxPolygonVertexCount: number;
   bbox: [number, number, number, number];
 }> => {
   const featureCount = collection.features.length;
   let vertexCount = 0;
   let polygonCount = 0;
   let maxPolygonPerFeature = 0;
+  let maxPolygonVertexCount = 0;
   for (let featureIndex = 0; featureIndex < collection.features.length; featureIndex += 1) {
     await options?.onFeatureCountProgress?.(featureIndex + 1, featureCount);
     const feature = collection.features[featureIndex];
@@ -758,6 +926,11 @@ const summarizeFeatureCollection = async (
     if (polygonCountPerFeature > maxPolygonPerFeature) {
       maxPolygonPerFeature = polygonCountPerFeature;
     }
+    visitPolygons(feature.geometry, ({ vertexCount }) => {
+      if (vertexCount > maxPolygonVertexCount) {
+        maxPolygonVertexCount = vertexCount;
+      }
+    });
   }
   let bbox: [number, number, number, number] = [0, 0, 0, 0];
   {
@@ -767,7 +940,7 @@ const summarizeFeatureCollection = async (
       bbox = [minX, minY, maxX, maxY];
     }
   }
-  return { featureCount, vertexCount, polygonCount, maxPolygonPerFeature, bbox };
+  return { featureCount, vertexCount, polygonCount, maxPolygonPerFeature, maxPolygonVertexCount, bbox };
 };
 
 const buildSourceTasks = (
@@ -900,6 +1073,11 @@ const createSourceHandler = (params: {
   const normalizeCount = (value: number | null | undefined): number | null => (
     typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.round(value)) : null
   );
+  const normalizeTolerance = (value: number | null | undefined): number | null => (
+    typeof value === 'number' && Number.isFinite(value) && value >= 0
+      ? Number.parseFloat(value.toFixed(8))
+      : null
+  );
 
   const buildSourceDetailMetadata = (
     input: ShapeSourceTaskInput,
@@ -910,6 +1088,10 @@ const createSourceHandler = (params: {
       polygonCount?: number | null;
       inputPolygonPerFeatureMax?: number | null;
       polygonPerFeatureMax?: number | null;
+      inputMaxPolygonVertexCount?: number | null;
+      maxPolygonVertexCount?: number | null;
+      baseTolerance?: number | null;
+      baseToleranceVertexLimit?: number | null;
     },
     preview?: {
       sourceCacheId?: string | null;
@@ -934,6 +1116,12 @@ const createSourceHandler = (params: {
         input: normalizeCount(counts.inputPolygonPerFeatureMax),
         output: normalizeCount(counts.polygonPerFeatureMax),
       },
+      maxPolygonVertexCount: {
+        input: normalizeCount(counts.inputMaxPolygonVertexCount),
+        output: normalizeCount(counts.maxPolygonVertexCount),
+      },
+      baseTolerance: normalizeTolerance(counts.baseTolerance),
+      baseToleranceVertexLimit: normalizeCount(counts.baseToleranceVertexLimit),
     },
     preview: {
       stage: 'source',
@@ -953,6 +1141,37 @@ const createSourceHandler = (params: {
       sourceCacheCompression: preview?.sourceCacheCompression ?? 'none',
     },
   });
+
+  const analyzeSourceToleranceMetrics = async (
+    collection: FeatureCollection,
+  ): Promise<{
+    maxPolygonVertexCount: number;
+    baseTolerance: number;
+    baseToleranceVertexLimit: number;
+  }> => {
+    const representativePolygon = findMaxVertexPolygon(collection);
+    if (!representativePolygon || representativePolygon.vertexCount <= 0) {
+      return {
+        maxPolygonVertexCount: 0,
+        baseTolerance: 0,
+        baseToleranceVertexLimit: SOURCE_BASE_TOLERANCE_VERTEX_LIMIT,
+      };
+    }
+    const baseSearch = await findSourceBaseToleranceByBisection({
+      feature: representativePolygon.polygon,
+      geometryEngine,
+      vertexLimit: SOURCE_BASE_TOLERANCE_VERTEX_LIMIT,
+      maxIterations: SOURCE_BASE_TOLERANCE_MAX_ITERATIONS,
+      initialHigh: SOURCE_BASE_TOLERANCE_INITIAL_HIGH,
+      highCap: SOURCE_BASE_TOLERANCE_HIGH_CAP,
+      epsilon: SOURCE_BASE_TOLERANCE_EPSILON,
+    });
+    return {
+      maxPolygonVertexCount: representativePolygon.vertexCount,
+      baseTolerance: baseSearch.tolerance,
+      baseToleranceVertexLimit: SOURCE_BASE_TOLERANCE_VERTEX_LIMIT,
+    };
+  };
 
   return async (task) => {
     const input = task.inputData;
@@ -998,27 +1217,44 @@ const createSourceHandler = (params: {
           ?? (existingInputFeatureCount > 0
             ? (existing.inputPolygonCount ?? existing.polygonCount ?? 0) / existingInputFeatureCount
             : 0);
+        const cachedMaxPolygonVertexCount = readNumericProperty(existingMetadata, 'maxPolygonVertexCount')
+          ?? 0;
+        const cachedInputMaxPolygonVertexCount = readNumericProperty(existingMetadata, 'inputMaxPolygonVertexCount')
+          ?? cachedMaxPolygonVertexCount;
+        let cachedBaseTolerance = readNumericProperty(existingMetadata, 'baseTolerance') ?? 0;
+        const cachedBaseToleranceVertexLimit = readNumericProperty(existingMetadata, 'baseToleranceVertexLimit')
+          ?? SOURCE_BASE_TOLERANCE_VERTEX_LIMIT;
         const cachedCollection = await decodeSourceCacheData({
           data: existing.data,
           format: existing.format,
           compression: existing.compression,
         });
-        const sourceMetadata = buildSourceCacheMetadata({
-          status: 'completed',
-          dataSource: input.dataSource,
-          sourceKey: input.sourceKey,
-          countryCode: input.countryCode,
-          adminLevel: input.adminLevel,
-          featureCount: existing.featureCount,
-          inputFeatureCount: existingInputFeatureCount,
-          vertexCount: existing.vertexCount ?? 0,
-          polygonCount: existing.polygonCount ?? 0,
-          inputVertexCount: existing.inputVertexCount ?? 0,
-          inputPolygonCount: existing.inputPolygonCount ?? 0,
-          polygonPerFeatureMax: cachedPolygonPerFeatureMax,
-          inputPolygonPerFeatureMax: cachedInputPolygonPerFeatureMax,
-        });
+        const buildCurrentSourceMetadata = (): Record<string, unknown> => (
+          buildSourceCacheMetadata({
+            status: 'completed',
+            dataSource: input.dataSource,
+            sourceKey: input.sourceKey,
+            countryCode: input.countryCode,
+            adminLevel: input.adminLevel,
+            featureCount: existing.featureCount,
+            inputFeatureCount: existingInputFeatureCount,
+            vertexCount: existing.vertexCount ?? 0,
+            polygonCount: existing.polygonCount ?? 0,
+            inputVertexCount: existing.inputVertexCount ?? 0,
+            inputPolygonCount: existing.inputPolygonCount ?? 0,
+            polygonPerFeatureMax: cachedPolygonPerFeatureMax,
+            inputPolygonPerFeatureMax: cachedInputPolygonPerFeatureMax,
+            maxPolygonVertexCount: cachedMaxPolygonVertexCount,
+            inputMaxPolygonVertexCount: cachedInputMaxPolygonVertexCount,
+            baseTolerance: cachedBaseTolerance,
+            baseToleranceVertexLimit: cachedBaseToleranceVertexLimit,
+          })
+        );
         if (cachedCollection && cachedCollection.features.length > 0) {
+          if (!Number.isFinite(cachedBaseTolerance) || cachedBaseTolerance <= 0) {
+            const metrics = await analyzeSourceToleranceMetrics(cachedCollection);
+            cachedBaseTolerance = metrics.baseTolerance;
+          }
           const hasMissingFeatureIds = cachedCollection.features.some((feature) => {
             const props = feature?.properties as Record<string, unknown> | undefined;
             return typeof props?.__hdbFeatureId !== 'string' || props.__hdbFeatureId.length === 0;
@@ -1054,12 +1290,12 @@ const createSourceHandler = (params: {
                 size: data.byteLength,
                 contentHash: sourceArtifactHash,
                 timestamp: Date.now(),
-                metadata: sourceMetadata,
+                metadata: buildCurrentSourceMetadata(),
               });
             }
           } else if (existing.metadata?.status !== 'completed') {
             await ephemeralDB.sourceCache.update(existing.id, {
-              metadata: sourceMetadata,
+              metadata: buildCurrentSourceMetadata(),
             });
           }
         } else if (existing.featureCount === 0) {
@@ -1075,7 +1311,7 @@ const createSourceHandler = (params: {
           await shapeMutationAPIImpl.putFeatureMetadata([emptyMetadata]);
           await ephemeralDB.sourceCache.update(existing.id, {
             metadata: {
-              ...sourceMetadata,
+              ...buildCurrentSourceMetadata(),
               status: 'completed',
             },
           });
@@ -1097,6 +1333,10 @@ const createSourceHandler = (params: {
             polygonCount: cachedPolygonCount,
             inputPolygonPerFeatureMax: cachedInputPolygonPerFeatureMax,
             polygonPerFeatureMax: cachedPolygonPerFeatureMax,
+            inputMaxPolygonVertexCount: cachedInputMaxPolygonVertexCount,
+            maxPolygonVertexCount: cachedMaxPolygonVertexCount,
+            baseTolerance: cachedBaseTolerance,
+            baseToleranceVertexLimit: cachedBaseToleranceVertexLimit,
           }, {
             sourceCacheId: existing.id,
             sourceCacheFormat: existing.format === 'topojson' ? 'topojson' : 'flatgeobuf',
@@ -1180,6 +1420,10 @@ const createSourceHandler = (params: {
             polygonCount: 0,
             inputPolygonPerFeatureMax: inputSummary.maxPolygonPerFeature,
             polygonPerFeatureMax: 0,
+            inputMaxPolygonVertexCount: inputSummary.maxPolygonVertexCount,
+            maxPolygonVertexCount: 0,
+            baseTolerance: 0,
+            baseToleranceVertexLimit: SOURCE_BASE_TOLERANCE_VERTEX_LIMIT,
           }),
         };
       }
@@ -1204,6 +1448,7 @@ const createSourceHandler = (params: {
       const outputSummary = await summarizeFeatureCollection(collectionWithOrigin, geometryEngine, {
         onFeatureCountProgress,
       });
+      const outputToleranceMetrics = await analyzeSourceToleranceMetrics(collectionWithOrigin);
       const cachedTopology = topojsonTopology({ collection: collectionWithOrigin });
       const encodedTopology = encodeTopoJson(cachedTopology);
       const compressedTopology = await compressGzip(encodedTopology);
@@ -1238,6 +1483,10 @@ const createSourceHandler = (params: {
           inputPolygonCount: inputSummary.polygonCount,
           polygonPerFeatureMax: outputSummary.maxPolygonPerFeature,
           inputPolygonPerFeatureMax: inputSummary.maxPolygonPerFeature,
+          maxPolygonVertexCount: outputSummary.maxPolygonVertexCount,
+          inputMaxPolygonVertexCount: inputSummary.maxPolygonVertexCount,
+          baseTolerance: outputToleranceMetrics.baseTolerance,
+          baseToleranceVertexLimit: outputToleranceMetrics.baseToleranceVertexLimit,
         }),
       });
       const reductionSummary = [
@@ -1256,6 +1505,10 @@ const createSourceHandler = (params: {
           polygonCount: outputSummary.polygonCount,
           inputPolygonPerFeatureMax: inputSummary.maxPolygonPerFeature,
           polygonPerFeatureMax: outputSummary.maxPolygonPerFeature,
+          inputMaxPolygonVertexCount: inputSummary.maxPolygonVertexCount,
+          maxPolygonVertexCount: outputSummary.maxPolygonVertexCount,
+          baseTolerance: outputToleranceMetrics.baseTolerance,
+          baseToleranceVertexLimit: outputToleranceMetrics.baseToleranceVertexLimit,
         }, {
           sourceCacheId: sourceCacheRecord.id,
           sourceCacheFormat: 'topojson',
@@ -1335,6 +1588,10 @@ const createSourceHandler = (params: {
           polygonCount: 0,
           inputPolygonPerFeatureMax: inputSummary.maxPolygonPerFeature,
           polygonPerFeatureMax: 0,
+          inputMaxPolygonVertexCount: inputSummary.maxPolygonVertexCount,
+          maxPolygonVertexCount: 0,
+          baseTolerance: 0,
+          baseToleranceVertexLimit: SOURCE_BASE_TOLERANCE_VERTEX_LIMIT,
         }),
       };
     }
@@ -1355,9 +1612,17 @@ const createSourceHandler = (params: {
     }
 
     assertNotAborted(params.abortSignal);
-    const { featureCount, vertexCount, polygonCount, maxPolygonPerFeature, bbox } = await summarizeFeatureCollection(filteredCollection, geometryEngine, {
+    const {
+      featureCount,
+      vertexCount,
+      polygonCount,
+      maxPolygonPerFeature,
+      maxPolygonVertexCount,
+      bbox,
+    } = await summarizeFeatureCollection(filteredCollection, geometryEngine, {
       onFeatureCountProgress,
     });
+    const outputToleranceMetrics = await analyzeSourceToleranceMetrics(filteredCollection);
     const data = await encodeFlatGeobufFromFeatureCollection(filteredCollection);
     assertNotAborted(params.abortSignal);
     const sourceCacheRecord = await putSourceCache({
@@ -1390,6 +1655,10 @@ const createSourceHandler = (params: {
         inputPolygonCount: inputSummary.polygonCount,
         polygonPerFeatureMax: maxPolygonPerFeature,
         inputPolygonPerFeatureMax: inputSummary.maxPolygonPerFeature,
+        maxPolygonVertexCount,
+        inputMaxPolygonVertexCount: inputSummary.maxPolygonVertexCount,
+        baseTolerance: outputToleranceMetrics.baseTolerance,
+        baseToleranceVertexLimit: outputToleranceMetrics.baseToleranceVertexLimit,
       }),
     });
     const reductionSummary = [
@@ -1408,6 +1677,10 @@ const createSourceHandler = (params: {
         polygonCount,
         inputPolygonPerFeatureMax: inputSummary.maxPolygonPerFeature,
         polygonPerFeatureMax: maxPolygonPerFeature,
+        inputMaxPolygonVertexCount: inputSummary.maxPolygonVertexCount,
+        maxPolygonVertexCount,
+        baseTolerance: outputToleranceMetrics.baseTolerance,
+        baseToleranceVertexLimit: outputToleranceMetrics.baseToleranceVertexLimit,
       }, {
         sourceCacheId: sourceCacheRecord.id,
         sourceCacheFormat: 'flatgeobuf',

--- a/plugins/shape-plugin/src/services/vt/shapePipelineSourceStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineSourceStage.ts
@@ -129,6 +129,9 @@ export const runShapeSourceStageSection = async (params: ShapeSourceStageParams)
   const fetchTasks = await listTasksByStage(params.taskQueue, params.nodeId, 'source');
   let featureMax = 0;
   let polygonMax = 0;
+  let maxPolygonVertexCount = 0;
+  let baseTolerance = 0;
+  let baseToleranceVertexLimit = 6553;
   fetchTasks.forEach((task) => {
     const metadata = task.metadata;
     const fetchDetail = (typeof metadata === 'object' && metadata !== null
@@ -144,6 +147,9 @@ export const runShapeSourceStageSection = async (params: ShapeSourceStageParams)
         : null);
     const fallbackPolygons = fetchDetail && typeof fetchDetail.polygons === 'object' && fetchDetail.polygons !== null
       ? fetchDetail.polygons as Record<string, unknown>
+      : null;
+    const maxPolygonVertexCountDetail = fetchDetail && typeof fetchDetail.maxPolygonVertexCount === 'object' && fetchDetail.maxPolygonVertexCount !== null
+      ? fetchDetail.maxPolygonVertexCount as Record<string, unknown>
       : null;
     const featureInput = typeof features?.input === 'number'
       ? features.input
@@ -161,17 +167,42 @@ export const runShapeSourceStageSection = async (params: ShapeSourceStageParams)
       : null;
     const featureValue = featureInput;
     const polygonValue = polygonInput ?? polygonFromAverage;
+    const maxPolygonVertexValue = typeof maxPolygonVertexCountDetail?.output === 'number'
+      ? maxPolygonVertexCountDetail.output
+      : (typeof maxPolygonVertexCountDetail?.input === 'number'
+        ? maxPolygonVertexCountDetail.input
+        : null);
+    const taskBaseTolerance = typeof fetchDetail?.baseTolerance === 'number'
+      ? fetchDetail.baseTolerance
+      : null;
+    const taskBaseToleranceVertexLimit = typeof fetchDetail?.baseToleranceVertexLimit === 'number'
+      ? fetchDetail.baseToleranceVertexLimit
+      : null;
     if (featureValue !== null && Number.isFinite(featureValue) && featureValue > featureMax) {
       featureMax = Math.max(0, Math.round(featureValue));
     }
     if (polygonValue !== null && Number.isFinite(polygonValue) && polygonValue > polygonMax) {
       polygonMax = Math.max(0, Math.round(polygonValue));
     }
+    if (maxPolygonVertexValue !== null && Number.isFinite(maxPolygonVertexValue) && maxPolygonVertexValue > maxPolygonVertexCount) {
+      maxPolygonVertexCount = Math.max(0, Math.round(maxPolygonVertexValue));
+      baseTolerance = taskBaseTolerance !== null && Number.isFinite(taskBaseTolerance) && taskBaseTolerance >= 0
+        ? taskBaseTolerance
+        : baseTolerance;
+      baseToleranceVertexLimit = taskBaseToleranceVertexLimit !== null
+        && Number.isFinite(taskBaseToleranceVertexLimit)
+        && taskBaseToleranceVertexLimit > 0
+        ? Math.round(taskBaseToleranceVertexLimit)
+        : baseToleranceVertexLimit;
+    }
   });
   await shapeMutationAPIImpl.updateBuildSession(params.nodeId, {
     sourceStageMaxima: {
       featureMax,
       polygonMax,
+      maxPolygonVertexCount,
+      baseTolerance,
+      vertexLimit: baseToleranceVertexLimit,
     },
   });
   if (stageCounts.failed > 0 && stageCounts.completed === 0) {

--- a/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionMetrics.ts
+++ b/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionMetrics.ts
@@ -35,6 +35,7 @@ import {
 import type {
   SessionStateChangeEvent,
   SessionHeartbeatEvent,
+  StageSnapshotEvent,
   TaskProgressEvent,
   SessionStateSubscription,
   StageSnapshotSubscription,


### PR DESCRIPTION
## Summary
- implement Source-stage representative polygon analysis and bisection search to derive `baseTolerance` (vertexLimit=6553)
- persist `maxPolygonVertexCount/baseTolerance/vertexLimit` into `sourceStageMaxima` and propagate through shape-api/store/gis-sdk types
- use session `sourceStageMaxima.baseTolerance` as Geometry-stage primary tolerance base, with existing per-task bisection as fallback
- update spec document for the session-driven tolerance model and log progress in TASKS.md

## Verification
- pnpm -w turbo run build --filter @hierarchidb/shape-api --filter @hierarchidb/shape-store --filter @hierarchidb/gis-sdk --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin
- pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator -- --run simplifyProfile.unit.test.ts

Closes #757
