### PR TITLE
fix(shape): re-enable t_base carry-over and enforce retry cap in geometry stage

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #778 / codex/fix/shape/tbase-retry-cap-recheck-778 / 2026-03-04 18:31
 - #765 / codex/feat/shape/preview-admin-subtile-guides-765 / 2026-03-04 15:12
 - #763 / codex/fix/shape/step5-preview-metrics-consistency-763 / 2026-03-04 13:56
 - #761 / codex/fix/app/shape-edit-window-mode / 2026-03-04 13:18
@@ -36,6 +37,7 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-04: Issue #778 開始 - Geometry tolerance が 0.1 始まりへ戻る再発について、t_base 適用経路と retry 上限制御の実処理経路を再検証・修正する対応に着手
 - 2026-03-04: Issue #776 完了 - PR #777 を main へ squash merge、Issue #776 close、Geometry Preview: Geometry の Features/Polygons テキスト化と Max Vertices 閾値線条件修正を反映
 - 2026-03-04: Issue #776 進捗 - Geometry Preview: Geometry の Features/Polygons を棒グラフからテキスト表示へ変更し、Max Vertices の閾値線を「分母>6553 の場合のみ表示」へ修正。`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` / `pnpm -w turbo run build --filter @hierarchidb/shape-plugin` / `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は成功（exit 0）。
 - 2026-03-04: Issue #776 開始 - Geometry Preview: Geometry の Features/Polygons をテキスト表示へ変更し、Max Vertices バーを表示値準拠（分母<=6553 で閾値線非表示）へ修正する対応に着手

--- a/packages/vt-orchestrator/src/transform/__tests__/transformByBandRetrySimplify.unit.test.ts
+++ b/packages/vt-orchestrator/src/transform/__tests__/transformByBandRetrySimplify.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { Feature } from 'geojson';
+import { retrySimplifyFeatureWithinVertexLimit } from '../createTransformByBandHandler/transformByBandRetrySimplify.js';
+
+const buildLineFeature = (vertexCount: number): Feature => {
+  const coordinates = Array.from({ length: vertexCount }, (_, index) => [index, index] as [number, number]);
+  return {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'LineString',
+      coordinates,
+    },
+  };
+};
+
+describe('retrySimplifyFeatureWithinVertexLimit', () => {
+  it('never exceeds maxRetryAttempts', async () => {
+    const baseFeature = buildLineFeature(10);
+    const attempts: Array<{ attempt: number; attemptTotal: number; tolerance: number }> = [];
+
+    const result = await retrySimplifyFeatureWithinVertexLimit({
+      feature: baseFeature,
+      baseTolerance: 0.2,
+      retryVertexLimit: 5,
+      maxRetryAttempts: 3,
+      maxTolerance: 1.6,
+      minTolerance: 0.2,
+      featureIndex: 1,
+      featureTotal: 1,
+      runRetrySimplifyAttempt: async (tolerance) => (tolerance >= 1 ? buildLineFeature(4) : buildLineFeature(10)),
+      countVerticesFromGeometry: (geometry) => {
+        if (!geometry || geometry.type !== 'LineString') return 0;
+        return geometry.coordinates.length;
+      },
+      updateRetrySimplifyAttemptPhase: async (params) => {
+        attempts.push({
+          attempt: params.attempt,
+          attemptTotal: params.attemptTotal,
+          tolerance: params.tolerance,
+        });
+      },
+    });
+
+    expect(result.retryAttempts).toBe(3);
+    expect(attempts).toHaveLength(3);
+    expect(attempts.map((entry) => entry.attempt)).toEqual([1, 2, 3]);
+    expect(attempts.map((entry) => entry.attemptTotal)).toEqual([3, 3, 3]);
+  });
+});

--- a/packages/vt-orchestrator/src/transform/createTransformByBandHandler/transformByBandRetrySimplify.ts
+++ b/packages/vt-orchestrator/src/transform/createTransformByBandHandler/transformByBandRetrySimplify.ts
@@ -262,7 +262,7 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     featureIndex,
     featureTotal,
     attempt: 1,
