### PR TITLE
fix(plugin-dialog): use preset size for URL maximize mode in hydration #972

### DIFF
--- a/packages/plugin-ui-host/src/headless/usePluginDialogController/frame-state.ts
+++ b/packages/plugin-ui-host/src/headless/usePluginDialogController/frame-state.ts
@@ -192,6 +192,17 @@ export function useDialogFrameState({
         height: Math.max(layoutViewport.height, FRAME_CONSTANTS.MIN_DIALOG_HEIGHT),
       });
       persistPosition({ x: 0, y: 0 });
+    } else if (mode === 'maximize') {
+      // URL maximize mode: use preset size instead of persisted dialogUIState
+      const maximizeSize = getPresetSize('maximize', layoutViewport);
+      const maximizePosition = initialPosition(maximizeSize, layoutViewport);
+      const normalized = normalizeDialogState(maximizeSize, maximizePosition, layoutViewport, {
+        enforceTopLeftMargin: false,
+        minPosition: 0,
+        clampSizeToViewport: true,
+      });
+      persistSize(normalized.size);
+      persistPosition(normalized.position);
     } else {
       const normalized = normalizeDialogState(size, position, viewport, {
         enforceTopLeftMargin: mode === 'normal',


### PR DESCRIPTION
## Summary

When the URL specifies `maximize` display mode, the hydration useEffect was falling through to the `else` branch and using persisted `dialogUIState` size/position. This caused the dialog to appear at the previously saved normal-mode size instead of the maximize preset.

## Changes

Add a dedicated `maximize` case in the hydration useEffect (between `full-screen` and `else`) that uses `getPresetSize('maximize', layoutViewport)` and `initialPosition()` to compute the correct maximize dimensions, matching the behavior of `transitionDisplayMode('maximize')`.

## Verification

- `pnpm -w turbo run typecheck --filter @hierarchidb/plugin-ui-host` → 80/80 tasks successful, exit 0

Closes #972