### PR TITLE
fix(i18n): enable bindI18nStore re-render and add missing common.basicInfo keys #973

### DIFF
--- a/app/public/locales/en/common.json
+++ b/app/public/locales/en/common.json
@@ -511,6 +511,23 @@
       "ready": "Ready to start build"
     }
   },
+  "common": {
+    "basicInfo": {
+      "title": "Info",
+      "subtitle": "Enter a name and optional description.",
+      "name": {
+        "label": "Name",
+        "helper": "Enter a descriptive name",
+        "required": "Name is required",
+        "placeholder": "Enter name"
+      },
+      "description": {
+        "label": "Description",
+        "helper": "Describe the purpose or contents (optional)",
+        "placeholder": "Enter description (optional)"
+      }
+    }
+  },
   "buildSessionQueue": {
     "empty": "No running or queued build sessions found",
     "deleteTitle": "Delete session from queue",

--- a/app/public/locales/ja/common.json
+++ b/app/public/locales/ja/common.json
@@ -490,6 +490,23 @@
       "ready": "ビルドを開始する準備ができています"
     }
   },
+  "common": {
+    "basicInfo": {
+      "title": "基本情報",
+      "subtitle": "名前と説明（任意）を入力してください。",
+      "name": {
+        "label": "名前",
+        "helper": "わかりやすい名前を入力してください",
+        "required": "名前は必須です",
+        "placeholder": "名前を入力"
+      },
+      "description": {
+        "label": "説明",
+        "helper": "目的や内容を説明してください（任意）",
+        "placeholder": "説明を入力（任意）"
+      }
+    }
+  },
   "buildSessionQueue": {
     "empty": "実行中または待機中のセッションが見つかりません",
     "deleteTitle": "キューからセッションを削除",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -490,6 +490,23 @@
     "checkReference": "Check reference",
     "preview": "Preview"
   },
+  "common": {
+    "basicInfo": {
+      "title": "Info",
+      "subtitle": "Enter a name and optional description.",
+      "name": {
+        "label": "Name",
+        "helper": "Enter a descriptive name",
+        "required": "Name is required",
+        "placeholder": "Enter name"
+      },
+      "description": {
+        "label": "Description",
+        "helper": "Describe the purpose or contents (optional)",
+        "placeholder": "Enter description (optional)"
+      }
+    }
+  },
   "buildSessionQueue": {
     "empty": "No running or queued build sessions found",
     "deleteTitle": "Delete session from queue",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -469,6 +469,23 @@
     },
     "emptyCell": "-"
   },
+  "common": {
+    "basicInfo": {
+      "title": "基本情報",
+      "subtitle": "名前と説明（任意）を入力してください。",
+      "name": {
+        "label": "名前",
+        "helper": "わかりやすい名前を入力してください",
+        "required": "名前は必須です",
+        "placeholder": "名前を入力"
+      },
+      "description": {
+        "label": "説明",
+        "helper": "目的や内容を説明してください（任意）",
+        "placeholder": "説明を入力（任意）"
+      }
+    }
+  },
   "buildSessionQueue": {
     "empty": "実行中または待機中のセッションが見つかりません",
     "deleteTitle": "キューからセッションを削除",

--- a/packages/ui/i18n/src/i18n/index.ts
+++ b/packages/ui/i18n/src/i18n/index.ts
@@ -75,7 +75,7 @@ interface ReactI18nOptions {
 const reactOptions: ReactI18nOptions = {
   useSuspense: false,
   bindI18n: 'languageChanged',
-  bindI18nStore: '',
+  bindI18nStore: 'added removed',
   transSupportBasicHtmlNodes: true,
   transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'em'],
   unescape: (str) => {


### PR DESCRIPTION
## Summary

Fix two i18n issues:

1. **bindI18nStore empty string prevents re-render**: When HttpBackend finishes loading locale files asynchronously after a language switch, `t()` returns the fallback English value because the ja locale hasn't loaded yet. With `bindI18nStore: ''`, no re-render occurs when loading completes. Changed to `'added removed'` so React re-renders when the i18n store is updated.

2. **Missing common.basicInfo keys in app locales**: `t('common.basicInfo.title', 'Info')` always returns the fallback `'Info'` because the `common.basicInfo` keys exist in `packages/ui/i18n/public/locales/` but are missing from `app/public/locales/` and `locales/` (which are the paths loaded at runtime). Added the full `common.basicInfo` block to all four locale files.

## Changes

- `packages/ui/i18n/src/i18n/index.ts`: `bindI18nStore: '' → 'added removed'`
- `app/public/locales/{en,ja}/common.json`: Add `common.basicInfo` keys
- `locales/{en,ja}/common.json`: Add `common.basicInfo` keys

## Verification

- typecheck: `pnpm -w turbo run typecheck --filter @hierarchidb/ui-i18n` → exit 0
- All JSON files validated

Closes #973