### PR TITLE
refactor(plugin-dialog): use nextDisplayMode for enforceTopLeftMargin clarity (#964)

### DIFF
--- a/packages/plugin-ui-host/src/headless/usePluginDialogController/frame-state.ts
+++ b/packages/plugin-ui-host/src/headless/usePluginDialogController/frame-state.ts
@@ -406,12 +406,13 @@ export function useDialogFrameState({
       if (!next) return;
       defaultFrameRef.current = null;
       // When the user manually resizes from maximize, transition to normal
+      const nextDisplayMode = displayMode === 'maximize' ? 'normal' : displayMode;
       if (displayMode === 'maximize') {
         persistDisplayMode('normal');
       }
       const viewport = getViewportSize();
       const normalized = normalizeDialogState(next, dialogPositionRef.current, viewport, {
-        enforceTopLeftMargin: displayMode === 'normal' || displayMode === 'maximize',
+        enforceTopLeftMargin: nextDisplayMode === 'normal',
         minPosition: 0,
         clampSizeToViewport: true,
       });
@@ -430,12 +431,13 @@ export function useDialogFrameState({
       if (!next) return;
       defaultFrameRef.current = null;
       // When the user manually moves from maximize, transition to normal
+      const nextDisplayMode = displayMode === 'maximize' ? 'normal' : displayMode;
       if (displayMode === 'maximize') {
         persistDisplayMode('normal');
       }
       const viewport = getViewportSize();
       const normalized = normalizeDialogState(dialogSizeRef.current, next, viewport, {
-        enforceTopLeftMargin: displayMode === 'normal' || displayMode === 'maximize',
+        enforceTopLeftMargin: nextDisplayMode === 'normal',
         minPosition: 0,
         clampSizeToViewport: true,
       });


### PR DESCRIPTION
Closes review feedback on #965

## 変更内容
- PR #965 のレビュー指摘に対応: `nextDisplayMode` 変数を導入し、`enforceTopLeftMargin` の条件を `nextDisplayMode === 'normal'` に簡略化
- `handleSizeChange` / `handlePositionChange` 両方に適用

## 検証
- typecheck: exit 0 (81 tasks)