### PR TITLE
fix(shape-plugin): restore geometry preview admin guides and retry attempts

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #770 / codex/fix/shape/geometry-preview-admin-retry-770 / 2026-03-04 15:43
 - #768 / codex/fix/shape/geometry-preview-geometry-metrics-768 / 2026-03-04 15:34
 - #765 / codex/feat/shape/preview-admin-subtile-guides-765 / 2026-03-04 15:12
 - #763 / codex/fix/shape/step5-preview-metrics-consistency-763 / 2026-03-04 13:56
@@ -32,11 +33,14 @@
 - #708 / codex/chore/ci-build-checks-separation / 2026-03-03 22:10
 
 ## Blocked
+- Issue #770: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` が既存失敗を含み exit 1（`cache-entry-validation.property` / `cache-write-ordering.property` / `shapeSourceStage.unit` / `useShapeBuildTaskSnapshotProgressState.unit` / `TaskItemCard i18n-*`）。解除条件: 既存失敗の切り分けと期待値更新方針を Issue で合意後に再実行。
 - Issue #758: `pnpm -C plugins/shape-plugin exec vitest run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` が既存失敗（`geometry retryMax is missing`）で exit 1。解除条件: 既存失敗の解消後に再実行。
 - Issue #745: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` が既存失敗を含み exit 1（主に `useShapeBuildTaskSnapshotProgressState.unit.test.tsx` / `TaskItemCardListCard.unit.test.tsx` / `TaskItemCard i18n-preservation` 系）。解除条件: 既存失敗の切り分けと期待値更新方針を Issue で合意後に再実行。
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #770 進捗 - Geometry Preview: Geometry の adminLevel 分割線描画を `summary` 依存から `summary + task.metadata.preview` フォールバックへ拡張し、Retry attempts は `retryAttemptsTotal/finalRetryAttempts` と message 解析を加えて 0 固定を回避。`pnpm -w vitest plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx` / `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は成功（exit 0）。`pnpm -w turbo run test --filter @hierarchidb/shape-plugin` は既存失敗を含み exit 1（Blocked へ記録）。
+- 2026-03-04: Issue #770 開始 - Geometry Preview: Geometry で admin-level 分割線が描画されない不具合と Retry attempts が 0 固定表示になる不具合の修正に着手
 - 2026-03-04: Issue #768 進捗 - Geometry Preview: Geometry で Features/Polygons をテキスト表示へ変更し、Max Vertices は表示値比率（分子/分母）基準で描画、分母が 6,553 以下のとき閾値マーカー非表示に修正。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` は成功（exit 0）。
 - 2026-03-04: Issue #768 開始 - Geometry Preview: Geometry の Features/Polygons をテキスト表示へ変更し、Max Vertices の棒グラフ/閾値線を表示比率に一致させる修正に着手
 - 2026-03-04: Issue #765 進捗 - Geometry Preview で adminLevel 分割線が表示されない不具合を修正。`buildGeometryTaskOutcomeSummary` へ `adminLevel` 受け渡しを追加し、Floating Window 側で `summary.adminLevel` を優先参照。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` は成功（exit 0）。

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts
@@ -164,6 +164,49 @@ describe('buildGeometryTaskOutcomeSummary metadata handoff', () => {
     expect(summary.adminLevel).toBe(2);
   });
 
