### PR TITLE
fix(shape-plugin): align geometry preview metrics rendering

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #768 / codex/fix/shape/geometry-preview-geometry-metrics-768 / 2026-03-04 15:34
 - #765 / codex/feat/shape/preview-admin-subtile-guides-765 / 2026-03-04 15:12
 - #763 / codex/fix/shape/step5-preview-metrics-consistency-763 / 2026-03-04 13:56
 - #761 / codex/fix/app/shape-edit-window-mode / 2026-03-04 13:18
@@ -36,6 +37,8 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #768 進捗 - Geometry Preview: Geometry で Features/Polygons をテキスト表示へ変更し、Max Vertices は表示値比率（分子/分母）基準で描画、分母が 6,553 以下のとき閾値マーカー非表示に修正。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` は成功（exit 0）。
+- 2026-03-04: Issue #768 開始 - Geometry Preview: Geometry の Features/Polygons をテキスト表示へ変更し、Max Vertices の棒グラフ/閾値線を表示比率に一致させる修正に着手
 - 2026-03-04: Issue #765 進捗 - Geometry Preview で adminLevel 分割線が表示されない不具合を修正。`buildGeometryTaskOutcomeSummary` へ `adminLevel` 受け渡しを追加し、Floating Window 側で `summary.adminLevel` を優先参照。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` は成功（exit 0）。
 - 2026-03-04: Issue #765 進捗 - preview 地図のタイル描画に Admin level 別サブ分割点線を追加（L1=2x2 灰, L2=4x4 薄灰, L3=8x8 さらに薄灰, L0は追加なし）。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` は成功（exit 0）。
 - 2026-03-04: Issue #765 開始 - shape Step5 preview 地図で Admin level 1/2/3 の親タイル内サブ分割ガイド線（2x2, 4x4, 8x8）を点線表示する要件に着手

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
@@ -112,6 +112,7 @@ describe('TaskItemCardListCard', () => {
         metadata: {
           effectiveTolerance: 0.125,
           retryAttempt: 2,
+          retryMax: 10,
         },
       } as ShapeBuildTaskSummary,
     ];
