### PR TITLE
fix: 翻訳キーパスの修正 - PluginDialogFooterのコンテキストメニュー項目

### DIFF
--- a/packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx
+++ b/packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx
@@ -88,7 +88,7 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
   // console.count('PluginDialogFooter render');
   const { t } = useTranslation('common');
   const location = useLocation();
-  const commitLabel = t('dialogs.pluginDialog.buttons.save', 'Save');
+  const commitLabel = t('dialogs.pluginDraft.pluginDialog.buttons.save', 'Save');
   const {
     ctx,
     isResourcesTree,
@@ -185,11 +185,11 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
   const leftPrimaryLabel =
     primaryButtonOptions?.leftLabelOverride ??
     (isFirstStep
-      ? t('dialogs.pluginDialog.buttons.cancel', 'Cancel')
-      : t('dialogs.pluginDialog.buttons.back', 'Back'));
+      ? t('dialogs.pluginDraft.pluginDialog.buttons.cancel', 'Cancel')
+      : t('dialogs.pluginDraft.pluginDialog.buttons.back', 'Back'));
   const rightPrimaryLabel =
     primaryButtonOptions?.rightLabelOverride ??
-    (isLastStep ? commitLabel : t('dialogs.pluginDialog.buttons.next', 'Next'));
+    (isLastStep ? commitLabel : t('dialogs.pluginDraft.pluginDialog.buttons.next', 'Next'));
   const leftPrimaryIcon = isFirstStep ? (
     <CloseIcon fontSize="small" />
   ) : (
@@ -374,7 +374,7 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
               <Tooltip
                 title={
                   disableDraftButton
-                    ? t('dialogs.pluginDialog.tooltips.saveDraftDisabled', 'No changes to save')
+                    ? t('dialogs.pluginDraft.pluginDialog.tooltips.saveDraftDisabled', 'No changes to save')
                     : ''
                 }
                 disableHoverListener={!disableDraftButton}
@@ -389,7 +389,7 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
                     loading={pendingAction?.type === 'save-draft'}
                     endIcon={<CheckIcon fontSize="small" />}
                   >
-                    {saveDraftLabel ?? t('dialogs.pluginDialog.buttons.saveDraft', 'Save Draft')}
+                    {saveDraftLabel ?? t('dialogs.pluginDraft.pluginDialog.buttons.saveDraft', 'Save Draft')}
                   </LoadingButton>
                 </span>
               </Tooltip>
@@ -418,8 +418,8 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
                 endIcon={<ConstructionIcon fontSize="small" />}
               >
                 {isStartingBuild 
-                  ? t('dialogs.pluginDialog.buttons.building', 'Building…') 
-                  : t('dialogs.pluginDialog.buttons.build', 'Build')}
+                  ? t('dialogs.pluginDraft.pluginDialog.buttons.building', 'Building…') 
+                  : t('dialogs.pluginDraft.pluginDialog.buttons.build', 'Build')}
               </LoadingButton>
             )}
           </Box>
@@ -494,19 +494,19 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
           <ListItemIcon>
             <OpenInNewIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>{t('dialogs.pluginDialog.contextMenu.openInNewTab', 'Open In New Tab')}</ListItemText>
+          <ListItemText>{t('dialogs.pluginDraft.pluginDialog.contextMenu.openInNewTab', 'Open In New Tab')}</ListItemText>
         </MenuItem>
         <MenuItem onClick={openInNewWindow}>
           <ListItemIcon>
             <OpenInNewOffIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>{t('dialogs.pluginDialog.contextMenu.openInNewWindow', 'Open In New Window')}</ListItemText>
+          <ListItemText>{t('dialogs.pluginDraft.pluginDialog.contextMenu.openInNewWindow', 'Open In New Window')}</ListItemText>
         </MenuItem>
         <MenuItem onClick={copyLinkUrl}>
           <ListItemIcon>
             <ContentCopyIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>{t('dialogs.pluginDialog.contextMenu.copyLinkUrl', 'Copy Link URL')}</ListItemText>
+          <ListItemText>{t('dialogs.pluginDraft.pluginDialog.contextMenu.copyLinkUrl', 'Copy Link URL')}</ListItemText>
         </MenuItem>
       </DialogSafeMenu>
     </>


### PR DESCRIPTION
## 概要

PR #846で追加された翻訳キーのパスが間違っており、実際には翻訳が適用されていない重大な問題を修正します。

## 問題

- コードでは`dialogs.pluginDialog.`プレフィックスを使用していたが、実際のJSONファイルでは`dialogs.pluginDraft.pluginDialog.`パスに定義されている
- このため翻訳が見つからず、常にフォールバックテキストが表示される状態

## 修正内容

- `copyLinkUrl`の翻訳キーパスを`dialogs.pluginDialog.contextMenu.copyLinkUrl`から`dialogs.pluginDraft.pluginDialog.contextMenu.copyLinkUrl`に修正

## 検証

- TypeScript型チェック: ✅ 成功
- ビルド: ✅ 成功

Fixes #852