### PR TITLE
fix(plugin-dialog): auto-transition displayMode from maximize to normal on resize/move (#964)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,13 +2,17 @@
 
 ## Doing
 
-（なし）
+- #964 / fix/plugin-dialog/maximize-to-normal-on-resize / 2026-03-10 開始
 
 ## Blocked
 
 - 2026-03-09: mapでshape-styler同一フォルダ紐付け実装着手 blocked（`gh issue create` 実行時 `gh: command not found`、`apt-get install gh` はプロキシ 403 で失敗）。解除条件: `gh` CLI を利用可能にする（プリインストールまたは実行可能パス提供）。
 
 ## 今日の運用ログ
+
+- 2026-03-10: #960 CommonDialogTitle表示モードtooltip/label i18n化・PR #962→#963マージ済み
+  - DISPLAY_MODE_LABELSハードコード→t()化、IconButtonにTooltip追加、localeコピー同期
+  - typecheck: exit 0、test: 5/5 passed
 
 - 2026-03-10: #961 AGENTS.mdにReact Hooks依存配列ルール追加・PR #962マージ済み
 

--- a/packages/plugin-ui-host/src/headless/usePluginDialogController/frame-state.ts
+++ b/packages/plugin-ui-host/src/headless/usePluginDialogController/frame-state.ts
@@ -405,9 +405,13 @@ export function useDialogFrameState({
     (next?: DialogSize) => {
       if (!next) return;
       defaultFrameRef.current = null;
+      // When the user manually resizes from maximize, transition to normal
+      if (displayMode === 'maximize') {
+        persistDisplayMode('normal');
+      }
       const viewport = getViewportSize();
       const normalized = normalizeDialogState(next, dialogPositionRef.current, viewport, {
-        enforceTopLeftMargin: displayMode === 'normal',
+        enforceTopLeftMargin: displayMode === 'normal' || displayMode === 'maximize',
         minPosition: 0,
         clampSizeToViewport: true,
       });
@@ -418,16 +422,20 @@ export function useDialogFrameState({
         persistPosition(normalized.position);
       }
     },
-    [displayMode, persistPosition, persistSize]
+    [displayMode, persistDisplayMode, persistPosition, persistSize]
   );
 
   const handlePositionChange = useCallback(
     (next?: DialogPosition) => {
       if (!next) return;
       defaultFrameRef.current = null;
+      // When the user manually moves from maximize, transition to normal
+      if (displayMode === 'maximize') {
+        persistDisplayMode('normal');
+      }
       const viewport = getViewportSize();
       const normalized = normalizeDialogState(dialogSizeRef.current, next, viewport, {
-        enforceTopLeftMargin: displayMode === 'normal',
+        enforceTopLeftMargin: displayMode === 'normal' || displayMode === 'maximize',
         minPosition: 0,
         clampSizeToViewport: true,
       });
@@ -438,7 +446,7 @@ export function useDialogFrameState({
         persistPosition(normalized.position);
       }
     },
-    [displayMode, persistPosition, persistSize]
+    [displayMode, persistDisplayMode, persistPosition, persistSize]
   );
 
   return {


### PR DESCRIPTION
Closes #964

## 変更内容
- `frame-state.ts` の `handleSizeChange` / `handlePositionChange` で、`displayMode === 'maximize'` の場合に `persistDisplayMode('normal')` を呼ぶようにした
- これにより URL の `maximize` セグメントも自動的に `normal` に差し替わる

## 検証
- typecheck: exit 0 (81 tasks)