-    attemptTotal: boundedAttempts + 1,
+    attemptTotal: boundedAttempts,
     tolerance: high,
   });
   const highFeature = await runRetrySimplifyAttempt(high);
@@ -291,7 +291,7 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
     };
   }
 
-  for (let attempt = 0; attempt < boundedAttempts; attempt += 1) {
+  for (let attempt = 1; attempt < boundedAttempts; attempt += 1) {
     if (Math.abs(high - low) < epsilon) {
       break;
     }
@@ -300,7 +300,7 @@ export const retrySimplifyFeatureWithinVertexLimit = async (
       featureIndex,
       featureTotal,
       attempt: retryAttempts + 1,
-      attemptTotal: boundedAttempts + 1,
+      attemptTotal: boundedAttempts,
       tolerance: nextToleranceValue,
     });
     const retryFeature = await runRetrySimplifyAttempt(nextToleranceValue);

--- a/plugins/shape-plugin/src/__tests__/unit/shapeTaskCacheIdentity.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/shapeTaskCacheIdentity.unit.test.ts
@@ -72,6 +72,31 @@ describe('shapeTaskCacheIdentity', () => {
     expect(first.inputHash).not.toEqual(second.inputHash);
   });
 
+  it('changes geometry inputHash when sourceBaseTolerance changes', () => {
+    const first = buildGeometryTaskCacheIdentity({
+      nodeId: 'node-1' as NodeId,
+      sourceKey: 'JP:0',
+      bandIndex: 2,
+      sourceArtifactHash: 'artifact:a',
+      sourceBaseTolerance: 0.125,
+      bandMinZoom: 6,
+      bandMaxZoom: 8,
+      configSignature: 'sig-1',
+    });
+    const second = buildGeometryTaskCacheIdentity({
+      nodeId: 'node-1' as NodeId,
+      sourceKey: 'JP:0',
+      bandIndex: 2,
+      sourceArtifactHash: 'artifact:a',
+      sourceBaseTolerance: 0.25,
+      bandMinZoom: 6,
+      bandMaxZoom: 8,
+      configSignature: 'sig-1',
+    });
+    expect(first.cacheKey).toEqual(second.cacheKey);
+    expect(first.inputHash).not.toEqual(second.inputHash);
+  });
+
   it('changes source inputHash when upstreamRevision changes', () => {
     const first = buildSourceTaskCacheIdentity({
       nodeId: 'node-1' as NodeId,

--- a/plugins/shape-plugin/src/services/vt/runShapeGeometryStageSection.ts
+++ b/plugins/shape-plugin/src/services/vt/runShapeGeometryStageSection.ts
@@ -348,6 +348,7 @@ export const runShapeGeometryStageSection = async (params: ShapeGeometryStagePar
         sourceKey: buffer.sourceKey,
         bandIndex: band.bandIndex,
         sourceArtifactHash: buffer.sourceArtifactHash,
+        sourceBaseTolerance: buffer.sourceBaseTolerance ?? sourceBaseTolerance,
         bandMinZoom: band.zMin,
         bandMaxZoom: band.zMax,
         configSignature: geometryConfigSignature,

--- a/plugins/shape-plugin/src/services/vt/shapePipelineShared.ts
+++ b/plugins/shape-plugin/src/services/vt/shapePipelineShared.ts
@@ -481,6 +481,8 @@ export const buildGeometryByBandTasks = async (
       const stagePriority = typeof adminLevel === 'number' ? adminLevel : 0;
       const countryCode = buffer.countryCode?.trim().toUpperCase();
       const countryMeta = countryCode ? countryLookup.get(countryCode) : undefined;
+      const bufferMetadata = (buffer.metadata ?? {}) as Record<string, unknown>;
+      const sourceBaseTolerance = readNumericProperty(bufferMetadata, 'baseTolerance');
       for (const band of bands) {
         if (band.zMin >= HIGH_DETAIL_ZOOM_MIN) {
           if (!enableHighDetailBands) continue;
@@ -491,6 +493,7 @@ export const buildGeometryByBandTasks = async (
           sourceKey: buffer.sourceKey,
           bandIndex: band.bandIndex,
           sourceArtifactHash: sourceArtifactHash,
+          sourceBaseTolerance,
           bandMinZoom: band.zMin,
           bandMaxZoom: band.zMax,
           configSignature,
@@ -509,6 +512,7 @@ export const buildGeometryByBandTasks = async (
             bandIndex: band.bandIndex,
             bandMinZoom: band.zMin,
             bandMaxZoom: band.zMax,
+            sourceBaseTolerance,
             inputVertexCount: buffer.vertexCount ?? buffer.inputVertexCount,
             inputPolygonCount: buffer.polygonCount ?? buffer.inputPolygonCount,
             domainType: 'shape',

--- a/plugins/shape-plugin/src/services/vt/shapeTaskCacheIdentity.ts
+++ b/plugins/shape-plugin/src/services/vt/shapeTaskCacheIdentity.ts
@@ -45,6 +45,12 @@ const normalizeInteger = (value: unknown, fallback: number): number => (
   typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : fallback
 );
 
+const normalizeTolerance = (value: unknown): number | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  if (value < 0) return null;
+  return Number(value.toFixed(12));
+};
+
 const normalizeEndpointId = (urlLike: unknown): string => {
   const value = normalizeString(urlLike);
   if (!value) return 'endpoint';
@@ -122,6 +128,7 @@ export const buildGeometryTaskCacheIdentity = (params: {
   sourceKey: string;
   bandIndex: number;
   sourceArtifactHash: string;
+  sourceBaseTolerance?: number;
   bandMinZoom?: number;
   bandMaxZoom?: number;
   configSignature?: string;
@@ -136,6 +143,7 @@ export const buildGeometryTaskCacheIdentity = (params: {
   const cacheKey = `${namespacePrefix}:shape:geometry:${SHAPE_CACHE_KEY_VERSION}:${sourceKey}:band${bandIndex}`;
   const inputHash = buildStableSignature({
     sourceArtifactHash: normalizeString(params.sourceArtifactHash),
+    sourceBaseTolerance: normalizeTolerance(params.sourceBaseTolerance),
     bandMinZoom: normalizeInteger(params.bandMinZoom, 0),
     bandMaxZoom: normalizeInteger(params.bandMaxZoom, 0),
     geometryConfigSignature: normalizeString(params.configSignature) || null,
@@ -202,6 +210,7 @@ export const resolveTaskCacheIdentity = (
       sourceKey: normalizeString(input.sourceKey) || `${normalizeCountryCode(input.countryCode)}:${normalizeInteger(input.adminLevel, 0)}`,
       bandIndex: normalizeInteger(input.bandIndex, 0),
       sourceArtifactHash: normalizeString(input.sourceArtifactHash),
+      sourceBaseTolerance: typeof input.sourceBaseTolerance === 'number' ? input.sourceBaseTolerance : undefined,
       bandMinZoom: normalizeInteger(input.bandMinZoom, 0),
       bandMaxZoom: normalizeInteger(input.bandMaxZoom, 0),
       configSignature: normalizeString(input.configSignature) || undefined,


### PR DESCRIPTION
## Summary
- include `sourceBaseTolerance` in geometry task cache identity to avoid stale task reuse falling back to `0.1`
- carry `baseTolerance` from source metadata into geometry task identity/input data path
- enforce retry loop upper bound so attempts never exceed `maxRetryAttempts`
- add unit coverage for cache identity hash change and retry upper-bound behavior

## Verification
- `pnpm -w turbo run test --filter @hierarchidb/shape-plugin --filter @hierarchidb/vt-orchestrator -- --run src/__tests__/unit/shapeTaskCacheIdentity.unit.test.ts src/transform/__tests__/transformByBandRetrySimplify.unit.test.ts`
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin --filter @hierarchidb/vt-orchestrator`

Closes #778
