### PR TITLE
fix(plugin-dialog): i18n化未対応箇所の修正

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -152,7 +152,9 @@
           "maximize": "Maximize",
           "restoreSize": "Restore",
           "fullscreen": "Full screen",
-          "exitFullscreen": "Exit full screen"
+          "exitFullscreen": "Exit full screen",
+          "build": "Build",
+          "building": "Building…"
         },
         "tooltips": {
           "saveDraftDisabled": "No changes to save",
@@ -161,6 +163,11 @@
           "restoreSize": "Restore",
           "fullscreen": "Full screen",
           "exitFullscreen": "Exit full screen"
+        },
+        "contextMenu": {
+          "openInNewTab": "Open In New Tab",
+          "openInNewWindow": "Open In New Window",
+          "copyLinkUrl": "Copy Link URL"
         }
       }
     },

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -152,7 +152,9 @@
           "maximize": "最大化",
           "restoreSize": "元に戻す",
           "fullscreen": "全画面",
-          "exitFullscreen": "全画面を終了"
+          "exitFullscreen": "全画面を終了",
+          "build": "ビルド",
+          "building": "ビルド中…"
         },
         "tooltips": {
           "saveDraftDisabled": "変更がないため保存できません",
@@ -161,6 +163,11 @@
           "restoreSize": "元に戻す",
           "fullscreen": "全画面",
           "exitFullscreen": "全画面を終了"
+        },
+        "contextMenu": {
+          "openInNewTab": "新しいタブで開く",
+          "openInNewWindow": "新しいウィンドウで開く",
+          "copyLinkUrl": "リンクURLをコピー"
         }
       }
     },

--- a/packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx
+++ b/packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx
@@ -417,7 +417,9 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
                 loading={isStartingBuild}
                 endIcon={<ConstructionIcon fontSize="small" />}
               >
-                {isStartingBuild ? 'Building…' : 'Build'}
+                {isStartingBuild 
+                  ? t('dialogs.pluginDialog.buttons.building', 'Building…') 
+                  : t('dialogs.pluginDialog.buttons.build', 'Build')}
               </LoadingButton>
             )}
           </Box>
@@ -492,19 +494,19 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
           <ListItemIcon>
             <OpenInNewIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>Open In New Tab</ListItemText>
+          <ListItemText>{t('dialogs.pluginDialog.contextMenu.openInNewTab', 'Open In New Tab')}</ListItemText>
         </MenuItem>
         <MenuItem onClick={openInNewWindow}>
           <ListItemIcon>
             <OpenInNewOffIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>Open In New Window</ListItemText>
+          <ListItemText>{t('dialogs.pluginDialog.contextMenu.openInNewWindow', 'Open In New Window')}</ListItemText>
         </MenuItem>
         <MenuItem onClick={copyLinkUrl}>
           <ListItemIcon>
             <ContentCopyIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>Copy Link URL</ListItemText>
+          <ListItemText>{t('dialogs.pluginDialog.contextMenu.copyLinkUrl', 'Copy Link URL')}</ListItemText>
         </MenuItem>
       </DialogSafeMenu>
     </>


### PR DESCRIPTION
## 概要
PluginDialogのダイアログフッターで一部のボタンテキストとコンテキストメニュー項目がi18n化されていない問題を修正しました。

## 修正内容
- Build/Building…ボタンのテキストをi18n化
- コンテキストメニューの「Open In New Tab」「Open In New Window」「Copy Link URL」をi18n化
- locales/en/common.jsonとlocales/ja/common.jsonに翻訳キーを追加

## 検証
- TypeScript型チェック: ✅ 成功
- ビルド: ✅ 成功

Fixes #843