### PR TITLE
fix(components): prevent infinite re-render loop in StableIconSlot #949

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,7 @@
 
 ## Doing
 
+- #949 / fix/components/stable-icon-slot-infinite-loop / 2026-03-10 開始
 - #917 / feature/i18n/shape-step5-remaining-ui-labels / PR #945 作成済み
 
 ## Blocked

--- a/packages/components/src/LoadingButton.tsx
+++ b/packages/components/src/LoadingButton.tsx
@@ -16,8 +16,12 @@ function StableIconSlot({ icon, loading }: { icon: ReactNode; loading: boolean }
     const el = iconRef.current;
     if (el) {
       const measured = el.getBoundingClientRect().width;
-      setMinWidth((prev) => Math.max(prev, measured, SPINNER_SIZE_PX));
+      if (measured > minWidth) {
+        setMinWidth(measured);
+      }
     }
+    // minWidth is intentionally excluded to prevent re-measure loops.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [icon, loading]);
 
   const spinner = (
@@ -36,7 +40,7 @@ function StableIconSlot({ icon, loading }: { icon: ReactNode; loading: boolean }
         alignItems: 'center',
         justifyContent: 'center',
         minWidth,
-        height: minWidth,
+        height: SPINNER_SIZE_PX,
       }}
     >
       {loading ? (


### PR DESCRIPTION
## 概要
LoadingButton 内の StableIconSlot で Maximum update depth exceeded エラーが発生していた問題を修正。

## 原因
1. `height: minWidth` — minWidth 更新 → 高さ変更 → アイコン描画サイズ変更 → 再測定 → minWidth 再更新の無限ループ
2. `setMinWidth` が値未変更でも呼ばれる可能性

## 修正内容
- `height` を固定値 `SPINNER_SIZE_PX` に変更
- `measured > minWidth` の場合のみ `setMinWidth` を呼ぶように変更

## 検証
- typecheck 通過（exit code 0）

Closes #949