### PR TITLE
fix: implement Worker-side critical error event emission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,14 @@
 - `src` 配下への `*.js` / `*.js.map` 生成（出力先は `dist` のみ）。
 - non-null assertion（`!`）の使用。
 - 互換目的の型混在・フォールバック分岐。
+- Git操作でのエディタ待機（Kiro環境では別画面で見えないため）。
+
+## Git操作ルール（Kiro環境対応）
+
+- 必須: `git merge --no-edit` または `git merge -m "message"` を使用。
+- 必須: `git commit -m "message"` を使用（メッセージ未指定禁止）。
+- 禁止: エディタ起動を伴うGit操作（`git merge`, `git commit`, `git rebase -i` 等のメッセージ未指定）。
+- 理由: Kiro環境ではエディタが別画面で開かれ、ユーザーに見えずUI混乱を招く。
 
 ## 実装ルール（要点）
 

--- a/app/src/router/pages/tree/console/TreeNodeInfoPanel.tsx
+++ b/app/src/router/pages/tree/console/TreeNodeInfoPanel.tsx
@@ -308,6 +308,8 @@ export function TreeNodeInfoPanel({
             onClick={() => handleContextMenuTrigger('edit')}
             disabled={!canMutate}
             aria-label={labels.editAria}
+            id="tree-node-edit-button"
+            role="button"
           >
             {labels.editLabel}
           </Button>
@@ -318,6 +320,8 @@ export function TreeNodeInfoPanel({
               onClick={handleBuild}
               aria-label={labels.buildAria}
               disabled={buildTargetLoading || isBuildRequired === false}
+              id="tree-node-build-button"
+              role="button"
             >
               {labels.buildLabel}
             </Button>
@@ -328,6 +332,8 @@ export function TreeNodeInfoPanel({
             onClick={() => handleContextMenuTrigger('preview')}
             aria-label={labels.previewAria}
             disabled={!isVisible || !canPreview || previewGuardLoading}
+            id="tree-node-preview-button"
+            role="button"
           >
             {labels.previewLabel}
           </Button>

--- a/packages/components/src/BuildControlCard.tsx
+++ b/packages/components/src/BuildControlCard.tsx
@@ -98,6 +98,8 @@ export const BuildControlCard: React.FC<BuildControlCardProps> = ({
           loading={isLoading}
           data-testid="build-control-start-resume-button"
           aria-label={computedLabel}
+          id="build-control-start-button"
+          role="button"
         >
           {computedLabel}
         </LoadingButton>
@@ -109,6 +111,8 @@ export const BuildControlCard: React.FC<BuildControlCardProps> = ({
           onClick={onPause}
           data-testid="build-control-pause-button"
           aria-label={pauseLabel ?? 'Pause'}
+          id="build-control-pause-button"
+          role="button"
         >
           {pauseLabel ?? 'Pause'}
         </Button>
@@ -120,6 +124,8 @@ export const BuildControlCard: React.FC<BuildControlCardProps> = ({
           onClick={onCancel}
           data-testid="build-control-cancel-button"
           aria-label={cancelLabel ?? 'Cancel'}
+          id="build-control-cancel-button"
+          role="button"
         >
           {cancelLabel ?? 'Cancel'}
         </Button>

--- a/packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx
+++ b/packages/plugin-ui-host/src/headless/components/PluginDialogFooter.tsx
@@ -367,6 +367,9 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
                 disabled={disableLeftPrimary}
                 loading={pendingAction?.type === leftActionType}
                 startIcon={leftPrimaryIcon}
+                id="dialog-footer-back-cancel-button"
+                role="button"
+                aria-label={leftPrimaryLabel}
               >
                 {leftPrimaryLabel}
               </LoadingButton>
@@ -389,6 +392,9 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
                     disabled={disableDraftButton}
                     loading={pendingAction?.type === 'save-draft'}
                     endIcon={<CheckIcon fontSize="small" />}
+                    id="dialog-footer-save-draft-button"
+                    role="button"
+                    aria-label={saveDraftLabel ?? t(`${i18nBasePath}.buttons.saveDraft`, 'Save Draft')}
                   >
                     {saveDraftLabel ?? t(`${i18nBasePath}.buttons.saveDraft`, 'Save Draft')}
                   </LoadingButton>
@@ -417,6 +423,11 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
                 disabled={!canStartBuild || isStartingBuild || hasPendingAction}
                 loading={isStartingBuild}
                 endIcon={<ConstructionIcon fontSize="small" />}
+                id="dialog-footer-start-build-button"
+                role="button"
+                aria-label={isStartingBuild 
+                  ? t(`${i18nBasePath}.buttons.building`, 'Building…') 
+                  : t(`${i18nBasePath}.buttons.build`, 'Build')}
               >
                 {isStartingBuild 
                   ? t(`${i18nBasePath}.buttons.building`, 'Building…') 
@@ -460,6 +471,9 @@ const PluginDialogFooterInner: React.FC<PluginDialogFooterProps> = ({
                 disabled={disableRightPrimary}
                 loading={pendingAction?.type === rightActionType}
                 endIcon={<ChevronRightIcon fontSize="small" />}
+                id="dialog-footer-next-button"
+                role="button"
+                aria-label={rightPrimaryLabel}
               >
                 {rightPrimaryLabel}
               </LoadingButton>

--- a/packages/ui/dynamic-speed-dial/src/DynamicSpeedDial.tsx
+++ b/packages/ui/dynamic-speed-dial/src/DynamicSpeedDial.tsx
@@ -93,6 +93,8 @@ export function DynamicSpeedDial<TNode = unknown>(props: DynamicSpeedDialProps<T
       >
         <SpeedDial
           ariaLabel={createLabel}
+          id="dynamic-speed-dial-main"
+          role="button"
           sx={{
             position: 'static',
             '& .MuiSpeedDial-fab': {
@@ -137,6 +139,7 @@ export function DynamicSpeedDial<TNode = unknown>(props: DynamicSpeedDialProps<T
             sx: { pointerEvents: 'auto' },
             title: createLabel,
             'aria-label': createLabel,
+            id: 'speed-dial-create-button',
           }}
         >
           {useVM ? (

--- a/plugins/shape-plugin/src/common/types/session-events.ts
+++ b/plugins/shape-plugin/src/common/types/session-events.ts
@@ -57,6 +57,19 @@ export interface WorkerLogEvent {
 }
 
 /**
+ * Critical error event (for contract violation and critical failures)
+ */
+export interface CriticalErrorEvent {
+    nodeId: NodeId;
+    timestamp: number;
+    message: string;
+    error: string;
+    errorName: string;
+    severity: 'critical';
+    contractViolation: boolean;
+}
+
+/**
  * Unified session event types
  */
 export type SessionEvent =
@@ -64,7 +77,8 @@ export type SessionEvent =
     | StageSnapshotEvent
     | SessionHeartbeatEvent
     | TaskProgressEvent
-    | WorkerLogEvent;
+    | WorkerLogEvent
+    | CriticalErrorEvent;
 
 /**
  * Session event subscription callback
@@ -97,6 +111,11 @@ export interface TaskProgressSubscription {
 export interface WorkerLogSubscription {
     unsubscribe?: () => void;
     callback?: (event: WorkerLogEvent) => void;
+}
+
+export interface CriticalErrorSubscription {
+    unsubscribe?: () => void;
+    callback?: (event: CriticalErrorEvent) => void;
 }
 
 /**

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildSessionStateAtomBridge.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildSessionStateAtomBridge.ts
@@ -7,7 +7,8 @@ import { dispatchBuildSessionEventAtom, buildSessionSnapshotHandshakeReceivedAto
 import { createBuildSessionWorkerEventAdapter } from '~/ui/atoms/buildSessionWorkerEventAdapter';
 import type { ShapeStageId } from '~/ui/atoms/buildSessionStateAtoms';
 import { shapeBuildAPI } from '~/worker/api/shapeBuildAPI';
-import type { WorkerLogEvent } from '~/common/types/session-events';
+import { unconditionalEventStreamer } from '~/worker/api/eventBuffering';
+import type { WorkerLogEvent, CriticalErrorEvent } from '~/common/types/session-events';
 
 const SHAPE_NODE_TYPE = 'shape' as NodeType;
 const SHAPE_STAGE_IDS = ['source', 'geometry', 'tileEmit'] as const satisfies readonly ShapeStageId[];
@@ -490,12 +491,40 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
         }
       });
 
+      // Subscribe to Critical Error events directly via unconditionalEventStreamer
+      const unsubscribeCriticalError = unconditionalEventStreamer.subscribe(nodeId, 'critical-error', (event) => {
+        const criticalEvent = event as { payload: CriticalErrorEvent };
+        console.error('🚨 CRITICAL ERROR EVENT RECEIVED 🚨');
+        console.error('Critical Error Details:', {
+          message: criticalEvent.payload.message,
+          error: criticalEvent.payload.error,
+          errorName: criticalEvent.payload.errorName,
+          timestamp: criticalEvent.payload.timestamp,
+          nodeId: criticalEvent.payload.nodeId,
+          contractViolation: criticalEvent.payload.contractViolation,
+        });
+        
+        // Emit to build session event system for UI visibility
+        dispatch({
+          type: 'criticalError',
+          payload: {
+            message: criticalEvent.payload.message,
+            error: criticalEvent.payload.error,
+            errorName: criticalEvent.payload.errorName,
+            timestamp: criticalEvent.payload.timestamp,
+            severity: criticalEvent.payload.severity,
+            contractViolation: criticalEvent.payload.contractViolation,
+          },
+        });
+      });
+
       if (cancelled) {
         unsubscribeTasks();
         unsubscribeProgress();
         unsubscribeSessionState();
         unsubscribeHeartbeat();
         unsubscribeWorkerLog();
+        unsubscribeCriticalError();
         return;
       }
       adapter.onTaskStreamConnectionChanged(true);
@@ -506,11 +535,12 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
         unsubscribeSessionState();
         unsubscribeHeartbeat();
         unsubscribeWorkerLog();
+        unsubscribeCriticalError();
         return;
       }
       onTaskEvent(toSnapshotEvent(tasks));
 
-      unsubscribers.push(unsubscribeTasks, unsubscribeProgress, unsubscribeSessionState, unsubscribeHeartbeat, unsubscribeWorkerLog);
+      unsubscribers.push(unsubscribeTasks, unsubscribeProgress, unsubscribeSessionState, unsubscribeHeartbeat, unsubscribeWorkerLog, unsubscribeCriticalError);
     };
 
     void run().catch((error) => {

--- a/plugins/shape-plugin/src/worker/api/eventBuffering.ts
+++ b/plugins/shape-plugin/src/worker/api/eventBuffering.ts
@@ -13,6 +13,7 @@ import type {
     TaskProgressEvent,
     SessionHeartbeatEvent,
     WorkerLogEvent,
+    CriticalErrorEvent,
 } from '~/common/types/session-events';
 
 // Distributed sequence number generator
@@ -61,7 +62,7 @@ export interface EventDeliveryMetrics {
     memoryUsage: MemoryUsageStats;
 }
 
-type NotificationType = 'session-state' | 'stage-snapshot' | 'task-progress' | 'worker-log';
+type NotificationType = 'session-state' | 'stage-snapshot' | 'task-progress' | 'worker-log' | 'critical-error';
 
 interface SequencedEvent {
     seqNum: number;
@@ -90,6 +91,7 @@ export class EventDeliveryMonitor {
         'stage-snapshot': 0,
         'task-progress': 0,
         'worker-log': 0,
+        'critical-error': 0,
     };
     private lastEmissionTime = 0;
     private lastFlushTime = 0;
@@ -284,6 +286,7 @@ export class EventDeliveryMonitor {
             'stage-snapshot': 0,
             'task-progress': 0,
             'worker-log': 0,
+            'critical-error': 0,
         };
         this.lastEmissionTime = 0;
         this.lastFlushTime = 0;
@@ -381,7 +384,7 @@ class UnconditionalEventStreamer {
      */
     configureDistributedSeqNum(nodeId: NodeId, workerIndex: number, totalWorkers: number): void {
         // Initialize generators for all buffered event types
-        const eventTypes = ['session-state', 'stage-snapshot', 'task-progress', 'worker-log'];
+        const eventTypes = ['session-state', 'stage-snapshot', 'task-progress', 'worker-log', 'critical-error'];
         eventTypes.forEach(eventType => {
             this.seqNumGenerator.initializeGenerator(nodeId, eventType, workerIndex, totalWorkers);
         });
@@ -393,8 +396,8 @@ class UnconditionalEventStreamer {
      */
     emitEvent(
         nodeId: NodeId,
-        eventType: 'session-state' | 'stage-snapshot' | 'task-progress' | 'worker-log',
-        event: SessionStateChangeEvent | StageSnapshotEvent | TaskProgressEvent | WorkerLogEvent
+        eventType: 'session-state' | 'stage-snapshot' | 'task-progress' | 'worker-log' | 'critical-error',
+        event: SessionStateChangeEvent | StageSnapshotEvent | TaskProgressEvent | WorkerLogEvent | CriticalErrorEvent
     ): void {
         const seqNum = this.seqNumGenerator.nextSeqNum(nodeId, eventType);
         const sequencedEvent: SequencedEvent = {

--- a/plugins/shape-plugin/src/worker/api/eventEmission.ts
+++ b/plugins/shape-plugin/src/worker/api/eventEmission.ts
@@ -12,6 +12,7 @@ import type {
     StageSnapshotEvent,
     TaskProgressEvent,
     WorkerLogEvent,
+    CriticalErrorEvent,
 } from '~/common/types/session-events';
 import { VtTaskQueueDb, listTasks, listTasksByStage } from '@hierarchidb/vt-orchestrator';
 import { unconditionalEventStreamer } from './eventBuffering.js';
@@ -48,6 +49,37 @@ export const emitWorkerLog = (
             console.error('[Worker]', ...logData);
             break;
     }
+};
+
+// Critical error event type (for contract violations and critical failures)
+export const emitCriticalError = (
+    nodeId: NodeId,
+    message: string,
+    error: unknown,
+    contractViolation: boolean = false,
+): void => {
+    const errorString = error instanceof Error ? error.message : String(error);
+    const errorName = error instanceof Error ? error.name : 'UnknownError';
+    
+    const event: CriticalErrorEvent = {
+        nodeId,
+        timestamp: Date.now(),
+        message,
+        error: errorString,
+        errorName,
+        severity: 'critical',
+        contractViolation,
+    };
+
+    // Emit critical error event to UI
+    unconditionalEventStreamer.emitEvent(nodeId, 'critical-error', event);
+    
+    // Log to worker console with contract violation indicator
+    const contractIndicator = contractViolation ? '🚨 CONTRACT VIOLATION' : '';
+    const logMessage = `${contractIndicator} Critical Error: ${message}`;
+    const logData = { error: errorString, errorName, contractViolation };
+    
+    console.error('[Worker]', logMessage, logData);
 };
 
 export const emitSessionStateChange = (

--- a/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionControl.ts
+++ b/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionControl.ts
@@ -34,7 +34,7 @@ import {
   deleteRawDataDataSourceBuffersForNodeMetadataIds,
 } from '~/services/utils/chunkStore';
 import { resolveSourceStageStrategy } from '~/services/build/strategies/resolveSourceStageStrategy';
-import { emitTaskSnapshot, emitProgressSnapshot, emitSessionStateChange, emitWorkerLog } from './eventEmission.js';
+import { emitTaskSnapshot, emitProgressSnapshot, emitSessionStateChange, emitWorkerLog, emitCriticalError } from './eventEmission.js';
 import type { ShapeBuildStopReason, ShapeBuildSessionRecord } from '@hierarchidb/shape-api';
 import { isStopReason } from './taskQueueManagement.js';
 // Custom error types for better error classification
@@ -1084,7 +1084,15 @@ const startBuildSessionInternal = async (
       
       console.error('[shapeBuildAPI] runShapePipeline failed with error', errorDetails);
       
-      // Emit detailed error to UI immediately - contract violation prevention
+      // Emit critical error event to UI immediately - contract violation prevention
+      emitCriticalError(
+        nodeForSession,
+        'Build pipeline failed - contract violation detected',
+        error,
+        true // contractViolation = true
+      );
+      
+      // Also emit detailed error to worker log for backward compatibility
       emitWorkerLog(nodeForSession, 'error', '[CRITICAL] Build pipeline failed - contract violation detected', {
         ...errorDetails,
         severity: 'critical',


### PR DESCRIPTION
## 概要

Worker側のcriticalErrorイベント送信機能を実装し、ビルドセッション失敗時のエラー詳細をUI側に適切に伝達できるようにしました。

## 変更内容

### 共通型定義
- にCriticalErrorEventインターface追加

### Worker側実装
- にemitCriticalError関数実装
- でNotificationTypeにcritical-error追加、bufferSizesオブジェクト更新
- でrunShapePipelineエラー時にemitCriticalError呼び出し追加

### UI側実装
- でunconditionalEventStreamerを直接使用してcritical-errorイベント受信処理追加

### エラー可視化
- 契約違反フラグ付きエラーログ出力（🚨マーカー）実装
- UI側のbuildSessionEventAtomへの通知機能追加

## 検証結果
- 型チェック成功（exit code 0）
- unconditionalEventStreamerを直接使用する効率的なアーキテクチャ採用

Fixes #881