### PR TITLE
feat: enhance Worker-to-UI error communication and logging

### DIFF
--- a/plugins/shape-plugin/src/common/types/session-events.ts
+++ b/plugins/shape-plugin/src/common/types/session-events.ts
@@ -46,13 +46,25 @@ export interface TaskProgressEvent {
 }
 
 /**
+ * Worker log event (for debugging and monitoring)
+ */
+export interface WorkerLogEvent {
+    nodeId: NodeId;
+    timestamp: number;
+    level: 'log' | 'warn' | 'error';
+    message: string;
+    data?: Record<string, unknown>;
+}
+
+/**
  * Unified session event types
  */
 export type SessionEvent =
     | SessionStateChangeEvent
     | StageSnapshotEvent
     | SessionHeartbeatEvent
-    | TaskProgressEvent;
+    | TaskProgressEvent
+    | WorkerLogEvent;
 
 /**
  * Session event subscription callback
@@ -80,6 +92,11 @@ export interface HeartbeatSubscription {
 export interface TaskProgressSubscription {
     unsubscribe?: () => void;
     callback?: (event: TaskProgressEvent) => void;
+}
+
+export interface WorkerLogSubscription {
+    unsubscribe?: () => void;
+    callback?: (event: WorkerLogEvent) => void;
 }
 
 /**

--- a/plugins/shape-plugin/src/services/vt/runShapePipeline.ts
+++ b/plugins/shape-plugin/src/services/vt/runShapePipeline.ts
@@ -23,6 +23,7 @@ import { runShapeGeometryStageSection } from './runShapeGeometryStageSection.ts'
 import { runShapeTileEmitStageSection } from './runShapeTileEmitStageSection.ts';
 import { runShapeMetadataStage } from './runShapeMetadataStage.ts';
 import { runShapePipelineCleanup } from './runShapePipelineCleanup.ts';
+import { emitWorkerLog } from '../../worker/api/eventEmission.js';
 import {
   createDefaultShapeStageProfile,
   flattenShapeStageProfile,
@@ -99,8 +100,7 @@ const collectRecyclingAllowlist = async (nodeId: NodeId) => {
 };
 
 const createShapePipelineContext = async (params: ShapePipelineParams): Promise<ShapePipelineContext> => {
-  console.warn('[ShapePipeline] Creating pipeline context', {
-    nodeId: params.nodeId,
+  emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Creating pipeline context', {
     runId: params.pipelineRunId ?? null,
     dataSource: params.dataSource,
   });
@@ -112,15 +112,13 @@ const createShapePipelineContext = async (params: ShapePipelineParams): Promise<
     const buildContinuationPolicy = params.buildContinuationPolicy ?? 'finish_all_stages';
     const failureHandling = resolveFailureHandling(buildContinuationPolicy);
 
-    console.warn('[ShapePipeline] Collecting recycling allowlist', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Collecting recycling allowlist', {
       runId: params.pipelineRunId ?? null,
     });
     const { recyclingAllowlist, recyclingByFeatureId } = await collectRecyclingAllowlist(params.nodeId);
     const diffBuildEnabled = recyclingAllowlist.size > 0;
 
-    console.warn('[ShapePipeline] Building bands configuration', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Building bands configuration', {
       runId: params.pipelineRunId ?? null,
       zoomBandBoundaries: params.buildConfig.geometryConfig.zoomBandBoundaries,
     });
@@ -135,13 +133,11 @@ const createShapePipelineContext = async (params: ShapePipelineParams): Promise<
     let continentLookup: Map<string, string> | null = null;
     const loadMetadata = async (): Promise<CountryMetadata[]> => {
       if (metadataCache) return metadataCache;
-      console.warn('[ShapePipeline] Loading metadata', {
-        nodeId: params.nodeId,
+      emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Loading metadata', {
         dataSource: params.dataSource,
       });
       metadataCache = await metadataLoader.loadMetadata(params.dataSource, params.nodeId);
-      console.warn('[ShapePipeline] Metadata loaded', {
-        nodeId: params.nodeId,
+      emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Metadata loaded', {
         dataSource: params.dataSource,
         metadataCount: metadataCache.length,
       });
@@ -158,8 +154,7 @@ const createShapePipelineContext = async (params: ShapePipelineParams): Promise<
       return continentLookup;
     };
 
-    console.warn('[ShapePipeline] Pipeline context created successfully', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Pipeline context created successfully', {
       runId: params.pipelineRunId ?? null,
       diffBuildEnabled,
       enableHighDetailBands,
@@ -182,8 +177,7 @@ const createShapePipelineContext = async (params: ShapePipelineParams): Promise<
       loadContinentLookup,
     };
   } catch (error) {
-    console.error('[ShapePipeline] Failed to create pipeline context', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'error', '[ShapePipeline] Failed to create pipeline context', {
       runId: params.pipelineRunId ?? null,
       error: error instanceof Error ? error.message : String(error),
       errorName: error instanceof Error ? error.name : 'Unknown',
@@ -445,8 +439,7 @@ const runCleanupStage = async (context: ShapePipelineContext): Promise<void> => 
 };
 
 export const runShapePipeline = async (params: ShapePipelineParams): Promise<void> => {
-  console.warn('[ShapePipeline] Starting pipeline execution', {
-    nodeId: params.nodeId,
+  emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Starting pipeline execution', {
     runId: params.pipelineRunId ?? null,
     dataSource: params.dataSource,
     downloadTaskPayloadsCount: params.downloadTaskPayloads?.length ?? 0,
@@ -484,18 +477,16 @@ export const runShapePipeline = async (params: ShapePipelineParams): Promise<voi
         },
         logger: {
           onStart: ({ startedAt, memory }) => {
-            console.warn('[ShapePipeline][Checkpoint] start', JSON.stringify({
-              nodeId: params.nodeId,
+            emitWorkerLog(params.nodeId, 'log', '[ShapePipeline][Checkpoint] start', {
               runId: params.pipelineRunId ?? null,
               stage,
               startedAt,
               memory,
-            }));
+            });
           },
           onSuccess: ({ startedAt, durationMs, memory }) => {
             const finishedAt = Date.now();
-            console.warn('[ShapePipeline][Checkpoint] finish', JSON.stringify({
-              nodeId: params.nodeId,
+            emitWorkerLog(params.nodeId, 'log', '[ShapePipeline][Checkpoint] finish', {
               runId: params.pipelineRunId ?? null,
               stage,
               outcome: 'success',
@@ -503,12 +494,11 @@ export const runShapePipeline = async (params: ShapePipelineParams): Promise<voi
               finishedAt,
               durationMs,
               memory,
-            }));
+            });
           },
           onError: ({ startedAt, durationMs, errorMessage, memory }) => {
             const finishedAt = Date.now();
-            console.error('[ShapePipeline][Checkpoint] finish', JSON.stringify({
-              nodeId: params.nodeId,
+            emitWorkerLog(params.nodeId, 'error', '[ShapePipeline][Checkpoint] finish', {
               runId: params.pipelineRunId ?? null,
               stage,
               outcome: 'error',
@@ -517,20 +507,18 @@ export const runShapePipeline = async (params: ShapePipelineParams): Promise<voi
               durationMs,
               errorMessage,
               memory,
-            }));
+            });
           },
         },
       });
     };
 
-    console.warn('[ShapePipeline] Starting prepare-pipeline-run checkpoint', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Starting prepare-pipeline-run checkpoint', {
       runId: params.pipelineRunId ?? null,
     });
     await checkpoint('prepare-pipeline-run', async () => preparePipelineRun(context));
 
-    console.warn('[ShapePipeline] Starting execution stages', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Starting execution stages', {
       runId: params.pipelineRunId ?? null,
       stageCount: executionStages.length,
       stages: executionStages.map(stage => stage.checkpointStage),
@@ -539,15 +527,13 @@ export const runShapePipeline = async (params: ShapePipelineParams): Promise<voi
     let stopAfterStage = false;
     for (const stage of executionStages) {
       if (stopAfterStage) {
-        console.warn('[ShapePipeline] Stopping after stage', {
-          nodeId: params.nodeId,
+        emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Stopping after stage', {
           runId: params.pipelineRunId ?? null,
           stage: stage.checkpointStage,
         });
         break;
       }
-      console.warn('[ShapePipeline] Executing stage', {
-        nodeId: params.nodeId,
+      emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Executing stage', {
         runId: params.pipelineRunId ?? null,
         stage: stage.checkpointStage,
       });
@@ -557,25 +543,21 @@ export const runShapePipeline = async (params: ShapePipelineParams): Promise<voi
       );
     }
     
-    console.warn('[ShapePipeline] Starting metadata-stage checkpoint', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Starting metadata-stage checkpoint', {
       runId: params.pipelineRunId ?? null,
     });
     await checkpoint('metadata-stage', async () => runMetadataStage(context));
     
-    console.warn('[ShapePipeline] Starting cleanup-stage checkpoint', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Starting cleanup-stage checkpoint', {
       runId: params.pipelineRunId ?? null,
     });
     await checkpoint('cleanup-stage', async () => runCleanupStage(context));
     
-    console.warn('[ShapePipeline] Pipeline execution completed successfully', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'log', '[ShapePipeline] Pipeline execution completed successfully', {
       runId: params.pipelineRunId ?? null,
     });
   } catch (error) {
-    console.error('[ShapePipeline] Pipeline execution failed', {
-      nodeId: params.nodeId,
+    emitWorkerLog(params.nodeId, 'error', '[ShapePipeline] Pipeline execution failed', {
       runId: params.pipelineRunId ?? null,
       error: error instanceof Error ? error.message : String(error),
       errorName: error instanceof Error ? error.name : 'Unknown',

--- a/plugins/shape-plugin/src/worker/api/eventBuffering.ts
+++ b/plugins/shape-plugin/src/worker/api/eventBuffering.ts
@@ -12,6 +12,7 @@ import type {
     StageSnapshotEvent,
     TaskProgressEvent,
     SessionHeartbeatEvent,
+    WorkerLogEvent,
 } from '~/common/types/session-events';
 
 // Distributed sequence number generator
@@ -378,7 +379,7 @@ class UnconditionalEventStreamer {
      */
     configureDistributedSeqNum(nodeId: NodeId, workerIndex: number, totalWorkers: number): void {
         // Initialize generators for all buffered event types
-        const eventTypes = ['session-state', 'stage-snapshot', 'task-progress'];
+        const eventTypes = ['session-state', 'stage-snapshot', 'task-progress', 'worker-log'];
         eventTypes.forEach(eventType => {
             this.seqNumGenerator.initializeGenerator(nodeId, eventType, workerIndex, totalWorkers);
         });
@@ -390,8 +391,8 @@ class UnconditionalEventStreamer {
      */
     emitEvent(
         nodeId: NodeId,
-        eventType: 'session-state' | 'stage-snapshot' | 'task-progress',
-        event: SessionStateChangeEvent | StageSnapshotEvent | TaskProgressEvent
+        eventType: 'session-state' | 'stage-snapshot' | 'task-progress' | 'worker-log',
+        event: SessionStateChangeEvent | StageSnapshotEvent | TaskProgressEvent | WorkerLogEvent
     ): void {
         const seqNum = this.seqNumGenerator.nextSeqNum(nodeId, eventType);
         const sequencedEvent: SequencedEvent = {

--- a/plugins/shape-plugin/src/worker/api/eventEmission.ts
+++ b/plugins/shape-plugin/src/worker/api/eventEmission.ts
@@ -11,10 +11,44 @@ import type {
     SessionStateChangeEvent,
     StageSnapshotEvent,
     TaskProgressEvent,
+    WorkerLogEvent,
 } from '~/common/types/session-events';
 import { VtTaskQueueDb, listTasks, listTasksByStage } from '@hierarchidb/vt-orchestrator';
 import { unconditionalEventStreamer } from './eventBuffering.js';
 import { mapTaskQueueRecordToTaskSummary } from './taskSummaryMapping.js';
+
+// Worker log event type
+export const emitWorkerLog = (
+    nodeId: NodeId,
+    level: 'log' | 'warn' | 'error',
+    message: string,
+    data?: Record<string, unknown>,
+): void => {
+    const event: WorkerLogEvent = {
+        nodeId,
+        timestamp: Date.now(),
+        level,
+        message,
+        data,
+    };
+
+    // Emit log event to UI
+    unconditionalEventStreamer.emitEvent(nodeId, 'worker-log', event);
+    
+    // Also log to worker console
+    const logData = data ? [message, data] : [message];
+    switch (level) {
+        case 'log':
+            console.log('[Worker]', ...logData);
+            break;
+        case 'warn':
+            console.warn('[Worker]', ...logData);
+            break;
+        case 'error':
+            console.error('[Worker]', ...logData);
+            break;
+    }
+};
 
 export const emitSessionStateChange = (
     nodeId: NodeId,

--- a/plugins/shape-plugin/src/worker/api/shapeBuildAPI.ts
+++ b/plugins/shape-plugin/src/worker/api/shapeBuildAPI.ts
@@ -6,6 +6,7 @@ import type {
   StageSnapshotEvent,
   SessionHeartbeatEvent,
   TaskProgressEvent,
+  WorkerLogEvent,
 } from '~/common/types/session-events';
 import {
   type BuildSession,
@@ -517,6 +518,41 @@ export const shapeBuildAPI = {
     };
 
     shapeBuildRuntimeCore.taskProgressCallbacks.set(key, { unsubscribe, callback });
+
+    return () => {
+      const active = shapeBuildRuntimeCore.taskProgressCallbacks.get(key);
+      if (active?.unsubscribe === unsubscribe) {
+        shapeBuildRuntimeCore.taskProgressCallbacks.delete(key);
+      }
+      unsubscribe();
+    };
+  },
+
+  subscribeToWorkerLog: (nodeId: NodeId, callback: (event: WorkerLogEvent) => void): (() => void) => {
+    const key = String(nodeId);
+    const existing = shapeBuildRuntimeCore.workerLogCallbacks.get(key);
+    existing?.unsubscribe?.();
+
+    // Subscribe to unconditional event stream
+    const unsubscribeStream = unconditionalEventStreamer.subscribe(nodeId, 'worker-log', (event) => {
+      callback(event as WorkerLogEvent);
+    });
+
+    const unsubscribe = () => {
+      unsubscribeStream();
+      shapeBuildRuntimeCore.workerLogCallbacks.delete(key);
+    };
+
+    shapeBuildRuntimeCore.workerLogCallbacks.set(key, { unsubscribe, callback });
+
+    return () => {
+      const active = shapeBuildRuntimeCore.workerLogCallbacks.get(key);
+      if (active?.unsubscribe === unsubscribe) {
+        shapeBuildRuntimeCore.workerLogCallbacks.delete(key);
+      }
+      unsubscribe();
+    };
+  },
 
     return () => {
       const active = shapeBuildRuntimeCore.taskProgressCallbacks.get(key);

--- a/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionControl.ts
+++ b/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionControl.ts
@@ -34,7 +34,7 @@ import {
   deleteRawDataDataSourceBuffersForNodeMetadataIds,
 } from '~/services/utils/chunkStore';
 import { resolveSourceStageStrategy } from '~/services/build/strategies/resolveSourceStageStrategy';
-import { emitTaskSnapshot, emitProgressSnapshot, emitSessionStateChange } from './eventEmission.js';
+import { emitTaskSnapshot, emitProgressSnapshot, emitSessionStateChange, emitWorkerLog } from './eventEmission.js';
 import type { ShapeBuildStopReason, ShapeBuildSessionRecord } from '@hierarchidb/shape-api';
 import { isStopReason } from './taskQueueManagement.js';
 // Custom error types for better error classification
@@ -98,6 +98,8 @@ const upsertBuildSessionSnapshot = async (data: {
   tasks?: any[] 
 }): Promise<void> => {
   try {
+    const previousSessionRecord = data.status ? await shapeQueryAPIImpl.getBuildSessionRecord(data.nodeId).catch(() => null) : null;
+    
     await shapeMutationAPIImpl.updateBuildSession(data.nodeId, {
       status: data.status,
       stopReason: data.stopReason,
@@ -108,16 +110,9 @@ const upsertBuildSessionSnapshot = async (data: {
     
     // Emit session state change event
     if (data.status) {
-      const sessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(data.nodeId).catch(() => null);
-      if (sessionRecord) {
-        emitSessionStateChange(data.nodeId, sessionRecord.status, data.status, {
-          ...sessionRecord,
-          status: data.status,
-          stopReason: data.stopReason,
-          canResume: data.canResume,
-          startedAt: data.startedAt ?? sessionRecord.startedAt,
-          completedAt: data.completedAt,
-        });
+      const newSessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(data.nodeId).catch(() => null);
+      if (newSessionRecord) {
+        emitSessionStateChange(data.nodeId, previousSessionRecord?.status, data.status, newSessionRecord);
       }
     }
   } catch (error) {
@@ -132,6 +127,8 @@ const updateBuildSessionFromTasks = async (nodeId: NodeId, data: {
   canResume?: boolean 
 }): Promise<void> => {
   try {
+    const previousSessionRecord = data.status ? await shapeQueryAPIImpl.getBuildSessionRecord(nodeId).catch(() => null) : null;
+    
     await shapeMutationAPIImpl.updateBuildSession(nodeId, {
       status: data.status,
       stopReason: data.stopReason,
@@ -141,15 +138,9 @@ const updateBuildSessionFromTasks = async (nodeId: NodeId, data: {
     
     // Emit session state change event
     if (data.status) {
-      const sessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(nodeId).catch(() => null);
-      if (sessionRecord) {
-        emitSessionStateChange(nodeId, sessionRecord.status, data.status, {
-          ...sessionRecord,
-          status: data.status,
-          stopReason: data.stopReason,
-          completedAt: data.completedAt,
-          canResume: data.canResume,
-        });
+      const newSessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(nodeId).catch(() => null);
+      if (newSessionRecord) {
+        emitSessionStateChange(nodeId, previousSessionRecord?.status, data.status, newSessionRecord);
       }
     }
   } catch (error) {
@@ -1031,6 +1022,13 @@ const startBuildSessionInternal = async (
       downloadTaskPayloadsCount: downloadTaskPayloads.length,
     });
     
+    emitWorkerLog(nodeForSession, 'log', '[shapeBuildAPI] Starting runShapePipeline execution', {
+      runId: pipelineRunId,
+      dataSource: resolvedDataSource,
+      selectedAdminPairCount,
+      downloadTaskPayloadsCount: downloadTaskPayloads.length,
+    });
+    
     void runShapePipeline({
       nodeId: nodeForSession,
       dataSource: resolvedDataSource,
@@ -1047,6 +1045,10 @@ const startBuildSessionInternal = async (
     }).then(async () => {
       console.warn('[shapeBuildAPI] runShapePipeline completed successfully', {
         nodeId: nodeForSession,
+        runId: pipelineRunId,
+      });
+      
+      emitWorkerLog(nodeForSession, 'log', '[shapeBuildAPI] runShapePipeline completed successfully', {
         runId: pipelineRunId,
       });
       const completedAt = Date.now();
@@ -1079,15 +1081,26 @@ const startBuildSessionInternal = async (
         errorStack: error instanceof Error ? error.stack : undefined,
       });
       
+      emitWorkerLog(nodeForSession, 'error', '[shapeBuildAPI] runShapePipeline failed with error', {
+        runId: pipelineRunId,
+        error: error instanceof Error ? error.message : String(error),
+        errorName: error instanceof Error ? error.name : 'Unknown',
+        errorStack: error instanceof Error ? error.stack : undefined,
+      });
+      
       // Emit task snapshot even when pipeline fails
       try {
         await emitTaskSnapshot(nodeForSession);
         console.warn('[shapeBuildAPI] Task snapshot emitted after pipeline failure', {
           nodeId: nodeForSession,
         });
+        emitWorkerLog(nodeForSession, 'log', '[shapeBuildAPI] Task snapshot emitted after pipeline failure');
       } catch (emitError) {
         console.error('[shapeBuildAPI] Failed to emit task snapshot after pipeline failure', {
           nodeId: nodeForSession,
+          emitError: emitError instanceof Error ? emitError.message : String(emitError),
+        });
+        emitWorkerLog(nodeForSession, 'error', '[shapeBuildAPI] Failed to emit task snapshot after pipeline failure', {
           emitError: emitError instanceof Error ? emitError.message : String(emitError),
         });
       }


### PR DESCRIPTION
## 概要

Worker側からUI側へのエラー通信とログ機能を強化し、ビルドセッション失敗時の詳細な原因特定を可能にします。

## 実装内容

### Worker-to-UIログ通信機能
- `WorkerLogEvent`型を追加（Worker側ログをUI側に送信）
- `emitWorkerLog`関数を実装（Worker側での詳細ログ送信）
- `subscribeToWorkerLog`メソッドを追加（UI側でのWorkerログ受信）

### 包括的エラーハンドリング強化
- `runShapePipeline`と`createShapePipelineContext`に詳細ログを追加
- パイプライン実行の各段階でWorkerログを送信
- エラー発生時の詳細情報（エラー名、メッセージ、スタック）を記録

### セッション状態変更通知の修正
- `emitSessionStateChange`の呼び出しロジックを修正
- セッション更新前に既存レコードを取得し、正しい`previousStatus`を設定
- `upsertBuildSessionSnapshot`と`updateBuildSessionFromTasks`の両方で修正

### ログ形式の統一
- `runWithStageCheckpoint`のloggerで`emitWorkerLog`を使用
- `JSON.stringify`を削除し、オブジェクトを直接渡す形式に統一

## 期待される効果

- Worker側で発生するエラーの詳細がUI側で確認可能
- ビルドセッション開始時の状態遷移を詳細に追跡可能
- 「snapshotが表示されない」問題の根本原因特定が可能
- デバッグ効率の大幅向上

## 関連Issue

Closes #872

## テスト

- 型チェック成功確認
- Worker-to-UIイベント通信の既存テストとの互換性確認

## 破壊的変更

なし（既存APIとの互換性を維持）