+  it('falls back to preview.adminLevel when fetchDetail is absent', () => {
+    const task = buildBaseTask({
+      metadata: {
+        retryAttempt: 1,
+        retryMax: 24,
+        preview: {
+          adminLevel: 3,
+        },
+      },
+    });
+
+    const summary = buildGeometryTaskOutcomeSummary({
+      task,
+      stageId: 'geometry',
+      taskTitle: 'geometry-task-1',
+      translate: t,
+    });
+
+    expect(summary.kind).toBe('completed');
+    expect(summary.adminLevel).toBe(3);
+  });
+
+  it('uses retryAttemptsTotal from message when retryAttempt metadata stays 0', () => {
+    const task = buildBaseTask({
+      errorMessage: 'geometry completed: retryAttemptsTotal=4, retriedFeatures=1/1',
+      metadata: {
+        retryAttempt: 0,
+        retryMax: 24,
+      },
+    });
+
+    const summary = buildGeometryTaskOutcomeSummary({
+      task,
+      stageId: 'geometry',
+      taskTitle: 'geometry-task-1',
+      translate: t,
+    });
+
+    expect(summary.kind).toBe('completed');
+    expect(summary.retryAttempt).toBe(4);
+    expect(summary.summaryLine).toContain('4/24');
+  });
+
   it('does not recover retryMax from message text', () => {
     const task = buildBaseTask({
       status: 'failed',

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx
@@ -264,6 +264,44 @@ describe('useShapeBuildTaskSnapshotProgressState', () => {
     });
   });
 
+  it('resolves retryAttempt from retryAttemptsTotal/finalRetryAttempts metadata', async () => {
+    const { result } = renderHook(() => useShapeBuildTaskSnapshotProgressState('node-progress' as NodeId));
+    await waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalled();
+    });
+
+    emitEvent('node-progress', {
+      type: 'snapshot',
+      nodeId: 'node-progress' as NodeId,
+      tasks: [
+        makeTaskSummary('node-progress:geometry:jp:0', {
+          stage: 'geometry',
+          status: 'completed',
+          progress: 100,
+          metadata: {
+            retryAttempt: 0,
+            retryAttemptsTotal: 3,
+            finalRetryAttempts: 2,
+          },
+          display: {
+            kind: 'summary',
+            metrics: {
+              features: { input: 1, output: 1 },
+              polygons: { input: 27, output: 27 },
+              vertices: { input: 39550, output: 840 },
+            },
+          },
+          index: 1,
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(1);
+      expect(result.current.tasks[0]?.retryAttempt).toBe(3);
+    });
+  });
+
   it('updates task state from initial snapshot and terminal-progress updates', async () => {
     const { result } = renderHook(() => useShapeBuildTaskSnapshotProgressState('node-progress' as NodeId));
     await waitFor(() => {

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
@@ -963,6 +963,7 @@ const toCollectionMetrics = (collection: FeatureCollection | null): CollectionMe
 type TaskDetailContentProps = {
   title: string;
   summary: TaskOutcomeSummary;
+  previewAdminLevel: number | null;
   detailColor: string;
   chartColor: string;
   countryFlag: string | null;
@@ -980,6 +981,7 @@ type TaskDetailContentProps = {
 const TaskDetailContent = ({
   title,
   summary,
+  previewAdminLevel,
   detailColor,
   chartColor,
   countryFlag,
@@ -1175,7 +1177,7 @@ const TaskDetailContent = ({
             originalBytes={previewOriginalBytes}
             resultBytes={previewResultBytes}
             resultColor={sizeAccentColor}
-            adminLevel={summary.adminLevel ?? summary.fetchDetails?.adminLevel ?? null}
+            adminLevel={previewAdminLevel}
           />
         )}
       </Box>
@@ -1212,6 +1214,20 @@ export const TaskItemDetailWindow = ({
   );
   const summary = activeDetail?.summary;
   const title = activeDetail?.title ?? '';
+  const previewAdminLevel = useMemo(() => {
+    if (!activeDetail) return null;
+    const summaryAdminLevel = summary?.adminLevel ?? summary?.fetchDetails?.adminLevel ?? null;
+    if (summaryAdminLevel !== null && Number.isFinite(summaryAdminLevel)) {
+      return Math.floor(summaryAdminLevel);
+    }
+    const taskMetadata = asRecord(activeDetail.task.metadata);
+    const previewMetadata = asRecord(taskMetadata?.preview);
+    const fromPreview = readNumber(previewMetadata?.adminLevel);
+    if (fromPreview !== null) return Math.floor(fromPreview);
+    const fromTask = readNumber(taskMetadata?.adminLevel);
+    if (fromTask !== null) return Math.floor(fromTask);
+    return null;
+  }, [activeDetail, summary]);
   const countryFlag = toFlagEmoji(summary?.fetchDetails?.countryCode ?? extractCountryCodeFromTitle(title));
   const detailColor = summary?.kind === 'failed' ? 'error.main' : 'text.secondary';
   const chartColor = summary?.kind === 'failed' ? 'error.main' : 'primary.main';
@@ -1392,6 +1408,7 @@ export const TaskItemDetailWindow = ({
   ) : (summary ? TaskDetailContent({
     title,
     summary,
+    previewAdminLevel,
     detailColor,
     chartColor,
     countryFlag,

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders.ts
@@ -288,10 +288,31 @@ export const buildGeometryTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ tas
   const retryAttemptRaw = readMetadataNumber(task.metadata, [
     'finalRetryAttempts',
     'metadata.finalRetryAttempts',
+    'retryAttemptsTotal',
+    'metadata.retryAttemptsTotal',
     'retryAttempt',
     'metadata.retryAttempt',
-  ]) ?? readNumber(task.retryAttempt);
-  const retryAttempt = retryAttemptRaw !== null && retryAttemptRaw >= 0 ? Math.floor(retryAttemptRaw) : null;
+  ]);
+  const retryAttemptFromMessage = readMessageNumber(
+    failedMessage ?? resolveTaskMetadataMessage(task.metadata),
+    [
+      /finalRetryAttempts=(\d+)/i,
+      /retryAttemptsTotal=(\d+)/i,
+      /retryAttempts=(\d+)/i,
+      /retryAttempt=(\d+)/i,
+    ],
+  );
+  const retryAttemptFromTask = readNumber(task.retryAttempt);
+  const retryAttemptCandidate = [
+    retryAttemptRaw,
+    retryAttemptFromMessage,
+    retryAttemptFromTask,
+  ].reduce<number | null>((currentMax, candidate) => {
+    if (candidate === null || candidate < 0) return currentMax;
+    if (currentMax === null) return candidate;
+    return Math.max(currentMax, candidate);
+  }, null);
+  const retryAttempt = retryAttemptCandidate !== null ? Math.floor(retryAttemptCandidate) : null;
 
   const retryMaxRaw = readMetadataNumber(task.metadata, [
     'retryMax',
@@ -346,6 +367,7 @@ export const buildGeometryTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ tas
   };
   const adminLevelRaw = readMetadataNumber(task.metadata, [
     'fetchDetail.adminLevel',
+    'preview.adminLevel',
     'adminLevel',
     'metadata.adminLevel',
   ]);

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSyncResolver.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSyncResolver.ts
@@ -26,6 +26,10 @@ const resolveTaskMetadataText = (task: ReturnType<typeof resolveTaskSummaryFromR
   return '';
 };
 
+const asRecord = (value: unknown): Record<string, unknown> | null => (
+  value && typeof value === 'object' ? value as Record<string, unknown> : null
+);
+
 type ResolverDeps = {
   sessionNodeId: string | null;
   refs: Pick<
@@ -69,9 +73,16 @@ export const useShapeBuildTaskSyncResolver = ({
       status: resolvedStatus,
       progress: resolveTaskProgress(resolvedStatus, normalizedTask.display, metadataMessage, progress),
     };
-    const rawRetryAttempt = resolveNumberFromMetadata(resolvedTask.metadata?.retryAttempt);
-    if (rawRetryAttempt !== null && Number.isFinite(rawRetryAttempt) && rawRetryAttempt >= 0) {
-      resolvedTask.retryAttempt = Math.floor(rawRetryAttempt);
+    const retryAttemptCandidates = [
+      resolveNumberFromMetadata(resolvedTask.metadata?.retryAttempt),
+      resolveNumberFromMetadata(resolvedTask.metadata?.retryAttemptsTotal),
+      resolveNumberFromMetadata(resolvedTask.metadata?.finalRetryAttempts),
+      resolveNumberFromMetadata(asRecord(resolvedTask.metadata?.metadata)?.retryAttempt),
+      resolveNumberFromMetadata(asRecord(resolvedTask.metadata?.metadata)?.retryAttemptsTotal),
+      resolveNumberFromMetadata(asRecord(resolvedTask.metadata?.metadata)?.finalRetryAttempts),
+    ].filter((value): value is number => value !== null && value >= 0);
+    if (retryAttemptCandidates.length > 0) {
+      resolvedTask.retryAttempt = Math.floor(Math.max(...retryAttemptCandidates));
     }
 
     const resolvedStageId = resolvedTask.stageId ?? resolvedTask.stage;

--- a/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionMetrics.ts
+++ b/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionMetrics.ts
@@ -545,7 +545,9 @@ const sanitizeTaskMetadataForSummary = (
 
   const primitiveKeys = [
     'message',
+    'adminLevel',
     'retryAttempt',
+    'retryAttemptsTotal',
     'finalRetryAttempts',
     'retryMax',
     'finalRetryCount',
@@ -591,6 +593,9 @@ const sanitizeTaskMetadataForSummary = (
   if (nestedMetadata) {
     const compactNested: Record<string, unknown> = {};
     for (const key of [
+      'adminLevel',
+      'retryAttempt',
+      'retryAttemptsTotal',
       'retryMax',
       'finalRetryCount',
       'finalRetryLimit',


### PR DESCRIPTION
## Summary
- Geometry Preview: Geometry の adminLevel 解決を拡張し、Floating Window でも L1/L2/L3 の分割ガイド線を描画
- Geometry retry attempts の解決キーを拡張（retryAttemptsTotal / finalRetryAttempts / message fallback）して 0 固定表示を解消
- runtime metrics sanitization と task sync resolver に retry/adminLevel を引き渡す補強を追加
- 回帰防止テストを追加（taskOutcomeSummaryBuilders / useShapeBuildTaskSync snapshot）

## Verification
- pnpm -w vitest plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx ✅
- pnpm -w turbo run build --filter @hierarchidb/shape-plugin ✅
- pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin ✅
- pnpm -w turbo run test --filter @hierarchidb/shape-plugin ❌ (既存失敗: property/i18n 系。今回差分外。TASKS.md Blocked に記録済み)

Closes #770
