### PR TITLE
fix(i18n): route-plugin t() String() wrap and I18nInstance import cleanup #988

### DIFF
--- a/app/src/i18n/workerInitMessages.ts
+++ b/app/src/i18n/workerInitMessages.ts
@@ -1,4 +1,4 @@
-import type { i18n as I18nInstance } from '@hierarchidb/ui-i18n';
+import type { I18nInstance } from '@hierarchidb/ui-i18n';
 
 const DEFAULT_MESSAGES = {
   start: 'Starting worker initialization…',

--- a/app/src/router/pages/tree/console/hooks/useI18nReadyVersion.ts
+++ b/app/src/router/pages/tree/console/hooks/useI18nReadyVersion.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import type { i18n as I18nInstance } from '@hierarchidb/ui-i18n';
+import type { I18nInstance } from '@hierarchidb/ui-i18n';
 
 export function useI18nReadyVersion(i18n: I18nInstance): number {
   const [version, setVersion] = useState(0);

--- a/plugins/route-plugin/src/ui/components/steps/RouteBuildStep.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/RouteBuildStep.tsx
@@ -145,16 +145,16 @@ export const RouteBuildStep: React.FC<RouteBuildStepProps> = ({
     includeDescriptions: true,
     overrides: {
       source: {
-        title: t('processing.source.title', 'Source'),
-        description: t('stage.route.source.description', 'Download, parse, and save source route features.'),
+        title: String(t('processing.source.title', 'Source')),
+        description: String(t('stage.route.source.description', 'Download, parse, and save source route features.')),
       },
       geometry: {
-        title: t('processing.geometry.title', 'Geometry'),
-        description: t('stage.route.geometry.description', 'Build tile index for route lookup.'),
+        title: String(t('processing.geometry.title', 'Geometry')),
+        description: String(t('stage.route.geometry.description', 'Build tile index for route lookup.')),
       },
       tileEmit: {
-        title: t('processing.tileEmit.title', 'TileEmit'),
-        description: t('stage.route.tileEmit.description', 'Generate tile artifacts for rendering.'),
+        title: String(t('processing.tileEmit.title', 'TileEmit')),
+        description: String(t('stage.route.tileEmit.description', 'Generate tile artifacts for rendering.')),
         icon: <CheckCircle />,
       },
     },
@@ -479,9 +479,9 @@ export const RouteBuildStep: React.FC<RouteBuildStepProps> = ({
             setHeapDialogOpen(false);
             dismissHeapEvent();
           }}
-          title={t('stage.heap.pauseTitle', 'Build paused due to memory pressure')}
-          confirmLabel={t('stage.heap.pauseConfirm', 'OK')}
-          description={t('stage.heap.pauseHint', 'Reduce concurrency and resume when ready.')}
+          title={String(t('stage.heap.pauseTitle', 'Build paused due to memory pressure'))}
+          confirmLabel={String(t('stage.heap.pauseConfirm', 'OK'))}
+          description={String(t('stage.heap.pauseHint', 'Reduce concurrency and resume when ready.'))}
         />
         <Dialog
           open={errorDialogOpen}

--- a/plugins/route-plugin/src/ui/components/steps/RouteDataSourceStep.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/RouteDataSourceStep.tsx
@@ -43,7 +43,7 @@ export const RouteDataSourceStep: React.FC<RouteDataSourceStepProps> = ({
 
   return (
     <DataSourceSelectionStep<number>
-      title={t('dataSource.title', 'Data Source')}
+      title={String(t('dataSource.title', 'Data Source'))}
       options={options}
       state={{
         dataSourceId: resolvedSource,
@@ -57,8 +57,8 @@ export const RouteDataSourceStep: React.FC<RouteDataSourceStepProps> = ({
         'Choose the primary dataset or service that provides route geometry.',
       )}
       createAgreedAt={() => Date.now()}
-      selectionTitle={t('dataSource.selectionTitle', 'Data Source')}
-      detailsTitle={t('dataSource.detailsTitle', 'Data Source Details')}
+      selectionTitle={String(t('dataSource.selectionTitle', 'Data Source'))}
+      detailsTitle={String(t('dataSource.detailsTitle', 'Data Source Details'))}
       licenseRequiredText={t(
         'dataSource.licenseRequired',
         'License agreement is required to proceed.',

--- a/plugins/route-plugin/src/ui/components/steps/RoutePreviewStep.tsx
+++ b/plugins/route-plugin/src/ui/components/steps/RoutePreviewStep.tsx
@@ -267,7 +267,7 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
                               size="small"
                               value={routeStyleConfig.modeColors[mode.id]}
                               onChange={(event) => handleModeColorChange(mode.id, event.target.value)}
-                              inputProps={{ 'aria-label': t('routeConfig.style.modeColorLabel', 'Color') }}
+                              inputProps={{ 'aria-label': String(t('routeConfig.style.modeColorLabel', 'Color')) }}
                             />
                           </Box>
                         </Grid>
@@ -314,7 +314,7 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
                         variant="contained"
                         color="primary"
                         size="large"
-                        aria-label={t('preview.modeFilters.reopen', 'Show route mode filters')}
+                        aria-label={String(t('preview.modeFilters.reopen', 'Show route mode filters'))}
                         onClick={modeWindow.handlers.show}
                       >
                         <FilterAlt />
@@ -325,7 +325,7 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
                         variant="contained"
                         color="primary"
                         size="large"
-                        aria-label={t('preview.listWindow.reopen', 'Show route metadata')}
+                        aria-label={String(t('preview.listWindow.reopen', 'Show route metadata'))}
                         onClick={listWindow.handlers.show}
                       >
                         <TableChart />
@@ -336,7 +336,7 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
                         variant="contained"
                         color="primary"
                         size="large"
-                        aria-label={t('routeConfig.style.reopen', 'Show route style')}
+                        aria-label={String(t('routeConfig.style.reopen', 'Show route style'))}
                         onClick={styleWindow.handlers.show}
                       >
                         <Palette />
@@ -349,7 +349,7 @@ export const RoutePreviewStep: React.FC<RoutePreviewStepProps> = ({ draft, nodeI
                   <RoutePreviewHoverSnackbar
                     {...hoverSnackbarProps}
                     isDarkMode={isDarkMode}
-                    popupHint={t('preview.hoverShortcutHelp', 'Click one of the nearby routes to add/remove selection.')}
+                    popupHint={String(t('preview.hoverShortcutHelp', 'Click one of the nearby routes to add/remove selection.'))}
                   />
                 ) : null}
               </Box>

--- a/plugins/route-plugin/src/ui/components/steps/useRouteDataSourceStep.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRouteDataSourceStep.ts
@@ -164,7 +164,7 @@ export const useRouteDataSourceStep = ({
       setImportInProgress(true);
       try {
         await ensureTabularXlsx();
-        const fallbackName = draft.ideGsmFileName ?? t('dataSource.ideGsm.fileFallback', 'Imported file');
+        const fallbackName = draft.ideGsmFileName ?? String(t('dataSource.ideGsm.fileFallback', 'Imported file'));
         const dataUrlFile = decodeDataUrlToFile(draft.ideGsmSourceUrl ?? '', fallbackName);
         const metadata = dataUrlFile
           ? await tabularApi.uploadTabularFile(dataUrlFile, {})

--- a/plugins/route-plugin/src/ui/components/steps/useRoutePreviewStep.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRoutePreviewStep.ts
@@ -593,7 +593,7 @@ export const useRoutePreviewStep = ({
           },
           filter: routeFilter,
         },
-        layerLabel: t('preview.vectorLayerLabel', 'Routes'),
+        layerLabel: String(t('preview.vectorLayerLabel', 'Routes')),
       },
     ];
   }, [hasGeometry, previewNodeId, routeFilter, routeStyleConfig, t]);

--- a/plugins/route-plugin/src/ui/components/steps/useRouteSelectionStep.ts
+++ b/plugins/route-plugin/src/ui/components/steps/useRouteSelectionStep.ts
@@ -155,7 +155,7 @@ export const useRouteSelectionStep = ({
     void (async () => {
       try {
         if (!api) {
-          throw new Error(t('routeConfig.ideGsmMissingWorker', 'Worker API is unavailable.'));
+          throw new Error(String(t('routeConfig.ideGsmMissingWorker', 'Worker API is unavailable.')));
         }
         await initialize();
         const routeMutation = await api.getRouteMutationAPI();
@@ -165,7 +165,7 @@ export const useRouteSelectionStep = ({
         });
         if (cancelled) return;
         if (!result || Object.keys(result.coverageByCountryOr ?? result.coverageByCountry ?? {}).length === 0) {
-          throw new Error(t('routeConfig.ideGsmEmptyCoverage', 'No routes found in IDE-GSM data.'));
+          throw new Error(String(t('routeConfig.ideGsmEmptyCoverage', 'No routes found in IDE-GSM data.')));
         }
         setCoverage(result);
         if (result.errors.length > 0) {

--- a/plugins/route-plugin/tsconfig.typecheck.json
+++ b/plugins/route-plugin/tsconfig.typecheck.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true
   }
 }


### PR DESCRIPTION
Closes #988

## Changes
- **route-plugin (6 files):** Wrap `t()` return values with `String()` where `string` type is expected, fixing `DefaultTFuncReturn` type errors
- **app (2 files):** Simplify `I18nInstance` import from `i18n as I18nInstance` to direct export name from `@hierarchidb/ui-i18n`
- **route-plugin/tsconfig.typecheck.json:** Add `allowImportingTsExtensions: true`

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/app --filter @hierarchidb/route-plugin`: 127/127 tasks successful, exit 0
