### PR TITLE
fix(shape-plugin): align Step5 Source/Geometry preview metrics

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #763 / codex/fix/shape/step5-preview-metrics-consistency-763 / 2026-03-04 13:56
 - #761 / codex/fix/app/shape-edit-window-mode / 2026-03-04 13:18
 - #757 / codex/feat/shape/session-driven-base-tolerance-757 / 2026-03-04 11:52
 - #758 / codex/fix/shape/step5-full-mode-preview-stability-758 / 2026-03-04 12:32
@@ -34,6 +35,8 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #763 進捗 - Geometry/source preview 指標の母数不整合を修正（`retryAttempt` 優先順位見直し、`polygons` を `polygonsPerFeature` より優先、Geometry summary へ Source `fetchDetail` を入力由来で補完、Source raw未取得時のサイズ比表示を縮減率ヒントで補正）。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` は成功（exit 0）。
+- 2026-03-04: Issue #763 開始 - Step5 Source/Geometry preview の指標表示不整合（Sourceサイズ、Retry attempts、Features/Polygons分母、`Max Poly` ラベル）修正に着手
 - 2026-03-04: Issue #761 進捗 - `usePluginDialogRoute` の route params 解決を `dialogModeStep > dialogMode > dialog` 優先へ修正し、`plugin-dialog-step.unit.test.tsx` に再発テスト追加。`pnpm -w turbo run test --filter @hierarchidb/app -- --run src/router/__tests__/unit/plugin-dialog-step.unit.test.tsx` / `pnpm -w turbo run typecheck --filter @hierarchidb/app` / `pnpm -w turbo run build --filter @hierarchidb/app` はすべて成功（exit 0）。
 - 2026-03-04: Issue #761 開始 - `/shape/edit/maximize/5` と `/shape/edit/full/5` で URL mode が `normal` へ巻き戻る再発不具合の調査と修正に着手
 - 2026-03-04: Issue #757 開始 - Source終了時の代表ポリゴン `t_base`（<=6553）をセッションへ保持し、Geometryで再利用する仕様ドキュメント化と実装修正に着手

--- a/plugins/shape-plugin/src/services/datasources/GADMStrategy.ts
+++ b/plugins/shape-plugin/src/services/datasources/GADMStrategy.ts
@@ -30,6 +30,7 @@ export interface GADMRawData {
     level: number;
     format: 'json';
     version: string;
+    rawSourceCacheKey?: string;
   };
 }
 
@@ -148,14 +149,20 @@ export class GADMStrategy extends BaseDataSourceStrategy<GADMRawData, GADMProces
         },
       });
 
