### PR TITLE
fix(i18n): fix translation key path mismatches and unify useTranslation imports

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,8 @@
 
 ## Doing
 
+- #926 i18n翻訳キーパス不一致修正・useTranslation統合 / fix/i18n/translation-key-path-unification / start
+
 ## Blocked
 
 ## 今日の運用ログ

--- a/packages/components/src/CloseActionButton/CloseActionButton.tsx
+++ b/packages/components/src/CloseActionButton/CloseActionButton.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { Button } from '@mui/material';
 import { Close as CloseIcon } from '@mui/icons-material';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@hierarchidb/ui-i18n';
 
 interface CloseActionButtonProps {
   to: string;

--- a/packages/ui/dialog/package.json
+++ b/packages/ui/dialog/package.json
@@ -44,6 +44,7 @@
     "@mui/material": "^7.3.6",
     "@mui/icons-material": "^7.3.6",
     "react-resizable": "^3.0.5",
-    "@hierarchidb/tree-api": "workspace:*"
+    "@hierarchidb/tree-api": "workspace:*",
+    "@hierarchidb/ui-i18n": "workspace:*"
   }
 }

--- a/packages/ui/dialog/src/components/CommonDialogTitle.tsx
+++ b/packages/ui/dialog/src/components/CommonDialogTitle.tsx
@@ -10,7 +10,7 @@ import {
   FullscreenExit as FullscreenExitIcon,
 } from '@mui/icons-material';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@hierarchidb/ui-i18n';
 import {
   DISPLAY_MODE_LABELS,
   useCommonDialogTitleView,

--- a/packages/ui/dialog/src/components/UnsavedChangesDialog.tsx
+++ b/packages/ui/dialog/src/components/UnsavedChangesDialog.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '@mui/material';
 import type { DialogProps } from '@mui/material';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@hierarchidb/ui-i18n';
 import { Delete as DeleteIcon, Save as SaveIcon, Warning as WarningIcon } from '@mui/icons-material';
 import { useUnsavedChangesDialogView } from './useUnsavedChangesDialogView.js';
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/startupTrace.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepHelpers/startupTrace.ts
@@ -81,18 +81,18 @@ export const getBuildSessionTransitionStatusLabel = (
   const elapsedSeconds = Math.max(0, Math.floor(durationMs / 1000));
   switch (phase) {
     case 'acquiring-lock':
-      return t('stage.status.startingLock', 'Starting build (acquiring lock)...');
+      return t('build.status.startingLock', 'Starting build (acquiring lock)...');
     case 'waiting-lock':
-      return t('stage.status.startingQueueElapsed', `Starting build (waiting for lock, ${elapsedSeconds}s)...`);
+      return t('build.status.startingQueueElapsed', `Starting build (waiting for lock, ${elapsedSeconds}s)...`);
     case 'saving-draft':
-      return t('stage.status.startingSave', 'Starting build (saving draft)...');
+      return t('build.status.startingSave', 'Starting build (saving draft)...');
     case 'initializing-worker':
-      return t('stage.status.startingWorker', 'Starting build (initializing worker)...');
+      return t('build.status.startingWorker', 'Starting build (initializing worker)...');
     case 'building-payloads':
-      return t('stage.status.startingPayload', 'Starting build (preparing tasks)...');
+      return t('build.status.startingPayload', 'Starting build (preparing tasks)...');
     case 'starting-session':
-      return t('stage.status.startingSession', 'Starting build (launching session)...');
+      return t('build.status.startingSession', 'Starting build (launching session)...');
     default:
-      return t('stage.status.starting', 'Starting stage...');
+      return t('build.status.starting', 'Starting stage...');
   }
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
@@ -374,7 +374,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
   const effectiveStatusLabel = buildSessionTransition.active
     ? getBuildSessionTransitionStatusLabel(t, buildSessionTransition.phase, startupLifecycleElapsedMs)
     : isStartPending && buildStatus === 'idle'
-      ? t('stage.status.starting', 'Starting stage...')
+      ? t('build.status.starting', 'Starting stage...')
       : statusLabel;
   return {
     t,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateComputed.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateComputed.ts
@@ -64,22 +64,22 @@ export type BuildProgressPanelStateComputed = {
 };
 
 const resolveStatusLabel = (t: TranslateFn) => (statusValue?: string, skipped?: boolean): string => {
-  if (skipped) return t('stage.taskStatus.skipped', 'Skipped');
+  if (skipped) return t('build.taskStatus.skipped', 'Skipped');
   switch (statusValue) {
     case 'running':
-      return t('stage.taskStatus.running', 'Running');
+      return t('build.taskStatus.running', 'Running');
     case 'completed':
-      return t('stage.taskStatus.completed', 'Completed');
+      return t('build.taskStatus.completed', 'Completed');
     case 'recycled':
-      return t('stage.taskStatus.recycled', 'Recycled');
+      return t('build.taskStatus.recycled', 'Recycled');
     case 'failed':
-      return t('stage.taskStatus.failed', 'Failed');
+      return t('build.taskStatus.failed', 'Failed');
     case 'paused':
-      return t('stage.taskStatus.paused', 'Paused');
+      return t('build.taskStatus.paused', 'Paused');
     case 'queued':
-      return t('stage.taskStatus.queued', 'Queued');
+      return t('build.taskStatus.queued', 'Queued');
     default:
-      return t('stage.taskStatus.waiting', 'Waiting');
+      return t('build.taskStatus.waiting', 'Waiting');
   }
 };
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildLabels/useShapeBuildLabels.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildLabels/useShapeBuildLabels.ts
@@ -33,15 +33,15 @@ export const useShapeBuildLabels = ({
   const statusLabel = useMemo(() => {
     switch (buildStatus) {
       case 'running':
-        return t('stage.status.running', 'Build in progress');
+        return t('build.status.running', 'Build in progress');
       case 'paused':
-        return t('stage.status.paused', 'Build paused');
+        return t('build.status.paused', 'Build paused');
       case 'completed':
-        return t('stage.status.completed', 'Build completed');
+        return t('build.status.completed', 'Build completed');
       case 'failed':
-        return t('stage.status.failed', 'Build failed');
+        return t('build.status.failed', 'Build failed');
       default:
-        return t('stage.status.ready', 'Ready to start stage');
+        return t('build.status.ready', 'Ready to start stage');
     }
   }, [buildStatus, t]);
 

--- a/plugins/shape-plugin/src/ui/locales/en.json
+++ b/plugins/shape-plugin/src/ui/locales/en.json
@@ -556,7 +556,14 @@
       "running": "Build in progress",
       "paused": "Build paused",
       "completed": "Build completed",
-      "failed": "Build failed"
+      "failed": "Build failed",
+      "starting": "Starting stage...",
+      "startingLock": "Starting build (acquiring lock)...",
+      "startingQueueElapsed": "Starting build (waiting for lock, {{elapsedSeconds}}s)...",
+      "startingSave": "Starting build (saving draft)...",
+      "startingWorker": "Starting build (initializing worker)...",
+      "startingPayload": "Starting build (preparing tasks)...",
+      "startingSession": "Starting build (launching session)..."
     },
     "stages": {
       "source": {

--- a/plugins/shape-plugin/src/ui/locales/ja.json
+++ b/plugins/shape-plugin/src/ui/locales/ja.json
@@ -556,7 +556,14 @@
       "running": "ビルド処理中",
       "paused": "ビルド一時停止中",
       "completed": "ビルド完了",
-      "failed": "ビルド失敗"
+      "failed": "ビルド失敗",
+      "starting": "ステージを開始中...",
+      "startingLock": "ビルド開始中（ロック取得中）...",
+      "startingQueueElapsed": "ビルド開始中（ロック待機中、{{elapsedSeconds}}秒）...",
+      "startingSave": "ビルド開始中（下書き保存中）...",
+      "startingWorker": "ビルド開始中（ワーカー初期化中）...",
+      "startingPayload": "ビルド開始中（タスク準備中）...",
+      "startingSession": "ビルド開始中（セッション起動中）..."
     },
     "stages": {
       "source": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1946,6 +1946,9 @@ importers:
       '@hierarchidb/tree-api':
         specifier: workspace:*
         version: link:../../tree-api
+      '@hierarchidb/ui-i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@mui/icons-material':
         specifier: ^7.3.6
         version: 7.3.9(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)


### PR DESCRIPTION
Closes #926

## 修正内容
1. shape-plugin内の翻訳キーパス不一致を修正:
   - `stage.taskStatus.*` → `build.taskStatus.*`（resolveStatusLabel）
   - `stage.status.*` → `build.status.*`（useShapeBuildLabels）
   - `stage.status.starting*` → `build.status.starting*`（startupTrace）
2. `build.status.starting*` キーをen.json/ja.jsonに追加
3. react-i18next直接importを@hierarchidb/ui-i18n経由に統一:
   - CloseActionButton, CommonDialogTitle, UnsavedChangesDialog
4. ui-dialogパッケージに@hierarchidb/ui-i18n peerDependency追加

## 検証
- typecheck exit 0 (ui-dialog, components, shape-plugin)