### PR TITLE
fix(components): resolve tsdown .d.ts splitting causing missing exports #947

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,7 +2,7 @@
 
 ## Doing
 
-- #944 / `refactor/components/consolidate-generic-ui-packages` / 2026-03-10 開始
+- #947 / `fix/components/dts-splitting-missing-exports` / 2026-03-10 開始
 - #917 / feature/i18n/shape-step5-remaining-ui-labels / PR #945 作成済み
 
 ## Blocked
@@ -18,6 +18,7 @@
   - typecheck・build・test全通過確認
 - 2026-03-10: #940 ナビゲーションコンポーネント抽出完了・PR #941マージ済み
 - 2026-03-10: クリーンアップ: #937 worktree+ブランチ削除(Issue CLOSED済)、#913 ブランチ削除(Issue CLOSED済)、#914 main含有確認→Issue close+ブランチ削除
+- 2026-03-10: #944 PR #946マージ完了・ローカル/リモートブランチ削除・stash整理(3件drop)
 - 2026-03-10: #917 mainリベース(コンフリクト2件解決)・push・PR #945作成
 
 - 2026-03-09: shape×styler同一フォルダ紐付けタスクは起票ゲートで停止（原因: gh未導入 / 発生範囲: 起票〜着手前 / 修正方法: gh CLI導入 / 適用範囲: 本環境の全新規実装タスク）。

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -26,7 +26,8 @@ export { SpacedSlider } from './SpacedSlider.tsx';
 
 export * from './SearchInput/index.ts';
 
-export * from './build-session/index.ts';
+export type { BuildStage } from './BuildStage.tsx';
+export type { BuildStatus } from './build-status/BuildStatus.ts';
 export * from './BuildSessionProgressPanel.tsx';
 export * from './BuildStepStageFilterContext.tsx';
 export * from './Icon/index.ts';

--- a/plugins/route-plugin/src/ui/components/steps/useRouteBuildSessionLifecycle.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRouteBuildSessionLifecycle.ts
@@ -10,12 +10,14 @@ import {
   type RouteMode,
 } from '@hierarchidb/route-api';
 import {
-  executePauseBuildFlow,
   notify,
   type BuildStatus,
+} from '@hierarchidb/components';
+import {
+  executePauseBuildFlow,
   type PauseBuildReason,
   useBuildSessionTransition,
-} from '@hierarchidb/components';
+} from '@hierarchidb/components/build-session';
 import { PLUGIN_NODE_TYPE } from '~/plugin-manifest';
 import { ROUTE_MODE_COLUMNS } from './routeSelectionConstants.js';
 


### PR DESCRIPTION
## 概要
`@hierarchidb/components` のビルドで tsdown が複数エントリポイントの `.d.ts` を生成する際、メインエントリの型定義が `dist/index2.d.ts` に分割され、`dist/index.d.ts` には `build-session` のエクスポートのみが残る問題を修正。

## 原因
`src/index.ts` が `export * from './build-session/index.ts'` で `build-session` サブエントリを再エクスポートしていたため、tsdown の dts code splitting で名前衝突が発生。

## 修正内容
1. `src/index.ts` から `export * from './build-session/index.ts'` を削除（`build-session` は独立サブエントリとして既に `package.json` exports に定義済み）
2. `BuildStage` / `BuildStatus` 型をメインエントリから直接エクスポート追加
3. `route-plugin` の `build-session` シンボルのインポートパスを `@hierarchidb/components/build-session` に変更

## 検証結果
- `@hierarchidb/components` ビルド成功、`index2.d.ts` 生成なし
- `dist/index.d.ts` が 33.34 kB（全エクスポート含む）
- 全体 typecheck: 143/147 成功（失敗は `route-plugin` の既存 i18n 型エラーのみ、main でも同一）

Closes #947