### PR TITLE
fix(i18n): correct translation key path for Stepper Step1 'Info' label

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,8 @@
 
 ## Doing
 
+- #924 Stepper Step1 "Info" i18nキーパス修正 / fix/i18n/stepper-info-label-key-path / start
+
 ## Blocked
 
 ## 今日の運用ログ

--- a/app/src/hooks/treeconsole/resolveOpenSteps.ts
+++ b/app/src/hooks/treeconsole/resolveOpenSteps.ts
@@ -48,7 +48,7 @@ const resolveDraftPayload = (node?: TreeNode | null): Record<string, unknown> =>
 
 const resolveBasicInfoLabel = (): string => {
   try {
-    const label = i18n.t('basicInfo.title', {
+    const label = i18n.t('common.basicInfo.title', {
       ns: 'common',
       defaultValue: 'Info',
     });


### PR DESCRIPTION
Closes #924

## 原因
resolveOpenSteps.ts の resolveBasicInfoLabel() が `basicInfo.title` を翻訳キーとして使用していたが、common.json の構造は `{ common: { basicInfo: { title: ... } } }` であり、正しいキーパスは `common.basicInfo.title`。

## 修正
- `i18n.t('basicInfo.title', ...)` → `i18n.t('common.basicInfo.title', ...)`

## 検証
- typecheck exit 0 (app)