### PR TITLE
fix(shape-plugin): sync geometry detail tolerance/retry values

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # 運用ハブ
 
 ## Doing
+- #796 / codex/fix/shape/geometry-detail-tolerance-retry-stale-796 / 2026-03-06 01:49
 - #791 / codex/fix/app/shape-create-maximize-deeplink-791 / 2026-03-06 01:31
 - #790 / codex/fix/shape/receiving-task-snapshot-handshake-790 / 2026-03-06 09:34
 - #788 / fix/app/vite-initial-access-reload-loop-788 / 2026-03-05 23:19
@@ -39,6 +40,7 @@
 - #708 / codex/chore/ci-build-checks-separation / 2026-03-03 22:10
 
 ## Blocked
+- Issue #796: `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は依存先 `@hierarchidb/vt-orchestrator` の既存型エラー（`TransformByBand*` 未解決）で exit 2。解除条件: `@hierarchidb/vt-orchestrator` の既存型エラー解消後に再実行。
 - Issue #791: `pnpm -w turbo run typecheck --filter @hierarchidb/app` は依存先 `@hierarchidb/vt-orchestrator` の既存型エラー（`TransformByBand*` 未解決など）で exit 2。解除条件: `@hierarchidb/vt-orchestrator` の既存型エラー解消後に再実行。
 - Issue #790: `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は依存先 `@hierarchidb/vt-orchestrator` の既存型エラー（`TransformByBand*` 未解決）で exit 2。解除条件: `@hierarchidb/vt-orchestrator` の既存型エラー解消後に再実行。
 - Issue #758: `pnpm -C plugins/shape-plugin exec vitest run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` が既存失敗（`geometry retryMax is missing`）で exit 1。解除条件: 既存失敗の解消後に再実行。
@@ -46,6 +48,7 @@
 - Issue #705 進捗コメント投稿（`gh issue comment 705`）: `api.github.com` 接続不可のため保留（解除条件: ネットワーク復旧後に再実行）
 
 ## 今日の運用ログ
+- 2026-03-06: Issue #796 開始 - Step5 Geometry Task Result Detail がクリック時スナップショットを保持し続けるため `Base tolerance` / `Initial tolerance` / `Retry attempts` が stale 表示になる不具合を修正。`useTaskItemCardListCardView` を taskId ベース選択へ変更し、detail 表示時に最新 `tasks` から summary を再解決するよう更新。再現テスト `TaskItemCardListCard.unit.test.tsx` に「detail window open中の metadata 更新追従」ケースを追加。`pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` は成功（exit 0）。`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は依存先 `@hierarchidb/vt-orchestrator` 既存型エラーで exit 2（Blocked 記録）。
 - 2026-03-06: Issue #791 進捗 - `usePluginDialogRoute` の mode/step fallback を `pathname` だけでなく `hash` からも解決するよう修正し、basepath 混在経路でも `t` セグメント起点で解析するよう更新。`plugin-dialog-step.unit.test.tsx` に `create + maximize + encoded pageNodeId` と `hash fallback` の再発テストを追加。`pnpm -w turbo run test --filter @hierarchidb/app -- --run src/router/__tests__/unit/plugin-dialog-step.unit.test.tsx` は成功（exit 0, 6 tests passed）。`pnpm -w turbo run typecheck --filter @hierarchidb/app` は依存先 `@hierarchidb/vt-orchestrator` 既存エラーで exit 2（Blockedへ記録）。`pnpm -C app typecheck` は成功（exit 0）。
 - 2026-03-06: Issue #790 進捗 - `receiving-task-snapshot` を snapshot ハンドシェイク起点へ厳密化。`buildSessionSnapshotHandshakeReceivedAtom` を追加し、空 snapshot でも受理シグナルを立てるよう修正。`useShapeBuildSessionStateAtomBridge` に task update 契約チェック（unknown `taskId` 例外停止、`progress.version > snapshotVersionMax` のみ受理、同一 `taskId` version 単調増加適用）と rAF バッファ適用（version順）を実装。worker 側 snapshot イベントへ `version`/`stage` を付与。ユニットテスト `useShapeBuildSessionStateAtomBridge.contract.unit.test.ts` を追加。`pnpm -C plugins/shape-plugin typecheck` と `pnpm -C plugins/shape-plugin exec vitest run src/ui/__tests__/hooks/unit/useShapeBuildSessionStateAtomBridge.contract.unit.test.ts src/ui/__tests__/hooks/unit/resolveReceivingTaskSnapshotDecision.unit.test.ts` は成功（exit 0）。`pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` は既存失敗（`@hierarchidb/vt-orchestrator` の型エラー）で exit 2。
 - 2026-03-05: Issue #788 進捗 - `pluginRegistryGeneratorPlugin` の dev watcher を調整し、chokidar 初期スキャン中の `add` では再生成を走らせず、更新系トリガは `handleHotUpdate` 中心へ整理。`pnpm -C app typecheck` は成功（exit 0）、`pnpm -w turbo run build --filter @hierarchidb/app` は成功（exit 0）。`pnpm -C app dev` は `Port 4200 is already in use` で起動不能だったが、起動ログ上 `generate-plugin-registry` 実行回数は 1 回を確認。

