### PR TITLE
fix(i18n): remove redundant 'common.' prefix from basicInfo.title translation key

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,7 +2,8 @@
 
 ## Doing
 
-- #966 / `refactor/build-progress/consolidate-build-modules-v2` / 2026-03-10 開始
+- #970 / `fix/i18n/stepper-basic-info-label-key` / 2026-03-10 開始
+- #969 / `refactor/review/gemini-review-batch-fixes` / 2026-03-10 開始
 
 ## Blocked
 

--- a/app/src/hooks/treeconsole/resolveOpenSteps.ts
+++ b/app/src/hooks/treeconsole/resolveOpenSteps.ts
@@ -48,7 +48,7 @@ const resolveDraftPayload = (node?: TreeNode | null): Record<string, unknown> =>
 
 const resolveBasicInfoLabel = (): string => {
   try {
-    const label = i18n.t('common.basicInfo.title', {
+    const label = i18n.t('basicInfo.title', {
       ns: 'common',
       defaultValue: 'Info',
     });

--- a/packages/plugin-ui-host/src/headless/usePluginDialogController.ts
+++ b/packages/plugin-ui-host/src/headless/usePluginDialogController.ts
@@ -537,7 +537,7 @@ export function usePluginDialogController(
     handleBasicInfoBridge,
     onDraftMetadataChange: handleDraftMetadataChange,
     dialogRef,
-    basicInfoLabel: t('common.basicInfo.title', 'Info'),
+    basicInfoLabel: t('basicInfo.title', 'Info'),
     onTagClick: handleTagNavigate,
   });
 


### PR DESCRIPTION
Closes #970

## 概要
PluginDialog Stepper の basic-info ステップラベルが i18n 化されず常に英語フォールバック "Info" が表示されていた問題を修正。

## 原因
`useTranslation('common')` で名前空間指定済みにもかかわらず、翻訳キーに `common.` プレフィックスが重複していた。

## 修正内容
- `usePluginDialogController.ts`: `t('common.basicInfo.title', 'Info')` → `t('basicInfo.title', 'Info')`
- `resolveOpenSteps.ts`: `i18n.t('common.basicInfo.title', ...)` → `i18n.t('basicInfo.title', ...)`

## 検証
- typecheck: plugin-ui-host, app ともに通過（route-plugin の既知 DefaultTFuncReturn エラーのみ）