### PR TITLE
refactor(shape-plugin): OrResume キーワード全廃・Start に統一

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,7 @@
 
 ## Doing
 
+- #984 / refactor/shape-plugin/remove-or-resume-keyword / 2026-03-10 開始
 - #983 / `fix/shape-plugin/rename-steps-processing-to-config` / 2026-03-10 開始
 - #970 / `fix/i18n/stepper-basic-info-label-key` / 2026-03-10 開始
 - #969 / `refactor/review/gemini-review-batch-fixes` / 2026-03-10 開始

--- a/plugins/route-plugin/tsconfig.json
+++ b/plugins/route-plugin/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.package.local-alias.base.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
     "allowArbitraryExtensions": true,
     "experimentalDecorators": true,
     "baseUrl": "."

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildAutoResume.reload.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildAutoResume.reload.unit.test.tsx
@@ -6,14 +6,14 @@ import { useShapeBuildAutoResume } from '../../../components/build-progress/useS
 describe('useShapeBuildAutoResume reload behavior', () => {
   const activeNodeId = 'node-1' as NodeId;
   const makeHook = (args: Partial<Parameters<typeof useShapeBuildAutoResume>[0]> = {}) => {
-    const handleStartOrResume = vi.fn().mockResolvedValue(true);
+    const handleStart = vi.fn().mockResolvedValue(true);
     const handlePause = vi.fn();
     const result = renderHook(() => useShapeBuildAutoResume({
       activeNodeId,
       buildStatus: 'idle' as BuildStatus,
       stopReason: undefined,
       runtimeStatus: 'processing',
-      handleStartOrResume,
+      handleStart,
       handlePause,
       hasFailedSourceTasks: false,
       hasDataSource: true,
@@ -22,7 +22,7 @@ describe('useShapeBuildAutoResume reload behavior', () => {
       isLockSupported: true,
       ...args,
     }));
-    return { result, handleStartOrResume, handlePause };
+    return { result, handleStart, handlePause };
   };
 
   beforeEach(() => {
@@ -32,29 +32,29 @@ describe('useShapeBuildAutoResume reload behavior', () => {
 
   it('auto-resumes when runtimeStatus is processing on reload', async () => {
     window.localStorage.setItem('autoResumeBuild', String(activeNodeId));
-    const { handleStartOrResume } = makeHook();
+    const { handleStart } = makeHook();
     await vi.waitFor(() => {
-      expect(handleStartOrResume).toHaveBeenCalledWith({ forceRestart: false, autoResume: true });
+      expect(handleStart).toHaveBeenCalledWith({ forceRestart: false, autoResume: true });
     });
   });
 
   it('does not auto-resume when build is completed', async () => {
     window.localStorage.setItem('autoResumeBuild', String(activeNodeId));
-    const { handleStartOrResume } = makeHook({ buildStatus: 'completed' as BuildStatus });
+    const { handleStart } = makeHook({ buildStatus: 'completed' as BuildStatus });
     await vi.waitFor(() => {
-      expect(handleStartOrResume).not.toHaveBeenCalled();
+      expect(handleStart).not.toHaveBeenCalled();
     });
   });
 
   it('does not auto-resume when stopReason is user-pause', async () => {
     window.localStorage.setItem('autoResumeBuild', String(activeNodeId));
-    const { handleStartOrResume } = makeHook({
+    const { handleStart } = makeHook({
       buildStatus: 'paused' as BuildStatus,
       stopReason: 'user-pause',
       runtimeStatus: 'paused',
     });
     await vi.waitFor(() => {
-      expect(handleStartOrResume).not.toHaveBeenCalled();
+      expect(handleStart).not.toHaveBeenCalled();
     });
   });
 });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildAutoResume.unit.test.tsx
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildAutoResume.unit.test.tsx
@@ -25,7 +25,7 @@ const createArgs = (overrides: Partial<Parameters<typeof useShapeBuildAutoResume
   buildStatus: 'paused' as BuildStatus,
   stopReason: 'route-leave' as const,
   runtimeStatus: 'paused',
-  handleStartOrResume: vi.fn(async () => true),
+  handleStart: vi.fn(async () => true),
   handlePause: vi.fn(),
   hasFailedSourceTasks: false,
   hasDataSource: true,
@@ -58,9 +58,9 @@ describe('useShapeBuildAutoResume', () => {
     renderHook(() => useShapeBuildAutoResume(args));
 
     await waitFor(() => {
-      expect(args.handleStartOrResume).toHaveBeenCalledTimes(1);
+      expect(args.handleStart).toHaveBeenCalledTimes(1);
     });
-    expect(args.handleStartOrResume).toHaveBeenCalledWith({
+    expect(args.handleStart).toHaveBeenCalledWith({
       forceRestart: false,
       autoResume: true,
     });
@@ -74,13 +74,13 @@ describe('useShapeBuildAutoResume', () => {
     renderHook(() => useShapeBuildAutoResume(args));
 
     await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(args.handleStartOrResume).not.toHaveBeenCalled();
+    expect(args.handleStart).not.toHaveBeenCalled();
     expect(window.localStorage.getItem('autoResumeBuild')).toBeNull();
   });
 
   it('keeps start pending while waiting for runtime transition', async () => {
-    const handleStartOrResume = vi.fn(async () => true);
-    const baseArgs = createArgs({ handleStartOrResume });
+    const handleStart = vi.fn(async () => true);
+    const baseArgs = createArgs({ handleStart });
     const { result, rerender } = renderHook(({ buildStatus }: { buildStatus: BuildStatus }) => (
       useShapeBuildAutoResume({
         ...baseArgs,
@@ -91,10 +91,10 @@ describe('useShapeBuildAutoResume', () => {
     });
 
     await act(async () => {
-      await result.current.startOrResume();
+      await result.current.start();
     });
 
-    expect(handleStartOrResume).toHaveBeenCalledTimes(1);
+    expect(handleStart).toHaveBeenCalledTimes(1);
     expect(result.current.isStartPending).toBe(true);
 
     rerender({ buildStatus: 'running' as BuildStatus });

--- a/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildStartExecutionHelpers.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/hooks/unit/useShapeBuildStartExecutionHelpers.unit.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   runStartSessionRequest,
-} from '../../../components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildStartOrResumeExecutionHelpers';
+} from '../../../components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildStartExecutionHelpers';
 
-describe('useShapeBuildStartOrResumeExecutionHelpers', () => {
+describe('useShapeBuildStartExecutionHelpers', () => {
   let onTrace: ReturnType<typeof vi.fn>;
   let beginBuildStartupStep: ReturnType<typeof vi.fn>;
   let finishBuildStartupStep: ReturnType<typeof vi.fn>;

--- a/plugins/shape-plugin/src/ui/atoms/shapeBuildProgressTypes.ts
+++ b/plugins/shape-plugin/src/ui/atoms/shapeBuildProgressTypes.ts
@@ -41,12 +41,12 @@ export type TaskProgressSummary = {
 };
 
 export type TaskProgressControls = {
-  canStartOrResume: boolean;
+  canStart: boolean;
   statusLabel: string;
   showResumeLabel?: boolean;
   startPending?: boolean;
   requestedControlAction?: 'none' | 'start' | 'pause' | 'cancel';
-  handleStartOrResume?: () => Promise<void>;
+  handleStart?: () => Promise<void>;
   handlePause?: () => void;
   handleCancelQueued?: () => Promise<void> | void;
   stopRequested?: boolean;

--- a/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelViewModel.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/ShapeBuildProgressPanel/useShapeBuildProgressPanelViewModel.ts
@@ -163,7 +163,7 @@ export const useShapeBuildProgressPanelViewModel = ({
     stageHeaderMeta,
     chipPlacement: 'bottom' as const,
     suppressStatusFallback: true,
-    onResume: controls.canStartOrResume ? handleStartClickWithHold : undefined,
+    onResume: controls.canStart ? handleStartClickWithHold : undefined,
     onPause: controls.stopRequested ? undefined : (() => {
       void controls.handlePause?.();
     }),

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions.ts
@@ -1,8 +1,8 @@
 import { useShapeBuildCancelQueued } from './useShapeBuildStepControlActions/useShapeBuildCancelQueued.js';
 import { useShapeBuildPause } from './useShapeBuildStepControlActions/useShapeBuildPause.js';
-import { useShapeBuildStartOrResume } from './useShapeBuildStepControlActions/useShapeBuildStart.js';
+import { useShapeBuildStart } from './useShapeBuildStepControlActions/useShapeBuildStart.js';
 import type {
-  StartOrResumeControlActionsArgs,
+  StartControlActionsArgs,
   PauseControlActionsArgs,
   CancelQueuedControlActionsArgs,
 } from './useShapeBuildStepControlActions/types.js';
@@ -31,8 +31,8 @@ export const useShapeBuildStepControlActions = ({
   updateSessionRecord,
   setIsStopRequested,
   setIsStopAccepted,
-}: StartOrResumeControlActionsArgs & PauseControlActionsArgs & CancelQueuedControlActionsArgs) => {
-  const handleStartOrResume = useShapeBuildStartOrResume({
+}: StartControlActionsArgs & PauseControlActionsArgs & CancelQueuedControlActionsArgs) => {
+  const handleStart = useShapeBuildStart({
     activeNodeId,
     data,
     buildStatus,
@@ -84,7 +84,7 @@ export const useShapeBuildStepControlActions = ({
   });
 
   return {
-    handleStartOrResume,
+    handleStart,
     handleCancelQueued,
     handlePause,
   };

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/executeStartFlow.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/executeStartFlow.ts
@@ -1,8 +1,8 @@
-import { onTraceFailure, runStartSessionRequest } from './useShapeBuildStartOrResumeExecutionHelpers.js';
-import type { StartOrResumeExecutionArgs } from './types.js';
+import { onTraceFailure, runStartSessionRequest } from './useShapeBuildStartExecutionHelpers.js';
+import type { StartExecutionArgs } from './types.js';
 import { getErrorMessage, summarizeSelectedEntries, toTransitionErrorMessage } from '~/ui/components/build-progress/internal/useShapeBuildStepHelpers/errors';
 
-export const executeStartOrResumeFlow = async (args: StartOrResumeExecutionArgs): Promise<boolean> => {
+export const executeStartFlow = async (args: StartExecutionArgs): Promise<boolean> => {
   const {
     activeNodeId,
     data,

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/types.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/types.ts
@@ -28,12 +28,12 @@ export type BuildStartupStep =
 
 export type BuildStartupStepOutcome = 'success' | 'error' | 'cancelled' | 'aborted';
 
-export type StartOrResumeOptions = {
+export type StartOptions = {
   forceRestart?: boolean;
   autoResume?: boolean;
 };
 
-export type StartOrResumeTrace = {
+export type StartTrace = {
   event: string;
   payload?: Record<string, unknown>;
 };
@@ -89,7 +89,7 @@ export type ControlActionsArgs = {
   setIsStopAccepted: (next: boolean) => void;
 };
 
-export type StartOrResumeControlActionsArgs = Pick<
+export type StartControlActionsArgs = Pick<
   ControlActionsArgs,
   | 'activeNodeId'
   | 'data'
@@ -113,11 +113,11 @@ export type StartOrResumeControlActionsArgs = Pick<
   | 'setIsStopAccepted'
 >;
 
-export type StartOrResumeExecutionArgs = StartOrResumeControlActionsArgs & {
-  options?: StartOrResumeOptions;
+export type StartExecutionArgs = StartControlActionsArgs & {
+  options?: StartOptions;
   startupSource: 'manual' | 'auto';
   shouldResumeSession: boolean;
-  onTrace: (trace: StartOrResumeTrace) => void;
+  onTrace: (trace: StartTrace) => void;
   requestStartedAt: number;
   runTimedStep: <T>(stepName: string, runner: () => Promise<T>) => Promise<T>;
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildStart.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildStart.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 import { notify } from '@hierarchidb/components/notify';
-import type { StartOrResumeControlActionsArgs, StartOrResumeOptions } from './types.js';
+import type { StartControlActionsArgs, StartOptions } from './types.js';
 import { shouldResumeBuildSession } from '~/ui/components/build-progress/shouldResumeBuildSession';
-import { executeStartOrResumeFlow } from './executeStartOrResumeFlow.js';
+import { executeStartFlow } from './executeStartFlow.js';
 import { isShapeBuildPanelDebugEnabled } from '~/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelState.utils.js';
 
-export const useShapeBuildStartOrResume = ({
+export const useShapeBuildStart = ({
   activeNodeId,
   data,
   buildStatus,
@@ -26,8 +26,8 @@ export const useShapeBuildStartOrResume = ({
   updateSessionRecord,
   setIsStopRequested,
   setIsStopAccepted,
-}: StartOrResumeControlActionsArgs) => {
-  const handleStartOrResume = useCallback(async (options?: StartOrResumeOptions): Promise<boolean> => {
+}: StartControlActionsArgs) => {
+  const handleStart = useCallback(async (options?: StartOptions): Promise<boolean> => {
     const requestStartedAt = Date.now();
     setRequestedControlAction('start');
     setIsStopRequested(false);
@@ -60,7 +60,7 @@ export const useShapeBuildStartOrResume = ({
     }
 
     try {
-      return executeStartOrResumeFlow({
+      return executeStartFlow({
         activeNodeId,
         data,
         buildStatus,
@@ -85,7 +85,7 @@ export const useShapeBuildStartOrResume = ({
         shouldResumeSession,
         onTrace: (trace) => {
           if (!isShapeBuildPanelDebugEnabled('startResume')) return;
-          console.log('[ShapeBuildStartResumeTrace] handleStartOrResume', {
+          console.log('[ShapeBuildStartTrace] handleStart', {
             nodeId: String(activeNodeId),
             durationMs: Math.max(0, Date.now() - requestStartedAt),
             event: trace.event,
@@ -96,7 +96,7 @@ export const useShapeBuildStartOrResume = ({
         runTimedStep: async <T, >(stepName: string, runner: () => Promise<T>): Promise<T> => {
           const stepStartedAt = Date.now();
           if (isShapeBuildPanelDebugEnabled('startResume')) {
-            console.log('[ShapeBuildStartResumeTrace] handleStartOrResume', {
+            console.log('[ShapeBuildStartTrace] handleStart', {
               nodeId: String(activeNodeId),
               durationMs: Math.max(0, Date.now() - requestStartedAt),
               event: `${stepName}:start`,
@@ -105,7 +105,7 @@ export const useShapeBuildStartOrResume = ({
           try {
             const result = await runner();
             if (isShapeBuildPanelDebugEnabled('startResume')) {
-              console.log('[ShapeBuildStartResumeTrace] handleStartOrResume', {
+              console.log('[ShapeBuildStartTrace] handleStart', {
                 nodeId: String(activeNodeId),
                 durationMs: Math.max(0, Date.now() - requestStartedAt),
                 event: `${stepName}:finish`,
@@ -115,7 +115,7 @@ export const useShapeBuildStartOrResume = ({
             return result;
           } catch (error) {
             if (isShapeBuildPanelDebugEnabled('startResume')) {
-              console.log('[ShapeBuildStartResumeTrace] handleStartOrResume', {
+              console.log('[ShapeBuildStartTrace] handleStart', {
                 nodeId: String(activeNodeId),
                 durationMs: Math.max(0, Date.now() - requestStartedAt),
                 event: `${stepName}:error`,
@@ -154,5 +154,5 @@ export const useShapeBuildStartOrResume = ({
     setIsStopAccepted,
   ]);
 
-  return handleStartOrResume;
+  return handleStart;
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildStartExecutionHelpers.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepControlActions/useShapeBuildStartExecutionHelpers.ts
@@ -1,10 +1,10 @@
 import type { BuildSessionStatus } from '@hierarchidb/build-api';
-import type { StartOrResumeExecutionArgs } from './types.js';
+import type { StartExecutionArgs } from './types.js';
 import { getErrorMessage, summarizeSelectedEntries } from '~/ui/components/build-progress/internal/useShapeBuildStepHelpers/errors';
 import { SHAPE_NODE_TYPE } from '~/ui/components/build-progress/shapeBuildTaskSyncDebug';
 
 type BaseRequestContext = Pick<
-  StartOrResumeExecutionArgs,
+  StartExecutionArgs,
   | 'bridgeRef'
   | 'activeNodeId'
   | 'advanceBuildSessionTransitionPhase'
@@ -19,7 +19,7 @@ type BaseRequestContext = Pick<
 >;
 
 type StartSessionRequestContext = BaseRequestContext & {
-  data?: StartOrResumeExecutionArgs['data'];
+  data?: StartExecutionArgs['data'];
 };
 
 type StartSessionResponse = {
@@ -34,7 +34,7 @@ type StartSessionResult = {
 };
 
 export const onTraceFailure = (
-  onTrace: StartOrResumeExecutionArgs['onTrace'],
+  onTrace: StartExecutionArgs['onTrace'],
   requestStartedAt: number,
   error: unknown,
 ): void => {

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
@@ -346,7 +346,7 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
   });
 
   const {
-    handleStartOrResume,
+    handleStart,
     handlePause,
     handleCancelQueued,
   } = useShapeBuildStepControlActions({
@@ -395,12 +395,12 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     }
   }, [isStopRequestedInFlight, runtimeStatusForBuildStatus, setPendingUserAction]);
 
-  const { canStartOrResume, isStartPending, startOrResume, clearStartPending } = useShapeBuildAutoResume({
+  const { canStart, isStartPending, start, clearStartPending } = useShapeBuildAutoResume({
     activeNodeId,
     buildStatus,
     stopReason,
     runtimeStatus,
-    handleStartOrResume,
+    handleStart,
     handlePause,
     hasFailedSourceTasks,
     hasDataSource,
@@ -443,8 +443,8 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     completedStageElapsedMs,
     warningMessage,
     showResumeLabel,
-    canStartOrResume,
-    handleStartOrResume: startOrResume,
+    canStart,
+    handleStart: start,
     handlePause,
     handleCancelQueued,
     isStartPending,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelState.ts
@@ -5,7 +5,7 @@ import type { ShapeEntity } from '~/common/types/ShapeEntity';
 import { useBuildProgressPanelStateActions } from './useBuildProgressPanelStateActions.js';
 import { useBuildProgressPanelStateRuntimeState } from './useBuildProgressPanelStateRuntimeState.js';
 import { useShapeBuildProgressWarnings } from './useShapeBuildProgressWarnings.js';
-import { isDev, logStartResumeTrace } from './useBuildProgressPanelState.utils.js';
+import { isDev, logStartTrace } from './useBuildProgressPanelState.utils.js';
 
 export const useBuildProgressPanelState = (params: {
   data?: Partial<ShapeEntity>;
@@ -63,7 +63,7 @@ export const useBuildProgressPanelState = (params: {
 
   useMemo(() => {
     if (nodeIdForLog) {
-      logStartResumeTrace('useBuildProgressPanelState render', {
+      logStartTrace('useBuildProgressPanelState render', {
         nodeId: nodeIdForLog ?? null,
         buildStatus: summary.buildStatus,
         activeStageId: resolvedActiveStageId,
@@ -133,5 +133,5 @@ export {
   resolveCompletionFailedStageLabel,
   resolveActiveRunningStageId,
   isDev,
-  logStartResumeTrace,
+  logStartTrace,
 } from './useBuildProgressPanelState.utils.js';

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelState.utils.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelState.utils.ts
@@ -4,7 +4,7 @@ import { resolveMostAdvancedStageId } from '~/ui/components/build-progress/stage
 
 export const isDev = import.meta.env.DEV;
 
-export const START_RESUME_TRACE_PREFIX = '[ShapeBuildStartResumeTrace]';
+export const START_TRACE_PREFIX = '[ShapeBuildStartTrace]';
 export const RUNNING_RESIDUE_LOG_PREFIX = '[ShapeRunningResidue]';
 
 type ShapeBuildPanelDebugChannel =
@@ -32,9 +32,9 @@ export const isShapeBuildPanelDebugEnabled = (channel: ShapeBuildPanelDebugChann
   return Boolean(config.all) || Boolean(config[channel]);
 };
 
-export const logStartResumeTrace = (event: string, payload?: Record<string, unknown>): void => {
+export const logStartTrace = (event: string, payload?: Record<string, unknown>): void => {
   if (!isShapeBuildPanelDebugEnabled('startResume')) return;
-  console.log(`${START_RESUME_TRACE_PREFIX} ${event}`, payload ?? {});
+  console.log(`${START_TRACE_PREFIX} ${event}`, payload ?? {});
 };
 
 export const formatRunningResidueValue = (value: unknown): string => {

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateActions.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateActions.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 import type { NodeId } from '@hierarchidb/core-types';
 import type { BuildStatus } from '@hierarchidb/ui-build-progress/build-status';
 import type { TaskProgressControls } from '~/ui/atoms/shapeBuildProgressTypes';
-import { logStartResumeTrace } from './useBuildProgressPanelState.utils.js';
+import { logStartTrace } from './useBuildProgressPanelState.utils.js';
 import type { PendingUserAction } from '~/ui/atoms/buildSessionStateAtoms';
 
 type Params = {
@@ -36,10 +36,10 @@ export const useBuildProgressPanelStateActions = (params: Params): Return => {
 
   const nodeId = resolvedNodeId ? String(resolvedNodeId) : null;
 
-  const runStartOrResume = useCallback(async () => {
+  const runStart = useCallback(async () => {
     const requestStartedAt = Date.now();
-    const startHandler = controls.handleStartOrResume;
-    logStartResumeTrace('runStartOrResume invoked', {
+    const startHandler = controls.handleStart;
+    logStartTrace('runStart invoked', {
       nodeId,
       localStartPending,
       controlStartPending: Boolean(controls.startPending),
@@ -47,29 +47,29 @@ export const useBuildProgressPanelStateActions = (params: Params): Return => {
       buildStatus,
     });
     if (localStartPending) {
-      logStartResumeTrace('runStartOrResume skipped (already pending)', { nodeId });
+      logStartTrace('runStart skipped (already pending)', { nodeId });
       return;
     }
     if (!startHandler) {
-      logStartResumeTrace('runStartOrResume skipped (missing handler)', { nodeId });
+      logStartTrace('runStart skipped (missing handler)', { nodeId });
       return;
     }
     setPendingUserAction('starting');
-    logStartResumeTrace('runStartOrResume pending enabled', { nodeId });
+    logStartTrace('runStart pending enabled', { nodeId });
     const waitTimer = window.setInterval(() => {
-      logStartResumeTrace('runStartOrResume waiting for handler', {
+      logStartTrace('runStart waiting for handler', {
         nodeId,
         durationMs: Math.max(0, Date.now() - requestStartedAt),
       });
     }, 3000);
     try {
       await startHandler();
-      logStartResumeTrace('runStartOrResume handler resolved', {
+      logStartTrace('runStart handler resolved', {
         nodeId,
         durationMs: Math.max(0, Date.now() - requestStartedAt),
       });
     } catch (error) {
-      logStartResumeTrace('runStartOrResume handler rejected', {
+      logStartTrace('runStart handler rejected', {
         nodeId,
         durationMs: Math.max(0, Date.now() - requestStartedAt),
         errorMessage: error instanceof Error ? error.message : String(error),
@@ -78,14 +78,14 @@ export const useBuildProgressPanelStateActions = (params: Params): Return => {
     } finally {
       window.clearInterval(waitTimer);
       setPendingUserAction('none');
-      logStartResumeTrace('runStartOrResume pending cleared', {
+      logStartTrace('runStart pending cleared', {
         nodeId,
         durationMs: Math.max(0, Date.now() - requestStartedAt),
       });
     }
   }, [
     buildStatus,
-    controls.handleStartOrResume,
+    controls.handleStart,
     controls.startPending,
     localStartPending,
     nodeId,
@@ -99,28 +99,28 @@ export const useBuildProgressPanelStateActions = (params: Params): Return => {
 
   const handleStartClick = useCallback(async () => {
     if (startWarning) {
-      logStartResumeTrace('handleStartClick blocked by warning dialog', {
+      logStartTrace('handleStartClick blocked by warning dialog', {
         nodeId,
         warningMessage,
       });
       setWarningDialogOpen(true);
       return;
     }
-    logStartResumeTrace('handleStartClick proceed', {
+    logStartTrace('handleStartClick proceed', {
       nodeId,
       buildStatus,
     });
-    await runStartOrResume();
-  }, [buildStatus, nodeId, runStartOrResume, setWarningDialogOpen, startWarning, warningMessage]);
+    await runStart();
+  }, [buildStatus, nodeId, runStart, setWarningDialogOpen, startWarning, warningMessage]);
 
   const handleConfirmStart = useCallback(async () => {
-    logStartResumeTrace('handleConfirmStart proceed', {
+    logStartTrace('handleConfirmStart proceed', {
       nodeId,
       buildStatus,
     });
     setWarningDialogOpen(false);
-    await runStartOrResume();
-  }, [buildStatus, nodeId, runStartOrResume, setWarningDialogOpen]);
+    await runStart();
+  }, [buildStatus, nodeId, runStart, setWarningDialogOpen]);
 
   return {
     mergedControls,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateRuntimeState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgressPanelState/useBuildProgressPanelStateRuntimeState.ts
@@ -109,12 +109,12 @@ export const useBuildProgressPanelStateRuntimeState = (
     stageTotals: stepState.stageTotals,
   };
   const controls: TaskProgressControls = {
-    canStartOrResume: stepState.canStartOrResume,
+    canStart: stepState.canStart,
     statusLabel: stepState.statusLabel,
     showResumeLabel: stepState.showResumeLabel,
     startPending: stepState.isStartPending,
     requestedControlAction: stepState.requestedControlAction,
-    handleStartOrResume: stepState.handleStartOrResume,
+    handleStart: stepState.handleStart,
     handlePause: stepState.handlePause,
     handleCancelQueued: stepState.handleCancelQueued,
     stopRequested: stepState.stopRequested,

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildAutoResume/useShapeBuildAutoResume.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildAutoResume/useShapeBuildAutoResume.ts
@@ -8,7 +8,7 @@ type Args = {
   buildStatus: BuildStatus;
   stopReason?: ShapeBuildStopReason;
   runtimeStatus: string | null;
-  handleStartOrResume: (options: { forceRestart: boolean; autoResume?: boolean }) => Promise<boolean>;
+  handleStart: (options: { forceRestart: boolean; autoResume?: boolean }) => Promise<boolean>;
   handlePause: (reason?: 'route-leave' | 'user-pause') => void;
   hasFailedSourceTasks: boolean;
   hasDataSource: boolean;
@@ -22,7 +22,7 @@ export const useShapeBuildAutoResume = ({
   buildStatus,
   stopReason,
   runtimeStatus,
-  handleStartOrResume,
+  handleStart,
   handlePause,
   hasFailedSourceTasks,
   hasDataSource,
@@ -36,7 +36,7 @@ export const useShapeBuildAutoResume = ({
     isStartPendingRef.current = next;
     setIsStartPending(next);
   }, []);
-  const canStartOrResume = useMemo(() => (
+  const canStart = useMemo(() => (
     !isStartPending
     && buildStatus !== 'running'
     && hasDataSource
@@ -100,24 +100,24 @@ export const useShapeBuildAutoResume = ({
     };
   }, []);
 
-  const startOrResume = useCallback(async (options?: { autoResume?: boolean }) => {
+  const start = useCallback(async (options?: { autoResume?: boolean }) => {
     if (isStartPendingRef.current) return;
     if (!isLockSupported) return;
     setStartPending(true);
-    const ok = await handleStartOrResume({
+    const ok = await handleStart({
       forceRestart: hasFailedSourceTasks,
       autoResume: options?.autoResume,
     });
     if (!ok) {
       setStartPending(false);
     }
-  }, [handleStartOrResume, hasFailedSourceTasks, isLockSupported, setStartPending]);
+  }, [handleStart, hasFailedSourceTasks, isLockSupported, setStartPending]);
   const clearStartPending = useCallback(() => {
     setStartPending(false);
   }, [setStartPending]);
 
   useEffect(() => {
-    if (!activeNodeId || !canStartOrResume || isStartPending) return;
+    if (!activeNodeId || !canStart || isStartPending) return;
     if (!isLockSupported) return;
     if (typeof window === 'undefined') return;
     const storage = window.localStorage;
@@ -147,7 +147,7 @@ export const useShapeBuildAutoResume = ({
       });
 
       storage.removeItem('autoResumeBuild');
-      void startOrResume({ autoResume: true });
+      void start({ autoResume: true });
     } catch (error) {
       console.warn('[ShapeBuildStep] auto-resume build failed', error);
       // エラー時はautoResumeBuildフラグを削除
@@ -157,12 +157,12 @@ export const useShapeBuildAutoResume = ({
         console.warn('[ShapeBuildStep] failed to cleanup autoResumeBuild flag', cleanupError);
       }
     }
-  }, [activeNodeId, canAutoResume, canStartOrResume, isStartPending, startOrResume, buildStatus, runtimeStatus, stopReason]);
+  }, [activeNodeId, canAutoResume, canStart, isStartPending, start, buildStatus, runtimeStatus, stopReason]);
 
   return {
-    canStartOrResume,
+    canStart,
     isStartPending,
-    startOrResume,
+    start,
     clearStartPending,
   };
 };

--- a/plugins/shape-plugin/src/ui/locales/en.json
+++ b/plugins/shape-plugin/src/ui/locales/en.json
@@ -167,10 +167,6 @@
       "body": "A build session is currently running. Open the Build step to view progress.",
       "action": "Open Build Step"
     },
-    "cache": {
-      "title": "Miscellaneous",
-      "descriptionTooltip": "Control how build outputs are retained or removed for each stage."
-    },
     "tileEmit": {
       "title": "TileEmit"
     },


### PR DESCRIPTION
## 概要
ビルドセッション制御の `OrResume` キーワードを全廃し `Start` に統一。

## 変更内容
- ファイルリネーム: `useShapeBuildStartOrResume` → `useShapeBuildStart` 他3ファイル
- 型リネーム: `StartOrResumeControlActionsArgs` → `StartControlActionsArgs` 他3型
- シンボルリネーム: `handleStartOrResume` → `handleStart`, `canStartOrResume` → `canStart` 他
- テストファイル更新

## 検証
- `build --filter @hierarchidb/shape-plugin`: 67/67 exit 0
- `typecheck --filter @hierarchidb/shape-plugin`: 既知の DefaultTFuncReturn エラーのみ（今回の変更に起因する新規エラーなし）
- `OrResume` 残存: 0件（shouldResumeBuildSession 等の正当な resume 参照は除外）

Closes #984