### PR TITLE
fix(i18n): add missing dialogs.pluginDialog.tooltips and minimize/restoreMinimized keys (#977)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,7 @@
 
 ## Doing
 
+- #977 / `fix/i18n/plugin-dialog-tooltip-keys` / 2026-03-10 開始
 - #966 / `refactor/build-progress/consolidate-build-modules-v2` / 2026-03-10 開始
 
 

--- a/app/public/locales/en/common.json
+++ b/app/public/locales/en/common.json
@@ -161,7 +161,9 @@
           "maximize": "Maximize",
           "restoreSize": "Restore",
           "fullscreen": "Full screen",
-          "exitFullscreen": "Exit full screen"
+          "exitFullscreen": "Exit full screen",
+          "minimize": "Minimize",
+          "restoreMinimized": "Restore"
         },
         "tooltips": {
           "saveDraftDisabled": "No changes to save",
@@ -169,7 +171,9 @@
           "maximize": "Maximize",
           "restoreSize": "Restore",
           "fullscreen": "Full screen",
-          "exitFullscreen": "Exit full screen"
+          "exitFullscreen": "Exit full screen",
+          "minimize": "Minimize",
+          "restoreMinimized": "Restore"
         },
         "contextMenu": {
           "openInNewTab": "Open In New Tab",
@@ -182,6 +186,19 @@
       "titles": {
         "create": "Create {{plugin}}",
         "edit": "Edit {{plugin}}"
+      },
+      "buttons": {
+        "minimize": "Minimize",
+        "restoreMinimized": "Restore"
+      },
+      "tooltips": {
+        "maximize": "Maximize",
+        "restoreSize": "Restore",
+        "fullscreen": "Full screen",
+        "exitFullscreen": "Exit full screen",
+        "minimize": "Minimize",
+        "restoreMinimized": "Restore",
+        "close": "Close dialog"
       }
     }
   },

--- a/app/public/locales/ja/common.json
+++ b/app/public/locales/ja/common.json
@@ -161,7 +161,9 @@
           "maximize": "最大化",
           "restoreSize": "元に戻す",
           "fullscreen": "全画面",
-          "exitFullscreen": "全画面を終了"
+          "exitFullscreen": "全画面を終了",
+          "minimize": "最小化",
+          "restoreMinimized": "元に戻す"
         },
         "tooltips": {
           "saveDraftDisabled": "変更がないため保存できません",
@@ -169,7 +171,9 @@
           "maximize": "最大化",
           "restoreSize": "元に戻す",
           "fullscreen": "全画面",
-          "exitFullscreen": "全画面を終了"
+          "exitFullscreen": "全画面を終了",
+          "minimize": "最小化",
+          "restoreMinimized": "元に戻す"
         },
         "contextMenu": {
           "openInNewTab": "新しいタブで開く",
@@ -182,6 +186,19 @@
       "titles": {
         "create": "{{plugin}}の作成",
         "edit": "{{plugin}}の編集"
+      },
+      "buttons": {
+        "minimize": "最小化",
+        "restoreMinimized": "元に戻す"
+      },
+      "tooltips": {
+        "maximize": "最大化",
+        "restoreSize": "元に戻す",
+        "fullscreen": "全画面",
+        "exitFullscreen": "全画面を終了",
+        "minimize": "最小化",
+        "restoreMinimized": "元に戻す",
+        "close": "ダイアログを閉じる"
       }
     }
   },

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -162,6 +162,8 @@
           "restoreSize": "Restore",
           "fullscreen": "Full screen",
           "exitFullscreen": "Exit full screen",
+          "minimize": "Minimize",
+          "restoreMinimized": "Restore",
           "build": "Build",
           "building": "Building…"
         },
@@ -171,7 +173,9 @@
           "maximize": "Maximize",
           "restoreSize": "Restore",
           "fullscreen": "Full screen",
-          "exitFullscreen": "Exit full screen"
+          "exitFullscreen": "Exit full screen",
+          "minimize": "Minimize",
+          "restoreMinimized": "Restore"
         },
         "contextMenu": {
           "openInNewTab": "Open In New Tab",
@@ -184,6 +188,19 @@
       "titles": {
         "create": "Create {{plugin}}",
         "edit": "Edit {{plugin}}"
+      },
+      "buttons": {
+        "minimize": "Minimize",
+        "restoreMinimized": "Restore"
+      },
+      "tooltips": {
+        "maximize": "Maximize",
+        "restoreSize": "Restore",
+        "fullscreen": "Full screen",
+        "exitFullscreen": "Exit full screen",
+        "minimize": "Minimize",
+        "restoreMinimized": "Restore",
+        "close": "Close dialog"
       }
     }
   },

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -162,6 +162,8 @@
           "restoreSize": "元に戻す",
           "fullscreen": "全画面",
           "exitFullscreen": "全画面を終了",
+          "minimize": "最小化",
+          "restoreMinimized": "元に戻す",
           "build": "ビルド",
           "building": "ビルド中…"
         },
@@ -171,7 +173,9 @@
           "maximize": "最大化",
           "restoreSize": "元に戻す",
           "fullscreen": "全画面",
-          "exitFullscreen": "全画面を終了"
+          "exitFullscreen": "全画面を終了",
+          "minimize": "最小化",
+          "restoreMinimized": "元に戻す"
         },
         "contextMenu": {
           "openInNewTab": "新しいタブで開く",
@@ -184,6 +188,19 @@
       "titles": {
         "create": "{{plugin}}の作成",
         "edit": "{{plugin}}の編集"
+      },
+      "buttons": {
+        "minimize": "最小化",
+        "restoreMinimized": "元に戻す"
+      },
+      "tooltips": {
+        "maximize": "最大化",
+        "restoreSize": "元に戻す",
+        "fullscreen": "全画面",
+        "exitFullscreen": "全画面を終了",
+        "minimize": "最小化",
+        "restoreMinimized": "元に戻す",
+        "close": "ダイアログを閉じる"
       }
     }
   },


### PR DESCRIPTION
## 概要
PluginDialogのモードボタン（Maximize/Restore/Full screen/Exit full screen/Minimize/Restore）のツールチップが日本語に切り替えても英語のまま表示される問題を修正。

## 原因
- `app/public/locales/` と `locales/` の `common.json` で、`dialogs.pluginDialog` に `tooltips` セクションが存在しなかった
- コードは `t('dialogs.pluginDialog.tooltips.maximize')` 等を参照するが、キーは `dialogs.pluginDraft.pluginDialog.tooltips` にのみ存在
- `minimize` / `restoreMinimized` はどのセクションにも不足

## 修正内容
- 4ファイルの `dialogs.pluginDialog` に `tooltips`（7キー）と `buttons`（minimize, restoreMinimized）を追加
- 4ファイルの `dialogs.pluginDraft.pluginDialog` にも minimize/restoreMinimized を追加

## 検証
- typecheck: 80/80 exit 0

Closes #977