-      const { decoded } = await fetchRawDataWithPipeline({
+      const { decoded, cacheKey } = await fetchRawDataWithPipeline({
         nodeId: resolvedNodeId,
         fetchOptions: options ?? {},
         pipeline,
         retryConfig: retries,
         onRetryAttempt: options?.onRetryAttempt,
       });
-      return decoded;
+      return {
+        ...decoded,
+        metadata: {
+          ...decoded.metadata,
+          rawSourceCacheKey: cacheKey,
+        },
+      };
 
     } catch (error) {
       throw new Error(`Failed to download GADM data for ${normalizedCountry}: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/plugins/shape-plugin/src/services/datasources/GeoBoundariesStrategy.ts
+++ b/plugins/shape-plugin/src/services/datasources/GeoBoundariesStrategy.ts
@@ -59,6 +59,7 @@ export interface GeoBoundariesRawData {
     format: 'geojson';
     apiResponse?: GeoBoundariesApiResponse;
     continent?: string;
+    rawSourceCacheKey?: string;
   };
 }
 
@@ -183,7 +184,7 @@ export class GeoBoundariesStrategy extends BaseDataSourceStrategy<GeoBoundariesR
         },
       });
 
-      const { decoded } = await fetchRawDataWithPipeline({
+      const { decoded, cacheKey } = await fetchRawDataWithPipeline({
         nodeId: resolvedNodeId,
         fetchOptions: options ?? {},
         pipeline,
@@ -191,7 +192,13 @@ export class GeoBoundariesStrategy extends BaseDataSourceStrategy<GeoBoundariesR
         onRetryAttempt: options?.onRetryAttempt,
       });
       console.log(`[GeoBoundaries] Download succeeded: ${downloadUrl}`);
-      return decoded;
+      return {
+        ...decoded,
+        metadata: {
+          ...decoded.metadata,
+          rawSourceCacheKey: cacheKey,
+        },
+      };
 
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/plugins/shape-plugin/src/services/vt/runShapeGeometryStageSection.ts
+++ b/plugins/shape-plugin/src/services/vt/runShapeGeometryStageSection.ts
@@ -56,6 +56,10 @@ type GeometryBufferMeta = {
   dataSource?: string;
   sourceUrl?: string;
   sourceCountryCode?: string;
+  sourceFeatureInputCount?: number;
+  sourceFeatureOutputCount?: number;
+  sourcePolygonInputCount?: number;
+  sourcePolygonOutputCount?: number;
   featureCount: number;
   inputPolygonCount?: number;
   polygonCount?: number;
@@ -93,6 +97,13 @@ const readSourceBaseTolerance = (value: unknown): number | undefined => {
   const baseTolerance = readNumber(value.baseTolerance);
   if (baseTolerance === null || baseTolerance < 0) return undefined;
   return baseTolerance;
+};
+
+const readMetricCount = (value: unknown, key: 'input' | 'output'): number | undefined => {
+  if (!isRecord(value)) return undefined;
+  const parsed = readNumber(value[key]);
+  if (parsed === null || parsed < 0) return undefined;
+  return Math.round(parsed);
 };
 
 const toMemoryValue = (value: number | undefined): number | null => (
@@ -227,8 +238,17 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
       const sourceKey = readString(input?.sourceKey);
       if (!sourceKey) continue;
       const preview = isRecord(task.metadata?.preview) ? task.metadata.preview : null;
+      const fetchDetail = isRecord(task.metadata?.fetchDetail) ? task.metadata.fetchDetail : null;
+      const fetchFeatures = isRecord(fetchDetail?.features) ? fetchDetail.features : null;
+      const fetchPolygons = isRecord(fetchDetail?.polygons) ? fetchDetail.polygons : null;
       const sourceCacheFormat = readString(preview?.sourceCacheFormat);
       const sourceCacheCompression = readString(preview?.sourceCacheCompression);
+      const sourceFeatureInputCount = readMetricCount(fetchFeatures, 'input');
+      const sourceFeatureOutputCount = readMetricCount(fetchFeatures, 'output');
+      const sourcePolygonInputCount = readMetricCount(fetchPolygons, 'input');
+      const sourcePolygonOutputCount = readMetricCount(fetchPolygons, 'output');
+      const fallbackFeatureCount = readNumber(output?.featureCount) ?? 0;
+      const fallbackPolygonCount = readNumber(output?.polygonCount) ?? undefined;
       next.push({
         id: sourceCacheId,
         sourceKey,
@@ -240,9 +260,13 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
         dataSource: readString(input?.dataSource) ?? undefined,
         sourceUrl: readString(input?.url) ?? undefined,
         sourceCountryCode: readString(input?.urlCountryCode) ?? readString(input?.countryCode) ?? undefined,
-        featureCount: readNumber(output?.featureCount) ?? 0,
-        inputPolygonCount: readNumber(output?.polygonCount) ?? undefined,
-        polygonCount: readNumber(output?.polygonCount) ?? undefined,
+        sourceFeatureInputCount,
+        sourceFeatureOutputCount,
+        sourcePolygonInputCount,
+        sourcePolygonOutputCount,
+        featureCount: sourceFeatureOutputCount ?? fallbackFeatureCount,
+        inputPolygonCount: sourcePolygonInputCount ?? fallbackPolygonCount,
+        polygonCount: sourcePolygonOutputCount ?? fallbackPolygonCount,
         inputVertexCount: readNumber(output?.vertexCount) ?? undefined,
         vertexCount: readNumber(output?.vertexCount) ?? undefined,
       });
@@ -350,6 +374,10 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
           dataSource: buffer.dataSource,
           sourceUrl: buffer.sourceUrl,
           sourceCountryCode: buffer.sourceCountryCode,
+          sourceFeatureInputCount: buffer.sourceFeatureInputCount ?? buffer.featureCount,
+          sourceFeatureOutputCount: buffer.sourceFeatureOutputCount ?? buffer.featureCount,
+          sourcePolygonInputCount: buffer.sourcePolygonInputCount ?? buffer.inputPolygonCount ?? buffer.polygonCount,
+          sourcePolygonOutputCount: buffer.sourcePolygonOutputCount ?? buffer.polygonCount ?? buffer.inputPolygonCount,
           configSignature: geometryConfigSignature,
           cacheKey: cacheIdentity.cacheKey,
           inputHash: cacheIdentity.inputHash,

--- a/plugins/shape-plugin/src/services/vt/runShapeSourceStage.ts
+++ b/plugins/shape-plugin/src/services/vt/runShapeSourceStage.ts
@@ -93,6 +93,10 @@ const textDecoder = new TextDecoder('utf-8');
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
+const asRecord = (value: unknown): Record<string, unknown> | null => (
+  isRecord(value) ? value : null
+);
+
 const GEOBOUNDARIES_MERGE_COUNTRIES = new Set(['CAN', 'GRL', 'CA', 'GL']);
 
 const isGeoBoundariesSource = (source: DataSourceName): boolean => (
@@ -393,6 +397,10 @@ const readNumericProperty = (properties: Record<string, unknown>, key: string): 
   return Number.isFinite(value) ? value : undefined;
 };
 
+const readString = (value: unknown): string | null => (
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+);
+
 const decodeSourceCacheData = async (params: {
   data: ArrayBuffer;
   format?: string;
@@ -444,6 +452,7 @@ const buildSourceCacheMetadata = (params: {
   baseTolerance?: number;
   baseToleranceVertexLimit?: number;
   retryAttempt?: number;
+  rawSourceCacheKey?: string;
 }): Record<string, unknown> => ({
   stage: 'source',
   status: params.status,
@@ -466,6 +475,7 @@ const buildSourceCacheMetadata = (params: {
   retryAttempt: Number.isFinite(params.retryAttempt ?? NaN)
     ? Math.trunc(params.retryAttempt!)
     : undefined,
+  rawSourceCacheKey: params.rawSourceCacheKey ?? undefined,
 });
 
 const markSourceCacheWriteComplete = async (cacheIds: string[]): Promise<void> => {
@@ -1097,6 +1107,7 @@ const createSourceHandler = (params: {
       sourceCacheId?: string | null;
       sourceCacheFormat?: 'flatgeobuf' | 'topojson';
       sourceCacheCompression?: 'gzip' | 'none';
+      rawSourceCacheKey?: string | null;
     },
   ): Record<string, unknown> => ({
     fetchDetail: {
@@ -1130,7 +1141,7 @@ const createSourceHandler = (params: {
       sourceUrl: input.url,
       sourceCountryCode: input.urlCountryCode || input.countryCode,
       adminLevel: input.adminLevel,
-      rawSourceCacheKey: buildRawDataDataSourceCacheKey({
+      rawSourceCacheKey: preview?.rawSourceCacheKey ?? buildRawDataDataSourceCacheKey({
         dataSource: input.dataSource,
         countryCode: input.urlCountryCode,
         adminLevel: input.adminLevel,
@@ -1141,6 +1152,21 @@ const createSourceHandler = (params: {
       sourceCacheCompression: preview?.sourceCacheCompression ?? 'none',
     },
   });
+
+  const resolveRawSourceCacheKey = (
+    input: ShapeSourceTaskInput,
+    rawData: unknown,
+  ): string | null => {
+    const rawRecord = asRecord(rawData);
+    const rawMetadata = asRecord(rawRecord?.metadata);
+    const apiResponse = asRecord(rawMetadata?.apiResponse);
+    return readString(rawMetadata?.rawSourceCacheKey)
+      ?? readString(rawMetadata?.downloadUrl)
+      ?? readString(rawMetadata?.endpoint)
+      ?? readString(apiResponse?.simplifiedGeometryGeoJSON)
+      ?? readString(input.url)
+      ?? null;
+  };
 
   const analyzeSourceToleranceMetrics = async (
     collection: FeatureCollection,
@@ -1221,6 +1247,7 @@ const createSourceHandler = (params: {
           ?? 0;
         const cachedInputMaxPolygonVertexCount = readNumericProperty(existingMetadata, 'inputMaxPolygonVertexCount')
           ?? cachedMaxPolygonVertexCount;
+        const cachedRawSourceCacheKey = readString(existingMetadata.rawSourceCacheKey);
         let cachedBaseTolerance = readNumericProperty(existingMetadata, 'baseTolerance') ?? 0;
         const cachedBaseToleranceVertexLimit = readNumericProperty(existingMetadata, 'baseToleranceVertexLimit')
           ?? SOURCE_BASE_TOLERANCE_VERTEX_LIMIT;
@@ -1248,6 +1275,7 @@ const createSourceHandler = (params: {
             inputMaxPolygonVertexCount: cachedInputMaxPolygonVertexCount,
             baseTolerance: cachedBaseTolerance,
             baseToleranceVertexLimit: cachedBaseToleranceVertexLimit,
+            rawSourceCacheKey: cachedRawSourceCacheKey ?? undefined,
           })
         );
         if (cachedCollection && cachedCollection.features.length > 0) {
@@ -1341,6 +1369,7 @@ const createSourceHandler = (params: {
             sourceCacheId: existing.id,
             sourceCacheFormat: existing.format === 'topojson' ? 'topojson' : 'flatgeobuf',
             sourceCacheCompression: existing.compression === 'gzip' ? 'gzip' : 'none',
+            rawSourceCacheKey: cachedRawSourceCacheKey,
           }),
           outputData: {
             sourceCacheId: existing.id,
@@ -1370,6 +1399,7 @@ const createSourceHandler = (params: {
         onRetryAttempt,
       });
       const downloadTime = Date.now() - downloadStart;
+      const rawSourceCacheKey = topojsonResult.downloadUrl;
 
       let baseCollection = normalizeTopoJsonCollection(topojsonResult.topology);
       if (shouldMergeGeoBoundaries({
@@ -1424,6 +1454,8 @@ const createSourceHandler = (params: {
             maxPolygonVertexCount: 0,
             baseTolerance: 0,
             baseToleranceVertexLimit: SOURCE_BASE_TOLERANCE_VERTEX_LIMIT,
+          }, {
+            rawSourceCacheKey,
           }),
         };
       }
@@ -1487,6 +1519,7 @@ const createSourceHandler = (params: {
           inputMaxPolygonVertexCount: inputSummary.maxPolygonVertexCount,
           baseTolerance: outputToleranceMetrics.baseTolerance,
           baseToleranceVertexLimit: outputToleranceMetrics.baseToleranceVertexLimit,
+          rawSourceCacheKey,
         }),
       });
       const reductionSummary = [
@@ -1513,6 +1546,7 @@ const createSourceHandler = (params: {
           sourceCacheId: sourceCacheRecord.id,
           sourceCacheFormat: 'topojson',
           sourceCacheCompression: 'gzip',
+          rawSourceCacheKey,
         }),
         outputData: {
           sourceCacheId: sourceCacheRecord.id,
@@ -1535,6 +1569,7 @@ const createSourceHandler = (params: {
       timeout: params.buildConfig.sourceConfig.timeoutMs,
       onRetryAttempt,
     });
+    const rawSourceCacheKey = resolveRawSourceCacheKey(input, raw);
     const downloadTime = Date.now() - downloadStart;
 
     assertNotAborted(params.abortSignal);
@@ -1592,6 +1627,8 @@ const createSourceHandler = (params: {
           maxPolygonVertexCount: 0,
           baseTolerance: 0,
           baseToleranceVertexLimit: SOURCE_BASE_TOLERANCE_VERTEX_LIMIT,
+        }, {
+          rawSourceCacheKey,
         }),
       };
     }
@@ -1659,6 +1696,7 @@ const createSourceHandler = (params: {
         inputMaxPolygonVertexCount: inputSummary.maxPolygonVertexCount,
         baseTolerance: outputToleranceMetrics.baseTolerance,
         baseToleranceVertexLimit: outputToleranceMetrics.baseToleranceVertexLimit,
+        rawSourceCacheKey: rawSourceCacheKey ?? undefined,
       }),
     });
     const reductionSummary = [
@@ -1685,6 +1723,7 @@ const createSourceHandler = (params: {
         sourceCacheId: sourceCacheRecord.id,
         sourceCacheFormat: 'flatgeobuf',
         sourceCacheCompression: 'none',
+        rawSourceCacheKey,
       }),
       outputData: {
         sourceCacheId: sourceCacheRecord.id,

--- a/plugins/shape-plugin/src/services/vt/shapePipelineShared.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineShared.ts
@@ -46,6 +46,10 @@ export type ShapeGeometryByBandTaskInput = {
   dataSource?: string;
   sourceUrl?: string;
   sourceCountryCode?: string;
+  sourceFeatureInputCount?: number;
+  sourceFeatureOutputCount?: number;
+  sourcePolygonInputCount?: number;
+  sourcePolygonOutputCount?: number;
   configSignature?: string;
   cacheKey?: string;
   inputHash?: string;

--- a/plugins/shape-plugin/src/services/vt/shapePipelineSourceStage.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineSourceStage.ts
@@ -140,10 +140,10 @@ export const runShapeSourceStageSection = async (params: ShapeSourceStageParams)
     const features = fetchDetail && typeof fetchDetail.features === 'object' && fetchDetail.features !== null
       ? fetchDetail.features as Record<string, unknown>
       : null;
-    const polygons = fetchDetail && typeof fetchDetail.polygonsPerFeature === 'object' && fetchDetail.polygonsPerFeature !== null
-      ? fetchDetail.polygonsPerFeature as Record<string, unknown>
-      : (fetchDetail && typeof fetchDetail.polygons === 'object' && fetchDetail.polygons !== null
-        ? fetchDetail.polygons as Record<string, unknown>
+    const polygons = fetchDetail && typeof fetchDetail.polygons === 'object' && fetchDetail.polygons !== null
+      ? fetchDetail.polygons as Record<string, unknown>
+      : (fetchDetail && typeof fetchDetail.polygonsPerFeature === 'object' && fetchDetail.polygonsPerFeature !== null
+        ? fetchDetail.polygonsPerFeature as Record<string, unknown>
         : null);
     const fallbackPolygons = fetchDetail && typeof fetchDetail.polygons === 'object' && fetchDetail.polygons !== null
       ? fetchDetail.polygons as Record<string, unknown>

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts
@@ -92,6 +92,54 @@ describe('buildGeometryTaskOutcomeSummary metadata handoff', () => {
     expect(summary.detailLines.join(' ')).toContain('Failure Reason: geometry failed: simplify');
   });
 
+  it('prioritizes finalRetryAttempts over interim retryAttempt', () => {
+    const task = buildBaseTask({
+      metadata: {
+        retryAttempt: 0,
+        finalRetryAttempts: 3,
+        retryMax: 24,
+      },
+    });
+
+    const summary = buildGeometryTaskOutcomeSummary({
+      task,
+      stageId: 'geometry',
+      taskTitle: 'geometry-task-1',
+      translate: t,
+    });
+
+    expect(summary.kind).toBe('completed');
+    expect(summary.retryAttempt).toBe(3);
+    expect(summary.summaryLine).toContain('3/24');
+  });
+
+  it('prefers fetchDetail.polygons over polygonsPerFeature for source metrics', () => {
+    const task = buildBaseTask({
+      metadata: {
+        retryAttempt: 1,
+        retryMax: 24,
+        fetchDetail: {
+          features: { input: 1, output: 1 },
+          polygons: { input: 1952, output: 27 },
+          polygonsPerFeature: { input: 27, output: 27 },
+        },
+      },
+    });
+
+    const summary = buildGeometryTaskOutcomeSummary({
+      task,
+      stageId: 'geometry',
+      taskTitle: 'geometry-task-1',
+      translate: t,
+    });
+
+    expect(summary.kind).toBe('completed');
+    expect(summary.sourceMetrics?.features.input).toBe(1);
+    expect(summary.sourceMetrics?.features.output).toBe(1);
+    expect(summary.sourceMetrics?.polygons.input).toBe(1952);
+    expect(summary.sourceMetrics?.polygons.output).toBe(27);
+  });
+
   it('does not recover retryMax from message text', () => {
     const task = buildBaseTask({
       status: 'failed',

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
@@ -241,6 +241,7 @@ const loadSourceCollectionFromCache = async (
 ): Promise<CollectionLoadResult | null> => {
   const rawSourceCacheKeys = Array.from(new Set([
     readString(preview?.rawSourceCacheKey),
+    readString(preview?.sourceUrl),
     (() => {
       const sourceUrl = readString(preview?.sourceUrl);
       if (!sourceUrl) return null;
@@ -940,18 +941,22 @@ const TaskDetailContent = ({
   const sourceFilteredMetrics = toCollectionMetrics(preview?.original ?? null);
   const geometryMetrics = toCollectionMetrics(preview?.result ?? null);
   const hasPreviewGeometryMetrics = sourceFilteredMetrics.featureCount > 0 && geometryMetrics.featureCount > 0;
-  const transformFeatureInput = hasPreviewGeometryMetrics
-    ? sourceFilteredMetrics.featureCount
-    : (summary.sourceMetrics?.features.output ?? summary.fetchDetails?.features.output ?? summary.metrics?.features.input ?? null);
-  const transformFeatureOutput = hasPreviewGeometryMetrics
-    ? geometryMetrics.featureCount
-    : (summary.metrics?.features.output ?? summary.sourceMetrics?.features.output ?? null);
-  const transformPolygonInput = hasPreviewGeometryMetrics
-    ? sourceFilteredMetrics.polygonCount
-    : (summary.sourceMetrics?.polygons.output ?? summary.fetchDetails?.polygons.output ?? summary.metrics?.polygons.input ?? null);
-  const transformPolygonOutput = hasPreviewGeometryMetrics
-    ? geometryMetrics.polygonCount
-    : (summary.metrics?.polygons.output ?? summary.sourceMetrics?.polygons.output ?? null);
+  const transformFeatureInput = summary.sourceMetrics?.features.input
+    ?? summary.fetchDetails?.features.input
+    ?? summary.metrics?.features.input
+    ?? null;
+  const transformFeatureOutput = summary.sourceMetrics?.features.output
+    ?? summary.fetchDetails?.features.output
+    ?? summary.metrics?.features.output
+    ?? null;
+  const transformPolygonInput = summary.sourceMetrics?.polygons.input
+    ?? summary.fetchDetails?.polygons.input
+    ?? summary.metrics?.polygons.input
+    ?? null;
+  const transformPolygonOutput = summary.sourceMetrics?.polygons.output
+    ?? summary.fetchDetails?.polygons.output
+    ?? summary.metrics?.polygons.output
+    ?? null;
   const transformVertexInput = hasPreviewGeometryMetrics
     ? sourceFilteredMetrics.vertexCount
     : (summary.metrics?.vertices.input ?? null);
@@ -964,6 +969,27 @@ const TaskDetailContent = ({
   const maxPolygonVertexOutput = hasPreviewGeometryMetrics
     ? geometryMetrics.maxPolygonVertexCount
     : (summary.maxPolygonVertices?.output ?? null);
+  const sizeMetricInput = summary.visualization === 'fetchMetrics'
+    ? (summary.fetchDetails?.polygons.input ?? summary.fetchDetails?.features.input ?? null)
+    : (summary.sourceMetrics?.polygons.input ?? summary.sourceMetrics?.features.input ?? null);
+  const sizeMetricOutput = summary.visualization === 'fetchMetrics'
+    ? (summary.fetchDetails?.polygons.output ?? summary.fetchDetails?.features.output ?? null)
+    : (summary.sourceMetrics?.polygons.output ?? summary.sourceMetrics?.features.output ?? null);
+  let previewOriginalBytes = preview?.originalBytes ?? 0;
+  const previewResultBytes = preview?.resultBytes ?? 0;
+  const canEstimateOriginalSize = (
+    previewResultBytes > 0
+    && previewOriginalBytes <= previewResultBytes
+    && typeof sizeMetricInput === 'number'
+    && Number.isFinite(sizeMetricInput)
+    && typeof sizeMetricOutput === 'number'
+    && Number.isFinite(sizeMetricOutput)
+    && sizeMetricInput > sizeMetricOutput
+    && sizeMetricOutput > 0
+  );
+  if (canEstimateOriginalSize) {
+    previewOriginalBytes = Math.max(previewOriginalBytes, Math.round(previewResultBytes * (sizeMetricInput / sizeMetricOutput)));
+  }
 
   return (
     <Box
@@ -1042,7 +1068,7 @@ const TaskDetailContent = ({
               false,
             )}
             {renderVertexLimitReferencedRow(
-              'Max Poly',
+              'Max Vertices',
               maxPolygonVertexOutput,
               maxPolygonVertexInput,
               chartColor,
@@ -1111,8 +1137,8 @@ const TaskDetailContent = ({
         ) : (
           <GeometryPreviewMap
             overlays={overlays}
-            originalBytes={preview?.originalBytes ?? 0}
-            resultBytes={preview?.resultBytes ?? 0}
+            originalBytes={previewOriginalBytes}
+            resultBytes={previewResultBytes}
             resultColor={sizeAccentColor}
           />
         )}

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders.ts
@@ -186,12 +186,12 @@ export const buildSourceTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ task,
     'fetchDetail.features.output',
   ]);
   const polygonsInput = readMetadataNumber(task.metadata, [
-    'fetchDetail.polygonsPerFeature.input',
     'fetchDetail.polygons.input',
+    'fetchDetail.polygonsPerFeature.input',
   ]);
   const polygonsOutput = readMetadataNumber(task.metadata, [
-    'fetchDetail.polygonsPerFeature.output',
     'fetchDetail.polygons.output',
+    'fetchDetail.polygonsPerFeature.output',
   ]);
   const featuresRatio = resolveRatio(featuresOutput, featuresInput);
   const polygonsRatio = resolveRatio(polygonsOutput, polygonsInput);
@@ -286,10 +286,10 @@ export const buildGeometryTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ tas
     : `${Number.parseFloat(effectiveTolerance.toFixed(6))}`;
 
   const retryAttemptRaw = readMetadataNumber(task.metadata, [
-    'retryAttempt',
     'finalRetryAttempts',
-    'metadata.retryAttempt',
     'metadata.finalRetryAttempts',
+    'retryAttempt',
+    'metadata.retryAttempt',
   ]) ?? readNumber(task.retryAttempt);
   const retryAttempt = retryAttemptRaw !== null && retryAttemptRaw >= 0 ? Math.floor(retryAttemptRaw) : null;
 
@@ -335,12 +335,12 @@ export const buildGeometryTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ tas
     },
     polygons: {
       input: readMetadataNumber(task.metadata, [
-        'fetchDetail.polygonsPerFeature.input',
         'fetchDetail.polygons.input',
+        'fetchDetail.polygonsPerFeature.input',
       ]),
       output: readMetadataNumber(task.metadata, [
-        'fetchDetail.polygonsPerFeature.output',
         'fetchDetail.polygons.output',
+        'fetchDetail.polygonsPerFeature.output',
       ]),
     },
   };

--- a/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionMetrics.ts
+++ b/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionMetrics.ts
@@ -497,6 +497,37 @@ const pickRecordMetadataField = (metadata: Record<string, unknown>, key: string)
   return value;
 };
 
+const buildFetchDetailFromGeometryInput = (task: TaskQueueRecord): Record<string, unknown> | null => {
+  if (!isGeometryStage(task.stage)) return null;
+  const input = asRecord(task.inputData);
+  if (!input) return null;
+  const sourceFeatureInput = readNumber(input.sourceFeatureInputCount);
+  const sourceFeatureOutput = readNumber(input.sourceFeatureOutputCount);
+  const sourcePolygonInput = readNumber(input.sourcePolygonInputCount);
+  const sourcePolygonOutput = readNumber(input.sourcePolygonOutputCount);
+  const hasMetrics = (
+    sourceFeatureInput !== null
+    || sourceFeatureOutput !== null
+    || sourcePolygonInput !== null
+    || sourcePolygonOutput !== null
+  );
+  if (!hasMetrics) return null;
+  return {
+    countryCode: readString(input.sourceCountryCode) ?? readString(input.countryCode),
+    countryName: readString(input.countryName),
+    adminLevel: readNumber(input.adminLevel),
+    url: readString(input.sourceUrl),
+    features: {
+      input: sourceFeatureInput,
+      output: sourceFeatureOutput,
+    },
+    polygons: {
+      input: sourcePolygonInput,
+      output: sourcePolygonOutput,
+    },
+  };
+};
+
 const sanitizeTaskMetadataForSummary = (
   task: TaskQueueRecord,
   preview: Record<string, unknown> | null,
@@ -515,7 +546,10 @@ const sanitizeTaskMetadataForSummary = (
   const primitiveKeys = [
     'message',
     'retryAttempt',
+    'finalRetryAttempts',
     'retryMax',
+    'finalRetryCount',
+    'finalRetryLimit',
     'retryCount',
     'retryLimit',
     'maxRetryAttempts',
@@ -541,6 +575,11 @@ const sanitizeTaskMetadataForSummary = (
   const fetchDetail = pickRecordMetadataField(metadata, 'fetchDetail');
   if (fetchDetail) {
     next.fetchDetail = fetchDetail;
+  } else {
+    const fetchDetailFromInput = buildFetchDetailFromGeometryInput(task);
+    if (fetchDetailFromInput) {
+      next.fetchDetail = fetchDetailFromInput;
+    }
   }
 
   const tileEmitParentInputSummary = pickRecordMetadataField(metadata, 'tileEmitParentInputSummary');
@@ -553,6 +592,9 @@ const sanitizeTaskMetadataForSummary = (
     const compactNested: Record<string, unknown> = {};
     for (const key of [
       'retryMax',
+      'finalRetryCount',
+      'finalRetryLimit',
+      'finalRetryAttempts',
       'effectiveTolerance',
       'finalTolerance',
       'extractionRatio',


### PR DESCRIPTION
## Summary
- Fix Step5 Source/Geometry preview metric consistency for Shape plugin
- Preserve and handoff raw source cache identity so preview fallback can read source buffers reliably
- Normalize Geometry summary to use Source-equivalent denominator metrics (`fetchDetail.polygons`/`features`)
- Prioritize terminal retry metadata (`finalRetryAttempts`) over interim retry fields
- Rename transform metric label from `Max Poly` to `Max Vertices`

## Changes
- `runShapeSourceStage.ts`
  - keep/propgate `rawSourceCacheKey` in source-stage metadata preview payload
- `GeoBoundariesStrategy.ts`, `GADMStrategy.ts`
  - persist `rawSourceCacheKey` into raw-data metadata from pipeline cache key
- `runShapeGeometryStageSection.ts`, `shapePipelineShared.ts`
  - carry Source fetch metrics into geometry task input metadata handoff fields
- `shapeBuildRuntimeExecutionMetrics.ts`
  - synthesize/fallback `fetchDetail` for geometry summaries from handoff input fields
  - include `finalRetryAttempts/finalRetryCount/finalRetryLimit` in summary metadata compaction
- `taskOutcomeSummaryBuilders.ts`
  - use `fetchDetail.polygons` as primary polygon metric source
  - prioritize `finalRetryAttempts` before `retryAttempt`
- `TaskItemDetailWindow.tsx`
  - source preview size ratio fallback now avoids false 100% when only reduced output cache is available
- tests
  - extend `taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` for retry priority and polygon metric precedence

## Verification
- `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` (exit 0)

Closes #763
