### PR TITLE
fix(shape-plugin): Geometry Preview metrics text + Max Vertices marker conditions

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #776 / codex/fix/shape/geometry-preview-max-vertices-776 / 2026-03-04 17:25
 - #765 / codex/feat/shape/preview-admin-subtile-guides-765 / 2026-03-04 15:12
 - #763 / codex/fix/shape/step5-preview-metrics-consistency-763 / 2026-03-04 13:56
 - #761 / codex/fix/app/shape-edit-window-mode / 2026-03-04 13:18
@@ -36,6 +37,8 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #776 進捗 - Geometry Preview: Geometry の Features/Polygons を棒グラフからテキスト表示へ変更し、Max Vertices の閾値線を「分母>6553 の場合のみ表示」へ修正。`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` / `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は成功（exit 0）。
+- 2026-03-04: Issue #776 開始 - Geometry Preview: Geometry の Features/Polygons をテキスト表示へ変更し、Max Vertices バーを表示値準拠（分母<=6553 で閾値線非表示）へ修正する対応に着手
 - 2026-03-04: Issue #765 進捗 - Geometry Preview で adminLevel 分割線が表示されない不具合を修正。`buildGeometryTaskOutcomeSummary` へ `adminLevel` 受け渡しを追加し、Floating Window 側で `summary.adminLevel` を優先参照。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` は成功（exit 0）。
 - 2026-03-04: Issue #765 進捗 - preview 地図のタイル描画に Admin level 別サブ分割点線を追加（L1=2x2 灰, L2=4x4 薄灰, L3=8x8 さらに薄灰, L0は追加なし）。`pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/taskOutcomeSummaryBuilders.transform-metadata.unit.test.ts` は成功（exit 0）。
 - 2026-03-04: Issue #765 開始 - shape Step5 preview 地図で Admin level 1/2/3 の親タイル内サブ分割ガイド線（2x2, 4x4, 8x8）を点線表示する要件に着手

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCard/TaskItemDetailWindow.tsx
@@ -449,10 +449,11 @@ const renderVertexLimitReferencedRow = (
 ): React.ReactNode => {
   const safeInput = typeof input === 'number' && Number.isFinite(input) && input >= 0 ? input : null;
   const safeOutput = typeof output === 'number' && Number.isFinite(output) && output >= 0 ? output : null;
-  const scaleMax = Math.max(limit, safeInput ?? 0, safeOutput ?? 0, 1);
+  const scaleMax = Math.max(safeInput ?? 0, safeOutput ?? 0, 1);
   const inputScale = safeInput !== null ? Math.max(0, Math.min(1, safeInput / scaleMax)) : null;
   const outputScale = safeOutput !== null ? Math.max(0, Math.min(1, safeOutput / scaleMax)) : null;
-  const limitScale = Math.max(0, Math.min(1, limit / scaleMax));
+  const showLimitMarker = safeInput !== null && safeInput > limit;
+  const limitScale = showLimitMarker ? Math.max(0, Math.min(1, limit / scaleMax)) : null;
   const ratio = resolveRatio(safeOutput, safeInput);
   const text = `${formatNumber(output)} / ${formatNumber(input)} (${formatPercent(ratio)})`;
 
@@ -487,16 +488,19 @@ const renderVertexLimitReferencedRow = (
             }}
           />
         ) : null}
-        <Box
-          sx={{
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            left: `calc(${limitScale * 100}% - 2px)`,
-            width: '4px',
-            background: (theme) => `linear-gradient(to right, ${theme.palette.warning.main} 0 2px, ${theme.palette.common.black} 2px 4px)`,
-          }}
-        />
+        {limitScale !== null ? (
+          <Box
+            data-testid="max-vertices-limit-marker"
+            sx={{
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              left: `calc(${limitScale * 100}% - 2px)`,
+              width: '4px',
+              background: (theme) => `linear-gradient(to right, ${theme.palette.warning.main} 0 2px, ${theme.palette.common.black} 2px 4px)`,
+            }}
+          />
+        ) : null}
         <Typography
           variant="caption"
           sx={{
@@ -563,6 +567,15 @@ const renderStackedRatioRow = (
     </Box>
   );
 };
+
+const renderSimpleMetricText = (
+  label: string,
+  value: number | null | undefined,
+): React.ReactNode => (
+  <Typography variant="caption" color="text.secondary">
+    {label}: {formatNumber(value)}
+  </Typography>
+);
 
 const lonToTileX = (lon: number, zoom: number): number => {
   const scale = 2 ** zoom;
@@ -984,17 +997,9 @@ const TaskDetailContent = ({
   const sourceFilteredMetrics = toCollectionMetrics(preview?.original ?? null);
   const geometryMetrics = toCollectionMetrics(preview?.result ?? null);
   const hasPreviewGeometryMetrics = sourceFilteredMetrics.featureCount > 0 && geometryMetrics.featureCount > 0;
-  const transformFeatureInput = summary.sourceMetrics?.features.input
-    ?? summary.fetchDetails?.features.input
-    ?? summary.metrics?.features.input
-    ?? null;
   const transformFeatureOutput = summary.sourceMetrics?.features.output
     ?? summary.fetchDetails?.features.output
     ?? summary.metrics?.features.output
-    ?? null;
-  const transformPolygonInput = summary.sourceMetrics?.polygons.input
-    ?? summary.fetchDetails?.polygons.input
-    ?? summary.metrics?.polygons.input
     ?? null;
   const transformPolygonOutput = summary.sourceMetrics?.polygons.output
     ?? summary.fetchDetails?.polygons.output
@@ -1089,19 +1094,13 @@ const TaskDetailContent = ({
             <Typography variant="caption" color="text.secondary">
               Retry attempts: {summary.retryAttempt ?? 'N/A'} / {summary.retryMax ?? 'N/A'}
             </Typography>
-            {renderVolumeRow(
+            {renderSimpleMetricText(
               'Features',
               transformFeatureOutput,
-              transformFeatureInput,
-              chartColor,
-              false,
             )}
-            {renderVolumeRow(
+            {renderSimpleMetricText(
               'Polygons',
               transformPolygonOutput,
-              transformPolygonInput,
-              chartColor,
-              false,
             )}
             {renderVolumeRow(
               'Vertices',


### PR DESCRIPTION
## Summary
- Geometry Preview: Geometry の `Features` / `Polygons` を棒グラフ表示からテキスト表示（`Features: <n>`, `Polygons: <n>`）へ変更
- `Max Vertices` 棒グラフのスケールを表示テキストの分子/分母に一致させるよう修正
- `Max Vertices` の 6,553 閾値線を「分母（input）が 6,553 を超える場合のみ」表示するよう修正

## Changes
- `TaskItemDetailWindow.tsx`
  - Geometry visualization (`transformMetrics`) の `Features` / `Polygons` を `Typography` のテキスト表示へ置換
  - `renderVertexLimitReferencedRow` の `scaleMax` から固定 `limit` 依存を除去
  - 閾値線表示条件を `safeInput > 6553` に限定
  - 閾値線に `data-testid="max-vertices-limit-marker"` を付与（既存テスト期待と一致）

## Verification
- `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` (exit 0)
- `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` (exit 0)

## Rollback
- このPRをrevertすれば表示ロジックを直前状態へ戻せます。

Closes #776
