### PR TITLE
fix(shape-plugin): break infinite render loop in elapsed snapshot useEffect

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,7 +2,7 @@
 
 ## Doing
 
-- #956 / fix/shape-plugin/stage-state-infinite-loop / 2026-03-10 start → PR #957作成
+- #958 / fix/shape-plugin/elapsed-snapshot-infinite-loop / 2026-03-10 start
 
 ## Blocked
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateSideEffects.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateSideEffects.ts
@@ -86,6 +86,8 @@ export const useBuildProgressPanelStateSideEffects = (args: {
   const previousBuildStatusRef = useRef<Summary['buildStatus'] | null>(null);
   const lastNodeIdRef = useRef<string | undefined>(undefined);
   const hasProgressRef = useRef(false);
+  const totalElapsedSnapshotRef = useRef(totalElapsedSnapshot);
+  totalElapsedSnapshotRef.current = totalElapsedSnapshot;
   const isTerminalStatus = (status: Summary['buildStatus'] | null) => status === 'completed' || status === 'failed';
 
   useEffect(() => {
@@ -206,7 +208,7 @@ export const useBuildProgressPanelStateSideEffects = (args: {
 
   useEffect(() => {
     if (shouldUpdateElapsedSnapshot({
-      snapshot: totalElapsedSnapshot,
+      snapshot: totalElapsedSnapshotRef.current,
       totalElapsedMs: summary.totalElapsedMs,
       buildStatus: summary.buildStatus,
     })) {
@@ -215,7 +217,7 @@ export const useBuildProgressPanelStateSideEffects = (args: {
         capturedAt: elapsedTickMs,
       });
     }
-  }, [elapsedTickMs, summary.buildStatus, summary.totalElapsedMs, totalElapsedSnapshot, setTotalElapsedSnapshot]);
+  }, [elapsedTickMs, summary.buildStatus, summary.totalElapsedMs, setTotalElapsedSnapshot]);
 
   useEffect(() => {
     if (!isShapeBuildPanelDebugEnabled('runningResiduePanel')) return;


### PR DESCRIPTION
## Summary

`totalElapsedSnapshot` state was in its own useEffect dependency array in `useBuildProgressPanelStateSideEffects`. When `buildStatus !== 'running'`, `shouldUpdateElapsedSnapshot` returns `true`, `setTotalElapsedSnapshot` creates a new object reference, which triggers the effect again — causing `Maximum update depth exceeded`.

## Fix

Introduce `totalElapsedSnapshotRef` with sync assignment and read from the ref inside the effect body, removing `totalElapsedSnapshot` from the dependency array.

## Verification

- typecheck: 0 new errors (15 pre-existing `DefaultTFuncReturn` issues only)
- getDiagnostics: no issues

Fixes #958