### PR TITLE
refactor(i18n): unify typed i18n usage via @hierarchidb/ui-i18n

### DIFF
--- a/app/src/i18n/workerInitMessages.ts
+++ b/app/src/i18n/workerInitMessages.ts
@@ -1,4 +1,4 @@
-import type { i18n as I18nInstance } from 'i18next';
+import type { i18n as I18nInstance } from '@hierarchidb/ui-i18n';
 
 const DEFAULT_MESSAGES = {
   start: 'Starting worker initialization…',

--- a/app/src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx
+++ b/app/src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx
@@ -25,17 +25,6 @@ vi.mock('@hierarchidb/ui-plugin-shell/ui-i18n', () => ({
     language: 'en',
   }),
 }));
-
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
-  }),
-  initReactI18next: {
-    type: '3rdParty',
-    init: vi.fn(),
-  },
-}));
-
 const menuItemsModule = vi.hoisted(() => ({
   usePluginMenuItems: vi.fn<() => PluginMenuItem[]>(),
 }));

--- a/app/src/router/pages/tree/console/hooks/useI18nReadyVersion.ts
+++ b/app/src/router/pages/tree/console/hooks/useI18nReadyVersion.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import type { i18n as I18nInstance } from 'i18next';
+import type { i18n as I18nInstance } from '@hierarchidb/ui-i18n';
 
 export function useI18nReadyVersion(i18n: I18nInstance): number {
   const [version, setVersion] = useState(0);

--- a/packages/ui/i18n/src/index.ts
+++ b/packages/ui/i18n/src/index.ts
@@ -5,6 +5,7 @@
 
 // Re-export commonly used i18next hooks so downstream packages share the configured instance
 export { I18nextProvider, Trans, Translation, useTranslation } from 'react-i18next';
+export type { i18n as I18nInstance, TFunction, TOptions } from 'i18next';
 export * from './hooks/useGlobalI18nTranslator.js';
 import { i18n as i18nInstance } from './i18n/index.js';
 

--- a/packages/ui/usermenu/src/components/useUserLoginButtonView.ts
+++ b/packages/ui/usermenu/src/components/useUserLoginButtonView.ts
@@ -1,4 +1,4 @@
-import type { TFunction } from 'i18next';
+import type { TFunction } from '@hierarchidb/ui-i18n';
 import { useMemo, useState } from 'react';
 import type React from 'react';
 import type { OpenMaintenanceContext } from './UserLoginButton.js';


### PR DESCRIPTION
### Motivation
- Enforce a single i18n access point across the repo by preventing direct `i18next`/`react-i18next` usage and allow downstream packages to consume i18n types via the `@hierarchidb/ui-i18n` facade.

### Description
- Re-exported types `i18n as I18nInstance`, `TFunction`, and `TOptions` from `packages/ui/i18n/src/index.ts` so packages can import types from `@hierarchidb/ui-i18n` instead of `i18next` via `export type { i18n as I18nInstance, TFunction, TOptions } from 'i18next';`.
- Replaced direct `i18next` type imports with `@hierarchidb/ui-i18n` typed imports in `app/src/router/pages/tree/console/hooks/useI18nReadyVersion.ts` and `app/src/i18n/workerInitMessages.ts` by changing `import type { i18n as I18nInstance } from 'i18next';` to `import type { i18n as I18nInstance } from '@hierarchidb/ui-i18n';`.
- Replaced `import type { TFunction } from 'i18next'` with `import type { TFunction } from '@hierarchidb/ui-i18n'` in `packages/ui/usermenu/src/components/useUserLoginButtonView.ts`.
- Removed an inline `react-i18next` mock from `app/src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx` so tests no longer reference `react-i18next` directly.

### Testing
- Searched for direct i18next/react-i18next imports with `rg` and confirmed there are no direct imports outside `packages/ui/i18n` (passed).
- Ran workspace typecheck with `pnpm -w turbo run typecheck --filter @hierarchidb/ui-i18n --filter @hierarchidb/ui-usermenu --filter @hierarchidb/app` which failed due to preexisting workspace type-resolution issues in unrelated packages (e.g. `@hierarchidb/plugin-presentation` / `@hierarchidb/ui-icon`) (failed).
- Ran targeted app tests with `pnpm --filter @hierarchidb/app test -- app/src/i18n/__tests__/workerInitMessages.unit.test.ts app/src/router/pages/tree/console/__tests__/DynamicSpeedDial.unit.test.tsx` and observed the test run, but the overall suite failed due to unrelated unresolved imports elsewhere in the repo (failed).
- Ran per-package typechecks `pnpm --filter @hierarchidb/ui-i18n typecheck && pnpm --filter @hierarchidb/ui-usermenu typecheck`; `ui-i18n` started successfully while `ui-usermenu` typecheck failed due to missing workspace type resolutions (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae348b83b8832384d1a8bf778cee51)