### PR TITLE
feat(i18n): ダイアログUI表記のi18n化 #922

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,11 +2,7 @@
 
 ## Doing
 
-- #915 Shape Step5 ビルド関連UI表記のi18n化 / feature/i18n/shape-step5-build-ui-labels / done
-
-- #914 Shape Step5 Reset/Deleteメニューのi18n化 / feature/i18n/shape-step5-reset-delete-menu / start
-
-- #913 Shape Step5 UI改良 - Build Sessionヘッダー撤去とボタンサイズ変更 / feature/ui/build-session-header-removal / start
+- #922 ダイアログUI表記のi18n化 / feat/i18n/dialog-ui-labels / start
 
 ## Blocked
 

--- a/app/public/locales/en/common.json
+++ b/app/public/locales/en/common.json
@@ -79,6 +79,11 @@
     }
   },
   "dialogs": {
+    "common": {
+      "actions": {
+        "close": "Close dialog"
+      }
+    },
     "archive": {
       "modeMenu": {
         "ariaLabel": "Display mode",

--- a/app/public/locales/ja/common.json
+++ b/app/public/locales/ja/common.json
@@ -79,6 +79,11 @@
     }
   },
   "dialogs": {
+    "common": {
+      "actions": {
+        "close": "ダイアログを閉じる"
+      }
+    },
     "archive": {
       "modeMenu": {
         "ariaLabel": "表示モード",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -79,6 +79,11 @@
     }
   },
   "dialogs": {
+    "common": {
+      "actions": {
+        "close": "Close dialog"
+      }
+    },
     "archive": {
       "modeMenu": {
         "ariaLabel": "Display mode",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -79,6 +79,11 @@
     }
   },
   "dialogs": {
+    "common": {
+      "actions": {
+        "close": "ダイアログを閉じる"
+      }
+    },
     "archive": {
       "modeMenu": {
         "ariaLabel": "表示モード",

--- a/packages/components/src/CloseActionButton/CloseActionButton.tsx
+++ b/packages/components/src/CloseActionButton/CloseActionButton.tsx
@@ -1,12 +1,15 @@
 import type { ReactElement } from 'react';
 import { Button } from '@mui/material';
 import { Close as CloseIcon } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
 
 interface CloseActionButtonProps {
   to: string;
 }
 
 export function CloseActionButton({ to }: CloseActionButtonProps): ReactElement {
+  const { t } = useTranslation('common');
+  const closeLabel = t('dialogs.common.actions.close', 'Close dialog');
   return (
     <Button
       onClick={() => (window.location.href = to)}
@@ -20,8 +23,8 @@ export function CloseActionButton({ to }: CloseActionButtonProps): ReactElement 
         borderRadius: '50%',
         p: 1,
       }}
-      aria-label="Close Dialog"
-      title="Close Dialog"
+      aria-label={closeLabel}
+      title={closeLabel}
     >
       <CloseIcon />
     </Button>

--- a/packages/ui/dialog/src/components/CommonDialogTitle.tsx
+++ b/packages/ui/dialog/src/components/CommonDialogTitle.tsx
@@ -10,6 +10,7 @@ import {
   FullscreenExit as FullscreenExitIcon,
 } from '@mui/icons-material';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+import { useTranslation } from 'react-i18next';
 import {
   DISPLAY_MODE_LABELS,
   useCommonDialogTitleView,
@@ -44,6 +45,7 @@ export const CommonDialogTitle: React.FC<CommonDialogTitleProps> = ({
   onChangeDisplayMode,
   showDisplayModeControls = true,
 }) => {
+  const { t } = useTranslation('common');
   const {
     modeMenuAnchor,
     isModeMenuOpen,
@@ -118,7 +120,7 @@ export const CommonDialogTitle: React.FC<CommonDialogTitleProps> = ({
               </IconButton>
             </>
           )}
-          <IconButton onClick={onClose} color="inherit" aria-label="Close dialog">
+          <IconButton onClick={onClose} color="inherit" aria-label={String(t('dialogs.common.actions.close', 'Close dialog'))}>
             <CloseIcon />
           </IconButton>
         </Stack>

--- a/packages/ui/i18n/public/locales/en/common.json
+++ b/packages/ui/i18n/public/locales/en/common.json
@@ -128,6 +128,11 @@
     "effect": "effect"
   },
   "dialogs": {
+    "common": {
+      "actions": {
+        "close": "Close dialog"
+      }
+    },
     "archive": {
       "modeMenu": {
         "ariaLabel": "Display mode",

--- a/packages/ui/i18n/public/locales/ja/common.json
+++ b/packages/ui/i18n/public/locales/ja/common.json
@@ -77,7 +77,7 @@
     "warning": "警告",
     "themeChangeRequested": "テーマ変更がリクエストされました: {{theme}}",
     "basicInfo": {
-      "title": "Info",
+      "title": "基本情報",
       "subtitle": "名前と説明（任意）を入力してください。",
       "name": {
         "label": "名前",
@@ -128,6 +128,11 @@
     "effect": "エフェクト"
   },
   "dialogs": {
+    "common": {
+      "actions": {
+        "close": "ダイアログを閉じる"
+      }
+    },
     "archive": {
       "modeMenu": {
         "ariaLabel": "表示モード",

--- a/plugins/shape-plugin/src/ui/locales/en.json
+++ b/plugins/shape-plugin/src/ui/locales/en.json
@@ -537,6 +537,7 @@
       "counts": "{{percentage}}% ・ {{completed}}/{{total}} completed ・ failed {{failed}} ・ skipped {{skipped}}"
     },
     "tasks": {
+      "search": "Search tasks",
       "empty": "No tasks yet.",
       "summaryOnly": "Tasks are summarized. Detailed list is unavailable."
     },

--- a/plugins/shape-plugin/src/ui/locales/ja.json
+++ b/plugins/shape-plugin/src/ui/locales/ja.json
@@ -537,18 +537,19 @@
       "counts": "{{percentage}}% ・ {{completed}}/{{total}} 完了 ・ 失敗 {{failed}} ・ スキップ {{skipped}}"
     },
     "tasks": {
+      "search": "タスクを検索",
       "empty": "タスクがまだありません。",
       "summaryOnly": "タスクは集計のみ表示されています。詳細一覧は取得できません。"
     },
     "taskStatus": {
       "waiting": "待機中",
-      "queued": "待機中",
+      "queued": "実行待ち",
       "running": "実行中",
       "paused": "一時停止",
-      "completed": "完了",
+      "completed": "実行完了",
       "recycled": "再利用",
-      "skipped": "スキップ",
-      "failed": "失敗"
+      "skipped": "実行省略",
+      "failed": "実行失敗"
     },
     "status": {
       "ready": "ビルドを開始する準備ができています",


### PR DESCRIPTION
## Summary
- Close Dialogツールチップ、Search tasksプレースホルダー、Step1 Infoラベル、タスクステータスChipのi18n化

## Changes
- shape-plugin locales: `stage.tasks.search` キー追加 (en/ja)
- common locales: `basicInfo.title` 日本語訳追加（基本情報）
- `CloseActionButton.tsx`: aria-label/title をt()でi18n化
- `CommonDialogTitle.tsx`: close button aria-label をt()でi18n化
- `dialogs.common.actions.close` キーを全common.jsonに追加
- タスクステータスChip日本語訳更新: queued→実行待ち, completed→実行完了, failed→実行失敗, skipped→実行省略

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/ui-dialog` → exit 0
- `pnpm -w turbo run typecheck --filter @hierarchidb/components` → exit 0
- `pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin` → exit 0

Closes #922