@@ -131,9 +132,9 @@ describe('TaskItemCardListCard', () => {
       </Provider>
     );
 
-    expect(screen.getByText(/Tol 0\.125/)).toBeTruthy();
-    expect(screen.getByText(/Retry 2\/10/)).toBeTruthy();
-    expect(screen.getByText('Failed: retry 2')).toBeTruthy();
+    expect(screen.getByText(/Tol: 0\.125/)).toBeTruthy();
+    expect(screen.getByText(/Attempt: 2\/10/)).toBeTruthy();
+    expect(screen.getByText(/Failed \(Tol: 0\.125/)).toBeTruthy();
   });
 
   it('keeps source and tileEmit with simple summary without N/A charts', () => {
@@ -271,6 +272,106 @@ describe('TaskItemCardListCard', () => {
     expect(screen.getByText('5,000 / 10,000 (50%)')).toBeTruthy();
     expect(screen.getByText('Polygons')).toBeTruthy();
     expect(screen.getByText('10,000 / 25,000 (40%)')).toBeTruthy();
+  });
+
+  it('shows geometry Features/Polygons as text and hides max-vertices marker when denominator is below limit', () => {
+    const tasks: ShapeBuildTaskSummary[] = [
+      {
+        taskId: 'geometry-task-preview-1',
+        nodeId: 'node-1' as NodeId,
+        stage: 'geometry',
+        taskType: 'geometry',
+        status: 'completed',
+        progress: 100,
+        display: {
+          kind: 'summary',
+          metrics: {
+            features: { input: 1, output: 1 },
+            polygons: { input: 47, output: 47 },
+            vertices: { input: 39550, output: 6552 },
+          },
+        },
+        metadata: {
+          retryAttempt: 2,
+          retryMax: 24,
+          maxPolygonVertices: { input: 3754, output: 3754 },
+        },
+      } as ShapeBuildTaskSummary,
+    ];
+    const store = createStore();
+
+    const view = render(
+      <Provider store={store}>
+        <TaskItemCardListCard
+          stageId="geometry"
+          tasks={tasks}
+          stageValue={0}
+          resolveStatusLabel={() => 'Completed'}
+          resolveStatusColor={() => 'success'}
+          resolveTaskTitle={() => 'Geometry Task 1'}
+          virtualize={false}
+          isDetailFloatingWindowOpen
+        />
+      </Provider>
+    );
+
+    const chips = Array.from(view.container.querySelectorAll('[data-task-id] .MuiChip-root'));
+    expect(chips.length).toBe(1);
+    fireEvent.mouseEnter(chips[0]);
+
+    expect(screen.getByText('Features: 1')).toBeTruthy();
+    expect(screen.getByText('Polygons: 47')).toBeTruthy();
+    expect(screen.getByText('3,754 / 3,754 (100%)')).toBeTruthy();
+    expect(screen.queryByTestId('max-vertices-limit-marker')).toBeNull();
+  });
+
+  it('shows max-vertices marker when denominator exceeds limit', () => {
+    const tasks: ShapeBuildTaskSummary[] = [
+      {
+        taskId: 'geometry-task-preview-2',
+        nodeId: 'node-1' as NodeId,
+        stage: 'geometry',
+        taskType: 'geometry',
+        status: 'completed',
+        progress: 100,
+        display: {
+          kind: 'summary',
+          metrics: {
+            features: { input: 1, output: 1 },
+            polygons: { input: 27, output: 27 },
+            vertices: { input: 39550, output: 6552 },
+          },
+        },
+        metadata: {
+          retryAttempt: 1,
+          retryMax: 24,
+          maxPolygonVertices: { input: 17598, output: 2852 },
+        },
+      } as ShapeBuildTaskSummary,
+    ];
+    const store = createStore();
+
+    const view = render(
+      <Provider store={store}>
+        <TaskItemCardListCard
+          stageId="geometry"
+          tasks={tasks}
+          stageValue={0}
+          resolveStatusLabel={() => 'Completed'}
+          resolveStatusColor={() => 'success'}
+          resolveTaskTitle={() => 'Geometry Task 2'}
+          virtualize={false}
+          isDetailFloatingWindowOpen
+        />
+      </Provider>
+    );
+
+    const chips = Array.from(view.container.querySelectorAll('[data-task-id] .MuiChip-root'));
+    expect(chips.length).toBe(1);
+    fireEvent.mouseEnter(chips[0]);
+
+    expect(screen.getByText('2,852 / 17,598 (16.2%)')).toBeTruthy();
+    expect(screen.getByTestId('max-vertices-limit-marker')).toBeTruthy();
   });
 
   it('toggles selected chip and keeps preview fixed while selected', () => {

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
@@ -449,11 +449,11 @@ const renderVertexLimitReferencedRow = (
 ): React.ReactNode => {
   const safeInput = typeof input === 'number' && Number.isFinite(input) && input >= 0 ? input : null;
   const safeOutput = typeof output === 'number' && Number.isFinite(output) && output >= 0 ? output : null;
-  const scaleMax = Math.max(limit, safeInput ?? 0, safeOutput ?? 0, 1);
-  const inputScale = safeInput !== null ? Math.max(0, Math.min(1, safeInput / scaleMax)) : null;
-  const outputScale = safeOutput !== null ? Math.max(0, Math.min(1, safeOutput / scaleMax)) : null;
-  const limitScale = Math.max(0, Math.min(1, limit / scaleMax));
   const ratio = resolveRatio(safeOutput, safeInput);
+  const inputScale = safeInput !== null ? 1 : null;
+  const outputScale = ratio;
+  const showLimitMarker = safeInput !== null && safeInput > limit;
+  const limitScale = showLimitMarker ? Math.max(0, Math.min(1, limit / safeInput)) : null;
   const text = `${formatNumber(output)} / ${formatNumber(input)} (${formatPercent(ratio)})`;
 
   return (
@@ -487,16 +487,19 @@ const renderVertexLimitReferencedRow = (
             }}
           />
         ) : null}
-        <Box
-          sx={{
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            left: `calc(${limitScale * 100}% - 2px)`,
-            width: '4px',
-            background: (theme) => `linear-gradient(to right, ${theme.palette.warning.main} 0 2px, ${theme.palette.common.black} 2px 4px)`,
-          }}
-        />
+        {limitScale !== null ? (
+          <Box
+            data-testid="max-vertices-limit-marker"
+            sx={{
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              left: `calc(${limitScale * 100}% - 2px)`,
+              width: '4px',
+              background: (theme) => `linear-gradient(to right, ${theme.palette.warning.main} 0 2px, ${theme.palette.common.black} 2px 4px)`,
+            }}
+          />
+        ) : null}
         <Typography
           variant="caption"
           sx={{
@@ -519,6 +522,15 @@ const renderVertexLimitReferencedRow = (
     </Box>
   );
 };
+
+const renderCountTextRow = (
+  label: string,
+  value: number | null | undefined,
+): React.ReactNode => (
+  <Typography variant="caption" color="text.secondary">
+    {`${label}: ${formatNumber(value)}`}
+  </Typography>
+);
 
 const renderStackedRatioRow = (
   label: string,
@@ -984,17 +996,9 @@ const TaskDetailContent = ({
   const sourceFilteredMetrics = toCollectionMetrics(preview?.original ?? null);
   const geometryMetrics = toCollectionMetrics(preview?.result ?? null);
   const hasPreviewGeometryMetrics = sourceFilteredMetrics.featureCount > 0 && geometryMetrics.featureCount > 0;
-  const transformFeatureInput = summary.sourceMetrics?.features.input
-    ?? summary.fetchDetails?.features.input
-    ?? summary.metrics?.features.input
-    ?? null;
   const transformFeatureOutput = summary.sourceMetrics?.features.output
     ?? summary.fetchDetails?.features.output
     ?? summary.metrics?.features.output
-    ?? null;
-  const transformPolygonInput = summary.sourceMetrics?.polygons.input
-    ?? summary.fetchDetails?.polygons.input
-    ?? summary.metrics?.polygons.input
     ?? null;
   const transformPolygonOutput = summary.sourceMetrics?.polygons.output
     ?? summary.fetchDetails?.polygons.output
@@ -1089,20 +1093,8 @@ const TaskDetailContent = ({
             <Typography variant="caption" color="text.secondary">
               Retry attempts: {summary.retryAttempt ?? 'N/A'} / {summary.retryMax ?? 'N/A'}
             </Typography>
-            {renderVolumeRow(
-              'Features',
-              transformFeatureOutput,
-              transformFeatureInput,
-              chartColor,
-              false,
-            )}
-            {renderVolumeRow(
-              'Polygons',
-              transformPolygonOutput,
-              transformPolygonInput,
-              chartColor,
-              false,
-            )}
+            {renderCountTextRow('Features', transformFeatureOutput)}
+            {renderCountTextRow('Polygons', transformPolygonOutput)}
             {renderVolumeRow(
               'Vertices',
               transformVertexOutput,


### PR DESCRIPTION
## Summary
- render Geometry preview Features/Polygons as text rows instead of bars
- make Max Vertices bar use displayed output/input ratio
- hide the 6553 threshold marker when denominator is <= 6553
- keep threshold marker for denominator > 6553
- add/update TaskItemCardListCard tests for geometry preview rendering

## Verification
- pnpm -w turbo run build --filter @hierarchidb/shape-plugin
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin
- pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts

Closes #768