--- a/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx
@@ -374,6 +374,84 @@ describe('TaskItemCardListCard', () => {
     expect(screen.getByTestId('max-vertices-limit-marker')).toBeTruthy();
   });
 
+  it('keeps geometry detail synced with latest task metadata while detail window is open', () => {
+    const initialTask: ShapeBuildTaskSummary = {
+      taskId: 'geometry-task-sync-1',
+      nodeId: 'node-1' as NodeId,
+      stage: 'geometry',
+      taskType: 'geometry',
+      status: 'completed',
+      progress: 100,
+      display: {
+        kind: 'summary',
+        metrics: {
+          features: { input: 10, output: 10 },
+          polygons: { input: 27, output: 27 },
+          vertices: { input: 39550, output: 840 },
+        },
+      },
+      metadata: {
+        effectiveTolerance: 0.243059,
+        retryAttempt: 0,
+        retryMax: 24,
+      },
+    } as ShapeBuildTaskSummary;
+    const initialTasks: ShapeBuildTaskSummary[] = [initialTask];
+    const updatedTasks: ShapeBuildTaskSummary[] = [
+      {
+        ...initialTask,
+        version: 2,
+        metadata: {
+          baseTolerance: 0.121,
+          initialTolerance: 0.243059,
+          effectiveTolerance: 0.243059,
+          retryAttempt: 3,
+          retryMax: 24,
+        },
+      } as ShapeBuildTaskSummary,
+    ];
+    const store = createStore();
+
+    const view = render(
+      <Provider store={store}>
+        <TaskItemCardListCard
+          stageId="geometry"
+          tasks={initialTasks}
+          stageValue={0}
+          resolveStatusLabel={() => 'Completed'}
+          resolveStatusColor={() => 'success'}
+          resolveTaskTitle={() => 'Geometry Task Sync 1'}
+          virtualize={false}
+          isDetailFloatingWindowOpen
+        />
+      </Provider>
+    );
+
+    const chips = Array.from(view.container.querySelectorAll('[data-task-id] .MuiChip-root'));
+    expect(chips.length).toBe(1);
+    fireEvent.mouseEnter(chips[0]);
+    expect(screen.getByText('Base tolerance: N/A / Initial tolerance: N/A / Effective tolerance: 0.243059')).toBeTruthy();
+    expect(screen.getByText('Retry attempts: 0 / 24')).toBeTruthy();
+
+    view.rerender(
+      <Provider store={store}>
+        <TaskItemCardListCard
+          stageId="geometry"
+          tasks={updatedTasks}
+          stageValue={0}
+          resolveStatusLabel={() => 'Completed'}
+          resolveStatusColor={() => 'success'}
+          resolveTaskTitle={() => 'Geometry Task Sync 1'}
+          virtualize={false}
+          isDetailFloatingWindowOpen
+        />
+      </Provider>
+    );
+
+    expect(screen.getByText('Base tolerance: 0.121 / Initial tolerance: 0.243059 / Effective tolerance: 0.243059')).toBeTruthy();
+    expect(screen.getByText('Retry attempts: 3 / 24')).toBeTruthy();
+  });
+
   it('toggles selected chip and keeps preview fixed while selected', () => {
     const tasks: ShapeBuildTaskSummary[] = [
       {

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/TaskItemCardListCard.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/TaskItemCardListCard.tsx
@@ -66,6 +66,7 @@ export const TaskItemCardListCard = forwardRef<HTMLDivElement|null, TaskItemCard
     resolveTaskCardView,
     createTaskCardStyle,
   } = useTaskItemCardListCardView({
+    tasks,
     isDetailFloatingWindowOpen,
     onOpenDetailFloatingWindow,
     onCloseDetailFloatingWindow,

--- a/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/useTaskItemCardListCardView.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/TaskItemCardListCard/useTaskItemCardListCardView.ts
@@ -23,6 +23,7 @@ type TaskStageSummaryBuilderMap = Partial<Record<
 >>;
 
 type Args = {
+  tasks: ShapeBuildTaskSummary[];
   isDetailFloatingWindowOpen: boolean;
   onOpenDetailFloatingWindow?: () => void;
   onCloseDetailFloatingWindow?: () => void;
@@ -34,6 +35,7 @@ type Args = {
 };
 
 export const useTaskItemCardListCardView = ({
+  tasks,
   isDetailFloatingWindowOpen,
   onOpenDetailFloatingWindow,
   onCloseDetailFloatingWindow,
@@ -43,8 +45,8 @@ export const useTaskItemCardListCardView = ({
   stageValue,
   summaryBuilders,
 }: Args) => {
-  const [hoveredDetail, setHoveredDetail] = useState<TaskDetailSelection | null>(null);
-  const [selectedDetail, setSelectedDetail] = useState<TaskDetailSelection | null>(null);
+  const [hoveredTaskDetailId, setHoveredTaskDetailId] = useState<string | null>(null);
+  const [selectedTaskDetailId, setSelectedTaskDetailId] = useState<string | null>(null);
   const wasDetailFloatingWindowOpenRef = useRef(isDetailFloatingWindowOpen);
   const openRequestRef = useRef<string | null>(null);
   const suppressOpenRef = useRef(false);
@@ -56,12 +58,53 @@ export const useTaskItemCardListCardView = ({
   const resolveStageIcon = useCallback((taskStageId: string): ReactNode | null => (
     stageIconById.get(taskStageId) ?? null
   ), [stageIconById]);
+  const resolveSummaryBuilder = useCallback((taskStageId: string): TaskOutcomeSummaryBuilder => {
+    const injectedBuilder = (isGeometryLikeStageId(taskStageId)
+      ? summaryBuilders?.geometry
+      : (isTileEmitLikeStageId(taskStageId)
+        ? summaryBuilders?.tileEmit
+        : summaryBuilders?.source));
+    return injectedBuilder
+      ?? (
+        isGeometryLikeStageId(taskStageId)
+          ? buildGeometryTaskOutcomeSummary
+          : (isTileEmitLikeStageId(taskStageId) ? buildSimpleTaskOutcomeSummary : buildSourceTaskOutcomeSummary)
+      );
+  }, [summaryBuilders]);
+  const taskByDetailId = useMemo(() => {
+    const map = new Map<string, ShapeBuildTaskSummary>();
+    tasks.forEach((task) => {
+      const taskDetailId = task.taskId ?? resolveTaskTitle(task as TaskItemWithMetadata);
+      map.set(taskDetailId, task);
+    });
+    return map;
+  }, [resolveTaskTitle, tasks]);
+  const resolveDetailSelection = useCallback((detailId: string | null): TaskDetailSelection | null => {
+    if (!detailId) return null;
+    const task = taskByDetailId.get(detailId);
+    if (!task) return null;
+    const taskTitle = resolveTaskTitle(task as TaskItemWithMetadata);
+    const summary = resolveSummaryBuilder(task.stage)({
+      task,
+      stageId: task.stage,
+      taskTitle,
+      translate: t,
+    });
+    return {
+      title: taskTitle,
+      summary,
+      task,
+    };
+  }, [resolveSummaryBuilder, resolveTaskTitle, t, taskByDetailId]);
+  const detail = useMemo(() => (
+    resolveDetailSelection(selectedTaskDetailId) ?? resolveDetailSelection(hoveredTaskDetailId)
+  ), [hoveredTaskDetailId, resolveDetailSelection, selectedTaskDetailId]);
 
   useEffect(() => {
     const wasOpen = wasDetailFloatingWindowOpenRef.current;
     if (wasOpen && !isDetailFloatingWindowOpen) {
-      setSelectedDetail(null);
-      setHoveredDetail(null);
+      setSelectedTaskDetailId(null);
+      setHoveredTaskDetailId(null);
       openRequestRef.current = null;
       suppressOpenRef.current = false;
     }
@@ -69,18 +112,17 @@ export const useTaskItemCardListCardView = ({
   }, [isDetailFloatingWindowOpen]);
 
   useEffect(() => {
-    if (!selectedDetail || isDetailFloatingWindowOpen) return;
+    if (!selectedTaskDetailId || isDetailFloatingWindowOpen) return;
     if (suppressOpenRef.current) return;
-    const selectedId = selectedDetail.task.taskId ?? selectedDetail.title;
-    if (openRequestRef.current === selectedId) return;
-    openRequestRef.current = selectedId;
+    if (openRequestRef.current === selectedTaskDetailId) return;
+    openRequestRef.current = selectedTaskDetailId;
     onOpenDetailFloatingWindow?.();
-  }, [isDetailFloatingWindowOpen, onOpenDetailFloatingWindow, selectedDetail]);
+  }, [isDetailFloatingWindowOpen, onOpenDetailFloatingWindow, selectedTaskDetailId]);
 
   const handleCloseDetail = useCallback(() => {
     suppressOpenRef.current = true;
-    setSelectedDetail(null);
-    setHoveredDetail(null);
+    setSelectedTaskDetailId(null);
+    setHoveredTaskDetailId(null);
     openRequestRef.current = null;
     onCloseDetailFloatingWindow?.();
   }, [onCloseDetailFloatingWindow]);
@@ -88,35 +130,19 @@ export const useTaskItemCardListCardView = ({
   const resolveTaskCardView = useCallback((task: ShapeBuildTaskSummary) => {
     const taskStageId = task.stage;
     const stageIcon = resolveStageIcon(taskStageId);
-    const injectedBuilder = (isGeometryLikeStageId(taskStageId)
-      ? summaryBuilders?.geometry
-      : (isTileEmitLikeStageId(taskStageId)
-        ? summaryBuilders?.tileEmit
-        : summaryBuilders?.source));
-    const summaryBuilder = injectedBuilder
-      ?? (
-        isGeometryLikeStageId(taskStageId)
-          ? buildGeometryTaskOutcomeSummary
-          : (isTileEmitLikeStageId(taskStageId) ? buildSimpleTaskOutcomeSummary : buildSourceTaskOutcomeSummary)
-      );
+    const summaryBuilder = resolveSummaryBuilder(taskStageId);
     const currentTaskDetailId = task.taskId ?? resolveTaskTitle(task as TaskItemWithMetadata);
-    const selectedTaskDetailId = selectedDetail?.task.taskId ?? selectedDetail?.title;
-    const hoveredTaskDetailId = hoveredDetail?.task.taskId ?? hoveredDetail?.title;
     const isDetailSelected = selectedTaskDetailId === currentTaskDetailId;
-    const isDetailHoverPreviewActive = !selectedDetail && hoveredTaskDetailId === currentTaskDetailId;
+    const isDetailHoverPreviewActive = !selectedTaskDetailId && hoveredTaskDetailId === currentTaskDetailId;
 
     const handleDetailHoverChange = (value: TaskDetailSelection | null) => {
-      if (selectedDetail) return;
-      setHoveredDetail(value);
+      if (selectedTaskDetailId) return;
+      setHoveredTaskDetailId(value?.task.taskId ?? value?.title ?? null);
     };
     const handleDetailClick = (value: TaskDetailSelection) => {
-      setHoveredDetail(null);
-      setSelectedDetail((previous) => {
-        const previousId = previous?.task.taskId ?? previous?.title;
-        const clickedId = value.task.taskId ?? value.title;
-        if (previousId === clickedId) return null;
-        return value;
-      });
+      const clickedId = value.task.taskId ?? value.title;
+      setHoveredTaskDetailId(null);
+      setSelectedTaskDetailId((previousId) => (previousId === clickedId ? null : clickedId));
     };
 
     return {
@@ -132,7 +158,7 @@ export const useTaskItemCardListCardView = ({
       handleDetailHoverChange,
       handleDetailClick,
     };
-  }, [hoveredDetail, resolveStageIcon, resolveStatusColor, resolveStatusLabel, resolveTaskTitle, selectedDetail, stageValue, summaryBuilders, t]);
+  }, [hoveredTaskDetailId, resolveStageIcon, resolveStatusColor, resolveStatusLabel, resolveSummaryBuilder, resolveTaskTitle, selectedTaskDetailId, stageValue, t]);
 
   const createTaskCardStyle = useCallback((start: number, size: number): CSSProperties => ({
     position: 'absolute',
@@ -146,7 +172,7 @@ export const useTaskItemCardListCardView = ({
 
   return {
     createTaskCardStyle,
-    detail: selectedDetail ?? hoveredDetail,
+    detail,
     handleCloseDetail,
     resolveTaskCardView,
   };


### PR DESCRIPTION
## Summary
- fix Step5 Geometry task detail stale values for `Base tolerance`, `Initial tolerance`, and `Retry attempts`
- switch detail selection state from payload snapshot to taskId-based resolution
- recompute detail summary from latest `tasks` while detail window is open
- add regression test for metadata update synchronization

## Cause / Scope / Fix / Coverage
- Cause: detail window held click-time `task + summary` snapshot and did not follow later task metadata updates.
- Scope: build-progress task detail window path (`TaskItemCardListCard` view state).
- Fix: store selected/hovered detail as taskId and resolve latest task+summary from current task list.
- Coverage: add unit test validating detail values update after rerender with newer task metadata.

## Verification
- `pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run src/ui/__tests__/components/build-progress/TaskItemCardListCard.unit.test.tsx` (exit 0)
- `pnpm -C plugins/shape-plugin typecheck` (exit 0)
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` (exit 2, blocked by existing `@hierarchidb/vt-orchestrator` type errors)

Closes #796
