### PR TITLE
fix(shape): geometry retry cap and task-level baseTolerance wiring (#774)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #774 / codex/fix/shape/geometry-retry-cap-tbase-774 / 2026-03-04 16:20
 - #772 / codex/fix/shape/geometry-retry-attempt-zero-772 / 2026-03-04 16:06
 - #770 / codex/fix/shape/geometry-preview-admin-retry-770 / 2026-03-04 15:43
 - #768 / codex/fix/shape/geometry-preview-geometry-metrics-768 / 2026-03-04 15:34
@@ -34,12 +35,15 @@
 - #708 / codex/chore/ci-build-checks-separation / 2026-03-03 22:10
 
 ## Blocked
+- Issue #774: `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` および `pnpm -C plugins/shape-plugin test -- --run ...` が既存失敗を含み exit 1（`cache-entry-validation.property` / `cache-write-ordering.property` / `shapeSourceStage.unit` / `useShapeBuildTaskSnapshotProgressState.unit` / `TaskItemCard i18n-*`）。解除条件: 既存失敗の切り分けと期待値更新方針を Issue で合意後に再実行。
 - Issue #770: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` が既存失敗を含み exit 1（`cache-entry-validation.property` / `cache-write-ordering.property` / `shapeSourceStage.unit` / `useShapeBuildTaskSnapshotProgressState.unit` / `TaskItemCard i18n-*`）。解除条件: 既存失敗の切り分けと期待値更新方針を Issue で合意後に再実行。
 - Issue #758: `pnpm -C plugins/shape-plugin exec vitest run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` が既存失敗（`geometry retryMax is missing`）で exit 1。解除条件: 既存失敗の解消後に再実行。
 - Issue #745: `pnpm -w turbo run test --filter @hierarchidb/shape-plugin` が既存失敗を含み exit 1（主に `useShapeBuildTaskSnapshotProgressState.unit.test.tsx` / `TaskItemCardListCard.unit.test.tsx` / `TaskItemCard i18n-preservation` 系）。解除条件: 既存失敗の切り分けと期待値更新方針を Issue で合意後に再実行。
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #774 進捗 - Geometry retry 表示を `retryAttemptsTotal/toleranceSearchIterations` 由来から切り離し、`finalRetryAttempts/retryAttempt`（上限 `retryMax` clamp）へ統一。Source `baseTolerance` を Geometry task input に引き渡し、`t_base` 優先で tolerance 初期値を解決。Floating preview 再読込依存を task primitive key で補強し、zoom違いで Vertices/Max Vertices が更新されない問題を修正。`pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` は成功（exit 0）。`test` は既存失敗を含み exit 1（Blocked へ記録）。
+- 2026-03-04: Issue #774 開始 - Geometry Retry上限逸脱表示、`t_base` 未反映疑い、zoom違いで Vertices/Max Vertices 固定化の調査と修正に着手
 - 2026-03-04: Issue #772 進捗 - Geometry retry 値の解決に `toleranceSearchIterations`（metadata/nested metadata）を追加し、runtime metrics sanitize・task sync resolver・summary builder を統一。`pnpm -w vitest plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx` / `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は成功（exit 0）。
 - 2026-03-04: Issue #772 開始 - Geometry Preview: Geometry で Retry attempts が 0 固定表示になる残存不具合の原因特定と修正に着手
 - 2026-03-04: Issue #770 進捗 - Geometry Preview: Geometry の adminLevel 分割線描画を `summary` 依存から `summary + task.metadata.preview` フォールバックへ拡張し、Retry attempts は `retryAttemptsTotal/finalRetryAttempts` と message 解析を加えて 0 固定を回避。`pnpm -w vitest plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx` / `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は成功（exit 0）。`pnpm -w turbo run test --filter @hierarchidb/shape-plugin` は既存失敗を含み exit 1（Blocked へ記録）。

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler/createTransformByBandHandler.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler/createTransformByBandHandler.ts
@@ -324,6 +324,7 @@ export const createTransformByBandHandler = (
     let toleranceMinRatioSummary: number | undefined;
     let toleranceMaxRatioSummary: number | undefined;
     let vertexLimitSummary: number | undefined;
+    let retryAttemptsTotalForTask = 0;
     let retryMaxForTask = MAX_TOLERANCE_SEARCH_ITERATIONS;
     const toResultMetadata = (
       status: 'completed' | 'failed' | 'skipped',
@@ -362,7 +363,9 @@ export const createTransformByBandHandler = (
       }
       if (Number.isFinite(retryAttempt) && retryAttempt >= 0) {
         metadata.retryAttempt = Math.max(0, Math.floor(retryAttempt));
+        metadata.finalRetryAttempts = Math.max(0, Math.floor(retryAttempt));
       }
+      metadata.retryAttemptsTotal = Math.max(0, Math.floor(retryAttemptsTotalForTask));
       metadata.retryMax = retryMaxForTask;
       if (Number.isFinite(extractionRatio)) {
         metadata.extractionRatio = extractionRatio;
@@ -886,13 +889,18 @@ export const createTransformByBandHandler = (
           limit: memory.jsHeapSizeLimit ?? null,
         };
       };
-      const hasSessionBaseTolerance = Number.isFinite(sourceBaseTolerance) && (sourceBaseTolerance ?? 0) >= 0;
-      if (hasSessionBaseTolerance) {
-        const sessionBaseTolerance = sourceBaseTolerance ?? fallbackTolerance;
-        baseToleranceSummary = sessionBaseTolerance;
+      const inputBaseTolerance = Number.isFinite(input.sourceBaseTolerance) && (input.sourceBaseTolerance ?? 0) >= 0
+        ? input.sourceBaseTolerance ?? undefined
+        : undefined;
+      const contextBaseTolerance = Number.isFinite(sourceBaseTolerance) && (sourceBaseTolerance ?? 0) >= 0
+        ? sourceBaseTolerance ?? undefined
+        : undefined;
+      const resolvedBaseTolerance = inputBaseTolerance ?? contextBaseTolerance;
+      if (resolvedBaseTolerance !== undefined) {
+        baseToleranceSummary = resolvedBaseTolerance;
         toleranceSearchIterationsSummary = 0;
         toleranceSearchConvergedSummary = true;
-        tolerance = resolveAppliedTolerance(sessionBaseTolerance);
+        tolerance = resolveAppliedTolerance(resolvedBaseTolerance);
         finalToleranceSummary = tolerance;
         updateFinalEffectiveTolerance(tolerance);
         console.info('[ShapeGeometry][Tolerance]', JSON.stringify({
@@ -908,7 +916,7 @@ export const createTransformByBandHandler = (
           multiplier: resolvedMultiplier,
           minRatio: resolvedMinRatio,
           maxRatio: resolvedMaxRatio,
-          source: 'session',
+          source: inputBaseTolerance !== undefined ? 'task-input' : 'session',
         }));
       } else {
         const representativeFeature = selectMaxVertexFeature(inputCollection, countVerticesFromGeometry);
@@ -1390,11 +1398,12 @@ export const createTransformByBandHandler = (
               overLimitFeatureCount += 1;
             }
             retryAttemptsTotal += result.retryAttempts;
+            retryAttemptsTotalForTask = Math.max(retryAttemptsTotalForTask, retryAttemptsTotal);
             if (result.retryAttempts > 0) {
-              await updateTaskRetryAttempt(taskId, retryAttemptsTotal);
-              retryAttemptForTask = Math.max(retryAttemptForTask, Math.max(0, Math.floor(retryAttemptsTotal)));
-            }
-            if (result.retryAttempts > 0) {
+              maxRetryAttemptsPerFeature = Math.max(maxRetryAttemptsPerFeature, result.retryAttempts);
+              const displayedRetryAttempt = Math.max(0, Math.floor(maxRetryAttemptsPerFeature));
+              await updateTaskRetryAttempt(taskId, displayedRetryAttempt);
+              retryAttemptForTask = Math.max(retryAttemptForTask, displayedRetryAttempt);
               retryAttemptedFeatureCount += 1;
             }
             maxRetryAttemptsPerFeature = Math.max(maxRetryAttemptsPerFeature, result.retryAttempts);
@@ -1403,6 +1412,8 @@ export const createTransformByBandHandler = (
               maxFinalTolerance = Math.max(maxFinalTolerance, result.finalTolerance);
             }
           }
+          retryAttemptForTask = Math.max(retryAttemptForTask, Math.max(0, Math.floor(maxRetryAttemptsPerFeature)));
+          retryAttemptsTotalForTask = Math.max(retryAttemptsTotalForTask, retryAttemptsTotal);
           adjustedSimplified = {
             ...adjustedSimplified,
             features: nextFeatures,

--- a/packages/vt-orchestrator/src/types/types.ts
+++ b/packages/vt-orchestrator/src/types/types.ts
@@ -147,6 +147,7 @@ export type TransformByBandTaskInput = {
   bandIndex: number;
   bandMinZoom?: number;
   bandMaxZoom?: number;
+  sourceBaseTolerance?: number;
   inputVertexCount?: number;
   inputPolygonCount?: number;
   domainType: DomainType;

--- a/plugins/shape-plugin/src/services/vt/runShapeGeometryStageSection.ts
+++ b/plugins/shape-plugin/src/services/vt/runShapeGeometryStageSection.ts
@@ -60,6 +60,7 @@ type GeometryBufferMeta = {
   sourceFeatureOutputCount?: number;
   sourcePolygonInputCount?: number;
   sourcePolygonOutputCount?: number;
+  sourceBaseTolerance?: number;
   featureCount: number;
   inputPolygonCount?: number;
   polygonCount?: number;
@@ -247,6 +248,7 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
       const sourceFeatureOutputCount = readMetricCount(fetchFeatures, 'output');
       const sourcePolygonInputCount = readMetricCount(fetchPolygons, 'input');
       const sourcePolygonOutputCount = readMetricCount(fetchPolygons, 'output');
+      const sourceBaseToleranceValue = readNumber(fetchDetail?.baseTolerance);
       const fallbackFeatureCount = readNumber(output?.featureCount) ?? 0;
       const fallbackPolygonCount = readNumber(output?.polygonCount) ?? undefined;
       next.push({
@@ -264,6 +266,9 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
         sourceFeatureOutputCount,
         sourcePolygonInputCount,
         sourcePolygonOutputCount,
+        sourceBaseTolerance: sourceBaseToleranceValue !== null && sourceBaseToleranceValue >= 0
+          ? sourceBaseToleranceValue
+          : undefined,
         featureCount: sourceFeatureOutputCount ?? fallbackFeatureCount,
         inputPolygonCount: sourcePolygonInputCount ?? fallbackPolygonCount,
         polygonCount: sourcePolygonOutputCount ?? fallbackPolygonCount,
@@ -363,6 +368,7 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
           bandIndex: band.bandIndex,
           bandMinZoom: band.zMin,
           bandMaxZoom: band.zMax,
+          sourceBaseTolerance: buffer.sourceBaseTolerance ?? sourceBaseTolerance,
           inputPolygonCount: buffer.inputPolygonCount ?? buffer.polygonCount,
           inputVertexCount: buffer.inputVertexCount ?? buffer.vertexCount,
           domainType: 'shape',

--- a/plugins/shape-plugin/src/services/vt/shapePipelineShared.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineShared.ts
@@ -35,6 +35,7 @@ export type ShapeGeometryByBandTaskInput = {
   bandIndex: number;
   bandMinZoom?: number;
   bandMaxZoom?: number;
+  sourceBaseTolerance?: number;
   inputVertexCount?: number;
   inputPolygonCount?: number;
   domainType: 'shape';

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { ShapeBuildTaskSummary } from '../../../atoms/shapeBuildProgressAtoms';
 import { buildGeometryTaskOutcomeSummary } from '../../../components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders';
+import type { NodeId } from '@hierarchidb/core-types';
 
 const t = (_key: string, fallback?: string): string => fallback ?? _key;
 
 const buildBaseTask = (overrides: Partial<ShapeBuildTaskSummary>): ShapeBuildTaskSummary => ({
   taskId: 'geometry-task-1',
-  nodeId: 'node-1',
+  nodeId: 'node-1' as NodeId,
   stage: 'geometry',
   status: 'completed',
   progress: 100,
@@ -186,7 +187,7 @@ describe('buildGeometryTaskOutcomeSummary metadata handoff', () => {
     expect(summary.adminLevel).toBe(3);
   });
 
-  it('uses retryAttemptsTotal from message when retryAttempt metadata stays 0', () => {
+  it('does not use retryAttemptsTotal from message when retryAttempt metadata stays 0', () => {
     const task = buildBaseTask({
       errorMessage: 'geometry completed: retryAttemptsTotal=4, retriedFeatures=1/1',
       metadata: {
@@ -203,11 +204,11 @@ describe('buildGeometryTaskOutcomeSummary metadata handoff', () => {
     });
 
     expect(summary.kind).toBe('completed');
-    expect(summary.retryAttempt).toBe(4);
-    expect(summary.summaryLine).toContain('4/24');
+    expect(summary.retryAttempt).toBe(0);
+    expect(summary.summaryLine).toContain('0/24');
   });
 
-  it('uses toleranceSearchIterations when retryAttempt metadata stays 0', () => {
+  it('does not use toleranceSearchIterations when retryAttempt metadata stays 0', () => {
     const task = buildBaseTask({
       metadata: {
         retryAttempt: 0,
@@ -224,8 +225,8 @@ describe('buildGeometryTaskOutcomeSummary metadata handoff', () => {
     });
 
     expect(summary.kind).toBe('completed');
-    expect(summary.retryAttempt).toBe(5);
-    expect(summary.summaryLine).toContain('5/24');
+    expect(summary.retryAttempt).toBe(0);
+    expect(summary.summaryLine).toContain('0/24');
   });
 
   it('does not recover retryMax from message text', () => {

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildTaskSync.snapshot-progress.test.tsx
@@ -264,7 +264,7 @@ describe('useShapeBuildTaskSnapshotProgressState', () => {
     });
   });
 
-  it('resolves retryAttempt from retryAttemptsTotal/finalRetryAttempts metadata', async () => {
+  it('resolves retryAttempt from finalRetryAttempts metadata only', async () => {
     const { result } = renderHook(() => useShapeBuildTaskSnapshotProgressState('node-progress' as NodeId));
     await waitFor(() => {
       expect(subscribeMock).toHaveBeenCalled();
@@ -298,11 +298,11 @@ describe('useShapeBuildTaskSnapshotProgressState', () => {
 
     await waitFor(() => {
       expect(result.current.tasks).toHaveLength(1);
-      expect(result.current.tasks[0]?.retryAttempt).toBe(3);
+      expect(result.current.tasks[0]?.retryAttempt).toBe(2);
     });
   });
 
-  it('resolves retryAttempt from toleranceSearchIterations metadata', async () => {
+  it('does not resolve retryAttempt from toleranceSearchIterations metadata', async () => {
     const { result } = renderHook(() => useShapeBuildTaskSnapshotProgressState('node-progress' as NodeId));
     await waitFor(() => {
       expect(subscribeMock).toHaveBeenCalled();
@@ -335,7 +335,7 @@ describe('useShapeBuildTaskSnapshotProgressState', () => {
 
     await waitFor(() => {
       expect(result.current.tasks).toHaveLength(1);
-      expect(result.current.tasks[0]?.retryAttempt).toBe(4);
+      expect(result.current.tasks[0]?.retryAttempt).toBe(0);
     });
   });
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
@@ -1251,6 +1251,12 @@ export const TaskItemDetailWindow = ({
   const { windowState, handlers } = floatingWindow;
   const { show, hide, onStateChange, onClose: handleFloatingClose } = handlers;
 
+  const activeTaskId = activeDetail?.task.taskId ?? null;
+  const activeTaskStage = activeDetail?.task.stage ?? null;
+  const activeTaskProgress = activeDetail?.task.progress ?? null;
+  const activeTaskStatus = activeDetail?.task.status ?? null;
+  const activeTaskMetadata = activeDetail?.task.metadata ?? null;
+
   useEffect(() => {
     if (!open || !activeDetail) {
       setPreview(null);
@@ -1288,7 +1294,7 @@ export const TaskItemDetailWindow = ({
     return () => {
       cancelled = true;
     };
-  }, [activeDetail, open]);
+  }, [activeDetail, open, activeTaskId, activeTaskStage, activeTaskProgress, activeTaskStatus, activeTaskMetadata]);
 
   useEffect(() => {
     if (!open || !activeDetail) {
@@ -1313,7 +1319,7 @@ export const TaskItemDetailWindow = ({
     return () => {
       cancelled = true;
     };
-  }, [activeDetail, open]);
+  }, [activeDetail, open, activeTaskId, activeTaskStage, activeTaskProgress, activeTaskStatus]);
 
   useEffect(() => {
     if (!open) return;

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/taskOutcomeSummaryBuilders.ts
@@ -288,10 +288,6 @@ export const buildGeometryTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ tas
   const retryAttemptRaw = readMetadataNumber(task.metadata, [
     'finalRetryAttempts',
     'metadata.finalRetryAttempts',
-    'retryAttemptsTotal',
-    'metadata.retryAttemptsTotal',
-    'toleranceSearchIterations',
-    'metadata.toleranceSearchIterations',
     'retryAttempt',
     'metadata.retryAttempt',
   ]);
@@ -299,7 +295,6 @@ export const buildGeometryTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ tas
     failedMessage ?? resolveTaskMetadataMessage(task.metadata),
     [
       /finalRetryAttempts=(\d+)/i,
-      /retryAttemptsTotal=(\d+)/i,
       /retryAttempts=(\d+)/i,
       /retryAttempt=(\d+)/i,
     ],
@@ -314,7 +309,6 @@ export const buildGeometryTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ tas
     if (currentMax === null) return candidate;
     return Math.max(currentMax, candidate);
   }, null);
-  const retryAttempt = retryAttemptCandidate !== null ? Math.floor(retryAttemptCandidate) : null;
 
   const retryMaxRaw = readMetadataNumber(task.metadata, [
     'retryMax',
@@ -331,6 +325,9 @@ export const buildGeometryTaskOutcomeSummary: TaskOutcomeSummaryBuilder = ({ tas
     'metadata.maxRetryAttempts',
   ]);
   const retryMax = retryMaxRaw !== null && retryMaxRaw >= 0 ? Math.floor(retryMaxRaw) : null;
+  const retryAttempt = retryAttemptCandidate !== null
+    ? Math.floor(retryMax !== null ? Math.min(retryAttemptCandidate, retryMax) : retryAttemptCandidate)
+    : null;
 
   const metrics = {
     features: readDisplayMetric(task, 'features'),

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSyncResolver.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildTaskSync/useShapeBuildTaskSyncResolver.ts
@@ -75,16 +75,18 @@ export const useShapeBuildTaskSyncResolver = ({
     };
     const retryAttemptCandidates = [
       resolveNumberFromMetadata(resolvedTask.metadata?.retryAttempt),
-      resolveNumberFromMetadata(resolvedTask.metadata?.retryAttemptsTotal),
       resolveNumberFromMetadata(resolvedTask.metadata?.finalRetryAttempts),
-      resolveNumberFromMetadata(resolvedTask.metadata?.toleranceSearchIterations),
       resolveNumberFromMetadata(asRecord(resolvedTask.metadata?.metadata)?.retryAttempt),
-      resolveNumberFromMetadata(asRecord(resolvedTask.metadata?.metadata)?.retryAttemptsTotal),
       resolveNumberFromMetadata(asRecord(resolvedTask.metadata?.metadata)?.finalRetryAttempts),
-      resolveNumberFromMetadata(asRecord(resolvedTask.metadata?.metadata)?.toleranceSearchIterations),
     ].filter((value): value is number => value !== null && value >= 0);
+    const retryMaxCandidates = [
+      resolveNumberFromMetadata(resolvedTask.metadata?.retryMax),
+      resolveNumberFromMetadata(asRecord(resolvedTask.metadata?.metadata)?.retryMax),
+    ].filter((value): value is number => value !== null && value >= 0);
+    const retryMax = retryMaxCandidates.length > 0 ? Math.floor(Math.max(...retryMaxCandidates)) : null;
     if (retryAttemptCandidates.length > 0) {
-      resolvedTask.retryAttempt = Math.floor(Math.max(...retryAttemptCandidates));
+      const retryAttempt = Math.floor(Math.max(...retryAttemptCandidates));
+      resolvedTask.retryAttempt = retryMax !== null ? Math.min(retryAttempt, retryMax) : retryAttempt;
     }
 
     const resolvedStageId = resolvedTask.stageId ?? resolvedTask.stage;


### PR DESCRIPTION
## Summary
- Geometry retry display no longer resolves from aggregate counters (`retryAttemptsTotal`, `toleranceSearchIterations`); it now uses `finalRetryAttempts` / `retryAttempt` and clamps by `retryMax`.
- Added task-level `sourceBaseTolerance` handoff from Source stage metadata (`fetchDetail.baseTolerance`) into Geometry task input.
- Geometry tolerance resolution now prefers task input base tolerance over session fallback.
- Strengthened Step5 Geometry Preview floating-window reload triggers using primitive task keys so zoom-dependent preview metrics (Vertices / Max Vertices) refresh correctly.

## Root Cause
- Retry display mixed aggregate counters and search-iteration counters, allowing values above Step4 max retries to appear in UI.
- Base tolerance in Geometry was not consistently fed from per-task Source-derived metadata.
- Preview reload dependencies could miss task updates, leaving stale metrics in the floating window.

## Validation
- `pnpm -w turbo run build --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm -w turbo run test --filter @hierarchidb/vt-orchestrator --filter @hierarchidb/shape-plugin` (exit 1, existing unrelated failures)

## DoD Mapping
- Retry attempts display path is clamped by `retryMax` and no longer exceeds Step4 upper bound.
- `t_base` (`baseTolerance`) is passed and consumed at task granularity.
- Zoom-different tasks refresh preview metrics independently (no stale fixed Vertices/Max Vertices).
