### PR TITLE
fix(location-plugin): prevent ide-gsm select-all deselect from reverting (#1026)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,8 @@
 
 ## Doing
 
+- #1026 / `fix/location-plugin/select-all-deselect-reverts-1026` / 2026-03-14 開始
+
 - #1021 / `fix/treeconsole/treetable-core-viewport-height` / 2026-03-14 開始
 - #1020 / `refactor/shape-plugin/build-session-event-redesign-1020` / 2026-03-14 開始
 - #1019 / `fix/shape-plugin/task-snapshot-race-on-build-start-1019` / 2026-03-14 開始
@@ -31,6 +33,7 @@
   - TreeConsolePanel viewHeight={600} 削除（2箇所）、親Box に height:'100%' 追加
   - TreeConsoleContent viewHeight||400 フォールバック削除
   - typecheck: 42/42 exit 0
+
 - 2026-03-14: #1020 テスト修正（4イベント新設計対応）・コミット 707f259 / typecheck: 100/100 exit 0 / test: 366/369 pass
 - 2026-03-14: #1019 ビルド開始時タスクスナップショット競合修正・コミット bf1c2d1
   - emitTaskSnapshot に taskCallbacks を渡し、putTasks 完了後の完全スナップショットを subscribeBuildTasks コールバックに直接配信

--- a/docs/build-session-spec.md
+++ b/docs/build-session-spec.md
@@ -1,51 +1,84 @@
-# ビルドセッション仕様（ドラフト）
+# ビルドセッション仕様
 
 ## 目的と対象範囲
-本書は、Shape のビルドセッションにおけるタスク生成・実行・再開のルールを、メタデータまたはタイムスタンプ比較に基づく厳密な仕様として定義する。対象は fetch/transform/vt の各ステージと、それに付随するメタデータ生成である。
+
+本書は、Shape のビルドセッションにおけるタスク生成・実行・再開のルールを、メタデータまたはタイムスタンプ比較に基づく厳密な仕様として定義する。対象は source / geometry / tileEmit の各ステージと、それに付随するメタデータ生成である。
 
 ## 用語定義
-- ソースデータ（Source）
-ビルド処理の入力となるデータ。`meta`（メタデータ署名）を持つ。`updatedAt` は任意。例: データソースの国×ADM選択、Fetch の元となる取得対象。
-- 生成物（Artifact）
-ステージ処理の出力。元データを辿れる参照キー（`sourceKey` や `originKey` など）と `meta` または `updatedAt` を持つ。
-- タスク（Task）
-ステージ内で生成物を作成/更新する処理単位。
-- ステージ（Stage）
-`fetch` → `transform` → `vt` の順序で進行する。
-- ビルドセッション（Build Session）
-複数ステージを順に実行する一連の処理。再開可能な状態を永続化する。
+
+- 入力データ（Input data）: ビルド処理の入力となるデータ。`meta`（メタデータ署名）を持つ。`updatedAt` は任意。例: データソースの国×ADM 選択。
+- 生成物（Artifact）: ステージ処理の出力。元データを辿れる参照キー（`sourceKey` や `originKey` など）と `meta` または `updatedAt` を持つ。
+- タスク（Task）: ステージ内で生成物を作成/更新する処理単位。タスクステータスの定義は「タスクステータス定義」セクションを参照。
+- ステージ（Stage）: `source` → `geometry` → `tileEmit` の順序で進行する処理単位。
+- ビルドセッション（Build Session）: 複数ステージを順に実行する一連の処理。再開可能な状態を永続化する。ライフサイクルフェーズの定義は「ビルドセッションライフサイクル」セクションを参照。
+
+## ビルドセッションライフサイクル
+
+ビルドセッションは以下のフェーズを持つ。
+
+| フェーズ | 意味 |
+| --- | --- |
+| `idle` | セッション未開始または完全終了後の待機状態 |
+| `starting` | ビルド開始処理中（Worker への命令送信〜実行開始前） |
+| `running` | ステージ実行中 |
+| `pausing` | 一時停止命令を送信済み、Worker の応答待ち |
+| `paused` | 一時停止中（再開可能） |
+| `resuming` | 再開命令を送信済み、Worker の応答待ち |
+| `finalizing` | 全ステージ完了後の後処理中 |
+| `completed` | 正常完了（終端状態） |
+| `failed` | エラー終了（終端状態） |
+
+`isActive` は `starting / running / pausing / resuming / finalizing` のいずれかのとき `true` となる。
+
+## タスクステータス定義
+
+| ステータス | 意味 | 経過時間計算への影響 |
+| --- | --- | --- |
+| `queued` | 処理待ち | 分母に含める |
+| `running` | 処理中 | 分母に含める |
+| `completed` | 処理成功（成果物あり） | `done` に含める |
+| `failed` | 処理失敗（エラー） | `done` に含める |
+| `skipped` | 処理実行・成果物なし（エラーではない） | `done` に含める |
+| `recycled` | 有効なキャッシュが存在するため処理実行なし | 経過時間計算の分母から除外 |
+
+残り時間の推定において、`recycled` タスクは平均処理時間の分母から除外する。`skipped` タスクは `done` カウントに含める。
 
 ## データモデル要件（規範）
-1. ソースデータは `meta` または `updatedAt` のいずれかを持つ。
-2. 国×ADM など選択スナップショットがソースとなる場合、`meta` は必須で `updatedAt` は不要とする。
+
+1. 入力データは `meta` または `updatedAt` のいずれかを持つ。
+2. 国×ADM など選択スナップショットが入力となる場合、`meta` は必須で `updatedAt` は不要とする。
 3. 生成物は `meta` または `updatedAt` を持ち、元データを辿れる参照キーを保持する。
 4. 生成物は以下の向き付きグラフ構造で参照できる。
 
 ```mermaid
 graph LR
-  S["Source (country/admin selection)" ] --> F["Fetch Artifact"]
-  F --> T["Transform Artifact"]
-  T --> V["Vector Tile Artifact"]
+  I["Input (country/admin selection)"] --> SA["Source Artifact"]
+  SA --> GA["Geometry Artifact"]
+  GA --> TA["TileEmit Artifact"]
 ```
 
 ## ステージ別の入出力
-- fetch
-  - 入力: ソースデータ（国/ADM 選択、データソース）
-  - 出力: Fetch Cache（`sourceKey`, `meta` または `updatedAt`）
-- transform
-  - 入力: Fetch Cache
-  - 出力: Transform Cache（`sourceKey`, `meta` または `updatedAt`）
-- vt
-  - 入力: Transform Cache と Tile 関係
+
+- source
+  - 入力: 入力データ（国/ADM 選択、データソース）
+  - 出力: Source Cache（`sourceKey`, `meta` または `updatedAt`）
+- geometry
+  - 入力: Source Cache
+  - 出力: Geometry Cache（`sourceKey`, `meta` または `updatedAt`）
+- tileEmit
+  - 入力: Geometry Cache と Tile 関係
   - 出力: Vector Tile（`originKey`, `meta` または `updatedAt`）
 
 ## タスク生成規則（定式）
+
 ### 記号
+
 - ステージ k のソース集合を `S_k`、生成物集合を `A_k` とする。
 - `s.key` はソース識別子、`a.key` は生成物識別子、`a.sourceKey` はソース参照キー。
 - `s.meta`, `a.meta` はメタデータ署名。`s.updatedAt`, `a.updatedAt` は更新時刻。
 
 ### ルール
+
 1. 比較関数 `needsUpdate(s, a)` の定義
    - `s.meta` または `a.meta` のいずれかが存在する場合はメタデータ比較を採用する。
      - `s.meta` が未定義、または `a.meta` が未定義のときは更新対象とする。
@@ -57,57 +90,63 @@ graph LR
 2. 新規/更新タスクの生成
    - 任意の `s ∈ S_k` に対し、対応する `a ∈ A_k` が存在しない、または `needsUpdate(s, a)` が真の場合、タスク `t(s)` を生成する。
 3. 既存生成物の保持
-   - `needsUpdate(s, a)` が偽のとき、対応タスクは不要とし、生成物は保持する。
+   - `needsUpdate(s, a)` が偽のとき、対応タスクは不要とし、生成物は保持する（`recycled` 扱い）。
 4. ソース消失時の削除
    - `A_k` に存在するが対応する `s ∈ S_k` が存在しない生成物は削除する。
    - 当該生成物を入力とする下流ステージの生成物/タスクは連鎖削除する。
 
 ## ステージ進行規則
-1. ステージは `fetch` → `transform` → `vt` の順で実行する。
+
+1. ステージは `source` → `geometry` → `tileEmit` の順で実行する。
 2. 各ステージ開始時に「タスク生成規則」に従ってタスクを準備する。
 3. 準備が完了したタスクを全て実行する。
 4. すべてのタスクを完了したら次ステージへ移行する。
 5. 最終ステージ完了でビルドセッションを終了する。
 
 ## 新規セッションの仕様
+
 - 既存の生成物は無いものとして扱い、`S_k` に基づき全タスクを生成する。
 - ソースが存在しない生成物は発生しないため、削除処理は不要。
 
 ## 再開セッションの仕様
+
 - 既存タスクと生成物を読み込み、各ステージでタスク生成規則を再適用する。
 - 失敗タスクは同一入力として再キューイングする。
 - `sourceKey` が一致しない生成物は削除し、下流生成物も削除する。
 
 ## 仕様の十分性（新規/再開）
+
 - 新規セッションでは、ソース集合が完全であればタスク生成規則のみで正しい処理順序が確定する。
 - 再開セッションでは、メタデータ比較または `updatedAt` 比較とソース消失時の削除により、未処理・失敗・更新のいずれも再決定できるため、十分である。
 
 ## 現行実装との整合性（要点）
+
 以下は現行コードに対する比較観点であり、仕様と実装の差異を示す。
 
 - メタデータ/タイムスタンプ比較によるタスク更新
   - 仕様: `meta` 比較を優先し、無い場合に `updatedAt` 比較で更新判断。
   - 実装: `inputData` の署名比較（`buildStableSignature`）で `meta` を作成し、`reconcileByMetadata` で更新判定を行う。`updatedAt` も補助的に利用できる。
-  - 参照: `/Users/hiroya/WebstormProjects/hierarchidb/packages/batch/src/session/buildSessionReconcile.ts`
-  - 参照: `/Users/hiroya/WebstormProjects/hierarchidb/plugins/shape-plugin/src/services/vt/shapeStageReconcile.ts`
+  - 参照: `packages/batch/src/session/buildSessionReconcile.ts`
+  - 参照: `plugins/shape-plugin/src/services/vt/shapeStageReconcile.ts`
 
 - ソース消失時の生成物削除
-- 仕様: ソース消失→生成物と下流生成物を削除。
-- 実装: 選択差分に基づく削除は行うが、生成物そのものの連鎖削除は一部処理に限定される。
-  - 参照: `/Users/hiroya/WebstormProjects/hierarchidb/plugins/shape-plugin/src/worker/api.ts`（`applySelectionDiffCleanup`）
+  - 仕様: ソース消失→生成物と下流生成物を削除。
+  - 実装: 選択差分に基づく削除は行うが、生成物そのものの連鎖削除は一部処理に限定される。
+  - 参照: `plugins/shape-plugin/src/worker/api.ts`（`applySelectionDiffCleanup`）
 
 - ステージ順序とタスク生成のタイミング
-- 仕様: 各ステージ開始時にタスク生成規則を適用。
-- 実装: 各ステージでタスク生成は行い、`meta` 比較を利用する。fetch は選択スナップショット、transform は fetch タスク出力、vt は transform cache の関連情報に基づく。
-  - 参照: `/Users/hiroya/WebstormProjects/hierarchidb/plugins/shape-plugin/src/services/vt/shapePipeline.ts`
-  - 参照: `/Users/hiroya/WebstormProjects/hierarchidb/plugins/shape-plugin/src/services/vt/shapePipelineVtStage.ts`
+  - 仕様: 各ステージ開始時にタスク生成規則を適用。
+  - 実装: 各ステージでタスク生成は行い、`meta` 比較を利用する。source は選択スナップショット、geometry は source タスク出力、tileEmit は geometry cache の関連情報に基づく。
+  - 参照: `plugins/shape-plugin/src/services/vt/shapePipeline.ts`
+  - 参照: `plugins/shape-plugin/src/services/vt/shapePipelineVtStage.ts`（ファイル名は旧称 `vt` のまま、tileEmit ステージに対応）
 
 - 生成物の参照グラフ
   - 仕様: 生成物メタデータから元データを辿れる構造を要求。
   - 実装: `sourceKey` や `originKey` により辿れるが、グラフ構造を用いた更新判定は未実装。
-  - 参照: `/Users/hiroya/WebstormProjects/hierarchidb/packages/gis-sdk/src/ephemeral/EphemeralDBRecordTypes.ts`
-  - 参照: `/Users/hiroya/WebstormProjects/hierarchidb/plugins/shape-plugin/src/services/vt/shapeStageMetadata.ts`
+  - 参照: `packages/gis-sdk/src/ephemeral/EphemeralDBRecordTypes.ts`
+  - 参照: `plugins/shape-plugin/src/services/vt/shapeStageMetadata.ts`
 
 ## 実装との差異まとめ
+
 - タスク更新判定は `meta` 比較に寄せて整合しつつあるが、生成物の連鎖削除は選択差分に限定される。
 - `updatedAt` を用いた更新判定は補助的であり、ソース側の時刻更新が必要なケースは未整理である。

--- a/packages/ui/build-sessions/src/state/createBuildSessionStateAtoms.ts
+++ b/packages/ui/build-sessions/src/state/createBuildSessionStateAtoms.ts
@@ -19,9 +19,14 @@ type BaseTaskSummary = {
   progress: number;
 };
 
-type StageProgressState<SessionPhase extends string> = {
+type StageTiming = {
+  stageStartedAt: number;
+  stageInactiveMs: number;
+  stageCompletedAt?: number;
+};
+
+type StageProgressState = {
   value: number;
-  phase: SessionPhase;
   message?: string;
   metadata?: Record<string, unknown>;
 };
@@ -34,27 +39,28 @@ type StageCounters = {
   failed: number;
 };
 
-type StageExecutionState<StageId extends string, SessionPhase extends string, TaskSummary extends BaseTaskSummary> = {
+type StageExecutionState<StageId extends string, TaskSummary extends BaseTaskSummary> = {
   stageId: StageId;
   tasksById: Record<string, TaskSummary>;
   taskOrder: string[];
   counters: StageCounters;
-  progress: StageProgressState<SessionPhase>;
+  progress: StageProgressState;
+  timing: StageTiming | null;
 };
 
 type BuildSessionLifecycleState<SessionPhase extends string> = {
   nodeId: string | null;
-  sessionId: string | null;
   phase: SessionPhase;
   isActive: boolean;
   startedAt?: number;
   heartbeatAt?: number;
   completedAt?: number;
+  stopReason?: string;
 };
 
-type BuildSessionExecutionState<StageId extends string, SessionPhase extends string, TaskSummary extends BaseTaskSummary> = {
+type BuildSessionExecutionState<StageId extends string, TaskSummary extends BaseTaskSummary> = {
   taskStreamConnected: boolean;
-  stages: Record<StageId, StageExecutionState<StageId, SessionPhase, TaskSummary>>;
+  stages: Record<StageId, StageExecutionState<StageId, TaskSummary>>;
 };
 
 type BuildSessionViewState<StageId extends string> = {
@@ -67,83 +73,55 @@ export type BuildSessionState<
   SessionPhase extends string,
   TaskSummary extends BaseTaskSummary,
 > = {
-  meta: {
-    lastAcceptedEventVersion: number;
-  };
   lifecycle: BuildSessionLifecycleState<SessionPhase>;
-  execution: BuildSessionExecutionState<StageId, SessionPhase, TaskSummary>;
+  execution: BuildSessionExecutionState<StageId, TaskSummary>;
   view: BuildSessionViewState<StageId>;
 };
 
-type RuntimeSnapshotEvent<SessionPhase extends string> = {
-  type: 'runtimeSnapshotReceived';
-  eventVersion: number;
+// --- Canonical 4-event types (Worker → UI) ---
+
+type SessionStatusUpdatedEvent<SessionPhase extends string> = {
+  type: 'sessionStatusUpdated';
   payload: {
     nodeId: string;
-    sessionId?: string;
     phase: SessionPhase;
     isActive: boolean;
     startedAt?: number;
-    heartbeatAt?: number;
     completedAt?: number;
+    stopReason?: string;
   };
 };
 
-type SessionRecordEvent<StageId extends string, SessionPhase extends string> = {
-  type: 'sessionRecordReceived';
-  eventVersion: number;
+type HeartbeatEvent = {
+  type: 'heartbeat';
   payload: {
     nodeId: string;
-    phase: SessionPhase;
-    completedAt?: number;
-    heartbeatAt?: number;
-    startedAt?: number;
-    stageId?: StageId;
-    stopReason?: string;
-    inactiveMs?: number;
-    stageStartedAt?: number;
-    stageInactiveMs?: number;
+    heartbeatAt: number;
   };
 };
 
-type TaskSnapshotEvent<StageId extends string, TaskSummary extends BaseTaskSummary> = {
-  type: 'taskSnapshotReceived';
-  eventVersion: number;
+type StageSnapshotUpdatedEvent<StageId extends string, TaskSummary extends BaseTaskSummary> = {
+  type: 'stageSnapshotUpdated';
   payload: {
     stageId: StageId;
     tasks: TaskSummary[];
+    stageStartedAt: number;
+    stageInactiveMs: number;
+    stageCompletedAt?: number;
   };
 };
 
-type TaskUpdatedEvent<StageId extends string, TaskSummary extends BaseTaskSummary> = {
-  type: 'taskUpdated';
-  eventVersion: number;
-  payload: {
-    stageId: StageId;
-    task: TaskSummary;
-  };
-};
-
-type TaskDeletedEvent<StageId extends string> = {
-  type: 'taskDeleted';
-  eventVersion: number;
-  payload: {
-    stageId: StageId;
-    taskId: string;
-  };
-};
-
-type ProgressEvent<StageId extends string, SessionPhase extends string> = {
-  type: 'progressReceived';
-  eventVersion: number;
+type TaskProgressUpdatedEvent<StageId extends string> = {
+  type: 'taskProgressUpdated';
   payload: {
     stageId: StageId;
     value: number;
-    phase: SessionPhase;
     message?: string;
     metadata?: Record<string, unknown>;
   };
 };
+
+// --- UI-internal events (not from Worker) ---
 
 type TaskStreamConnectionEvent = {
   type: 'taskStreamConnectionChanged';
@@ -169,21 +147,13 @@ export type BuildSessionStateEvent<
   SessionPhase extends string,
   TaskSummary extends BaseTaskSummary,
 > =
-  | RuntimeSnapshotEvent<SessionPhase>
-  | SessionRecordEvent<StageId, SessionPhase>
-  | TaskSnapshotEvent<StageId, TaskSummary>
-  | TaskUpdatedEvent<StageId, TaskSummary>
-  | TaskDeletedEvent<StageId>
-  | ProgressEvent<StageId, SessionPhase>
+  | SessionStatusUpdatedEvent<SessionPhase>
+  | HeartbeatEvent
+  | StageSnapshotUpdatedEvent<StageId, TaskSummary>
+  | TaskProgressUpdatedEvent<StageId>
   | TaskStreamConnectionEvent
   | ViewSelectionChangedEvent<StageId>
   | ResetEvent;
-
-type VersionedEvent<
-  StageId extends string,
-  SessionPhase extends string,
-  TaskSummary extends BaseTaskSummary,
-> = Extract<BuildSessionStateEvent<StageId, SessionPhase, TaskSummary>, { eventVersion: number }>;
 
 type Config<
   StageId extends string,
@@ -193,12 +163,10 @@ type Config<
   stages: readonly StageId[];
   defaultStageId: StageId;
   idlePhase: SessionPhase;
-  activePhases: readonly SessionPhase[];
   resolveTaskStageId: (task: TaskSummary) => StageId;
   isTerminalTaskStatus: (status: TaskSummary['status']) => boolean;
   isRunningTaskStatus: (status: TaskSummary['status']) => boolean;
   isQueuedTaskStatus: (status: TaskSummary['status']) => boolean;
-  isLifecycleActiveFromSessionRecordPhase: (phase: SessionPhase) => boolean;
 };
 
 const assertProgressRange = (value: number): void => {
@@ -207,12 +175,18 @@ const assertProgressRange = (value: number): void => {
   }
 };
 
+const assertFiniteNumber = (value: number, label: string): void => {
+  if (!Number.isFinite(value)) {
+    throw new Error(`[buildSessionStateAtoms] ${label} must be a finite number, received ${value}`);
+  }
+};
+
 export const createBuildSessionStateAtoms = <
   StageId extends string,
   SessionPhase extends string = BuildSessionLifecyclePhase,
   TaskSummary extends BaseTaskSummary = BaseTaskSummary,
 >(config: Config<StageId, SessionPhase, TaskSummary>) => {
-  const createEmptyStage = (stageId: StageId): StageExecutionState<StageId, SessionPhase, TaskSummary> => ({
+  const createEmptyStage = (stageId: StageId): StageExecutionState<StageId, TaskSummary> => ({
     stageId,
     tasksById: {},
     taskOrder: [],
@@ -225,8 +199,8 @@ export const createBuildSessionStateAtoms = <
     },
     progress: {
       value: 0,
-      phase: config.idlePhase,
     },
+    timing: null,
   });
 
   const buildCounters = (tasksById: Record<string, TaskSummary>, taskOrder: string[]): StageCounters => {
@@ -252,18 +226,14 @@ export const createBuildSessionStateAtoms = <
   };
 
   const initialState = (): BuildSessionState<StageId, SessionPhase, TaskSummary> => {
-    const stages = config.stages.reduce<Record<StageId, StageExecutionState<StageId, SessionPhase, TaskSummary>>>((acc, stageId) => {
+    const stages = config.stages.reduce<Record<StageId, StageExecutionState<StageId, TaskSummary>>>((acc, stageId) => {
       acc[stageId] = createEmptyStage(stageId);
       return acc;
-    }, {} as Record<StageId, StageExecutionState<StageId, SessionPhase, TaskSummary>>);
+    }, {} as Record<StageId, StageExecutionState<StageId, TaskSummary>>);
 
     return {
-      meta: {
-        lastAcceptedEventVersion: 0,
-      },
       lifecycle: {
         nodeId: null,
-        sessionId: null,
         phase: config.idlePhase,
         isActive: false,
       },
@@ -282,6 +252,7 @@ export const createBuildSessionStateAtoms = <
     state: BuildSessionState<StageId, SessionPhase, TaskSummary>,
     stageId: StageId,
     tasks: TaskSummary[],
+    timing: StageTiming,
   ): BuildSessionState<StageId, SessionPhase, TaskSummary> => {
     const nextTasksById: Record<string, TaskSummary> = {};
     const nextOrder: string[] = [];
@@ -296,11 +267,12 @@ export const createBuildSessionStateAtoms = <
       nextOrder.push(task.taskId);
     }
     const currentStage = state.execution.stages[stageId];
-    const nextStage: StageExecutionState<StageId, SessionPhase, TaskSummary> = {
+    const nextStage: StageExecutionState<StageId, TaskSummary> = {
       ...currentStage,
       tasksById: nextTasksById,
       taskOrder: nextOrder,
       counters: buildCounters(nextTasksById, nextOrder),
+      timing,
     };
     return {
       ...state,
@@ -313,150 +285,66 @@ export const createBuildSessionStateAtoms = <
       },
     };
   };
-
-  const applyTaskUpsert = (
-    state: BuildSessionState<StageId, SessionPhase, TaskSummary>,
-    stageId: StageId,
-    task: TaskSummary,
-  ): BuildSessionState<StageId, SessionPhase, TaskSummary> => {
-    if (config.resolveTaskStageId(task) !== stageId) {
-      throw new Error(
-        `[buildSessionStateAtoms] task.stage (${String(task.stage)}) does not match target stage (${String(stageId)})`,
-      );
-    }
-    assertProgressRange(task.progress);
-    const currentStage = state.execution.stages[stageId];
-    const hadTask = currentStage.tasksById[task.taskId] !== undefined;
-    const nextTasksById: Record<string, TaskSummary> = {
-      ...currentStage.tasksById,
-      [task.taskId]: task,
-    };
-    const nextOrder = hadTask ? currentStage.taskOrder : [...currentStage.taskOrder, task.taskId];
-    const nextStage: StageExecutionState<StageId, SessionPhase, TaskSummary> = {
-      ...currentStage,
-      tasksById: nextTasksById,
-      taskOrder: nextOrder,
-      counters: buildCounters(nextTasksById, nextOrder),
-    };
-    return {
-      ...state,
-      execution: {
-        ...state.execution,
-        stages: {
-          ...state.execution.stages,
-          [stageId]: nextStage,
-        },
-      },
-    };
-  };
-
-  const applyTaskDelete = (
-    state: BuildSessionState<StageId, SessionPhase, TaskSummary>,
-    stageId: StageId,
-    taskId: string,
-  ): BuildSessionState<StageId, SessionPhase, TaskSummary> => {
-    const currentStage = state.execution.stages[stageId];
-    if (!currentStage.tasksById[taskId]) return state;
-    const nextTasksById = { ...currentStage.tasksById };
-    delete nextTasksById[taskId];
-    const nextOrder = currentStage.taskOrder.filter((id) => id !== taskId);
-    const nextStage: StageExecutionState<StageId, SessionPhase, TaskSummary> = {
-      ...currentStage,
-      tasksById: nextTasksById,
-      taskOrder: nextOrder,
-      counters: buildCounters(nextTasksById, nextOrder),
-    };
-    return {
-      ...state,
-      execution: {
-        ...state.execution,
-        stages: {
-          ...state.execution.stages,
-          [stageId]: nextStage,
-        },
-      },
-    };
-  };
-
-  const acceptEvent = (
-    state: BuildSessionState<StageId, SessionPhase, TaskSummary>,
-    eventVersion: number,
-  ): BuildSessionState<StageId, SessionPhase, TaskSummary> | null => {
-    if (eventVersion <= state.meta.lastAcceptedEventVersion) {
-      return null;
-    }
-    return {
-      ...state,
-      meta: {
-        ...state.meta,
-        lastAcceptedEventVersion: eventVersion,
-      },
-    };
-  };
-
-  const hasEventVersion = (
-    event: BuildSessionStateEvent<StageId, SessionPhase, TaskSummary>,
-  ): event is VersionedEvent<StageId, SessionPhase, TaskSummary> => (
-    'eventVersion' in event
-  );
 
   const reduceBuildSessionState = (
     state: BuildSessionState<StageId, SessionPhase, TaskSummary>,
     event: BuildSessionStateEvent<StageId, SessionPhase, TaskSummary>,
   ): BuildSessionState<StageId, SessionPhase, TaskSummary> => {
-    const accepted = hasEventVersion(event)
-      ? acceptEvent(state, event.eventVersion)
-      : state;
-    if (!accepted) return state;
     switch (event.type) {
       case 'reset':
         return initialState();
-      case 'runtimeSnapshotReceived':
+
+      case 'sessionStatusUpdated':
         return {
-          ...accepted,
+          ...state,
           lifecycle: {
-            ...accepted.lifecycle,
+            ...state.lifecycle,
             nodeId: event.payload.nodeId,
-            sessionId: event.payload.sessionId ?? accepted.lifecycle.sessionId,
             phase: event.payload.phase,
             isActive: event.payload.isActive,
-            startedAt: event.payload.startedAt ?? accepted.lifecycle.startedAt,
-            heartbeatAt: event.payload.heartbeatAt ?? accepted.lifecycle.heartbeatAt,
-            completedAt: event.payload.completedAt ?? accepted.lifecycle.completedAt,
+            startedAt: event.payload.startedAt ?? state.lifecycle.startedAt,
+            completedAt: event.payload.completedAt ?? state.lifecycle.completedAt,
+            stopReason: event.payload.stopReason ?? state.lifecycle.stopReason,
           },
         };
-      case 'sessionRecordReceived':
+
+      case 'heartbeat': {
+        assertFiniteNumber(event.payload.heartbeatAt, 'heartbeatAt');
         return {
-          ...accepted,
+          ...state,
           lifecycle: {
-            ...accepted.lifecycle,
-            nodeId: event.payload.nodeId,
-            phase: event.payload.phase,
-            isActive: config.isLifecycleActiveFromSessionRecordPhase(event.payload.phase),
-            startedAt: event.payload.startedAt ?? accepted.lifecycle.startedAt,
-            heartbeatAt: event.payload.heartbeatAt ?? accepted.lifecycle.heartbeatAt,
-            completedAt: event.payload.completedAt ?? accepted.lifecycle.completedAt,
+            ...state.lifecycle,
+            heartbeatAt: event.payload.heartbeatAt,
           },
         };
-      case 'taskSnapshotReceived':
-        return applyStageSnapshot(accepted, event.payload.stageId, event.payload.tasks);
-      case 'taskUpdated':
-        return applyTaskUpsert(accepted, event.payload.stageId, event.payload.task);
-      case 'taskDeleted':
-        return applyTaskDelete(accepted, event.payload.stageId, event.payload.taskId);
-      case 'progressReceived':
+      }
+
+      case 'stageSnapshotUpdated': {
+        assertFiniteNumber(event.payload.stageStartedAt, 'stageStartedAt');
+        assertFiniteNumber(event.payload.stageInactiveMs, 'stageInactiveMs');
+        if (event.payload.stageCompletedAt !== undefined) {
+          assertFiniteNumber(event.payload.stageCompletedAt, 'stageCompletedAt');
+        }
+        const timing: StageTiming = {
+          stageStartedAt: event.payload.stageStartedAt,
+          stageInactiveMs: event.payload.stageInactiveMs,
+          stageCompletedAt: event.payload.stageCompletedAt,
+        };
+        return applyStageSnapshot(state, event.payload.stageId, event.payload.tasks, timing);
+      }
+
+      case 'taskProgressUpdated':
         assertProgressRange(event.payload.value);
         return {
-          ...accepted,
+          ...state,
           execution: {
-            ...accepted.execution,
+            ...state.execution,
             stages: {
-              ...accepted.execution.stages,
+              ...state.execution.stages,
               [event.payload.stageId]: {
-                ...accepted.execution.stages[event.payload.stageId],
+                ...state.execution.stages[event.payload.stageId],
                 progress: {
                   value: event.payload.value,
-                  phase: event.payload.phase,
                   message: event.payload.message,
                   metadata: event.payload.metadata,
                 },
@@ -464,24 +352,27 @@ export const createBuildSessionStateAtoms = <
             },
           },
         };
+
       case 'taskStreamConnectionChanged':
         return {
-          ...accepted,
+          ...state,
           execution: {
-            ...accepted.execution,
+            ...state.execution,
             taskStreamConnected: event.payload.connected,
           },
         };
+
       case 'viewSelectionChanged':
         return {
-          ...accepted,
+          ...state,
           view: {
-            activeStageId: event.payload.activeStageId ?? accepted.view.activeStageId,
-            selectedTaskId: event.payload.selectedTaskId ?? accepted.view.selectedTaskId,
+            activeStageId: event.payload.activeStageId ?? state.view.activeStageId,
+            selectedTaskId: event.payload.selectedTaskId ?? state.view.selectedTaskId,
           },
         };
+
       default:
-        return accepted;
+        return state;
     }
   };
 
@@ -504,8 +395,7 @@ export const createBuildSessionStateAtoms = <
 
   const buildSessionStartButtonLoadingAtom = atom((get) => {
     const state = get(buildSessionStateAtom);
-    const lifecycleActive = config.activePhases.includes(state.lifecycle.phase);
-    if (!lifecycleActive) return false;
+    if (!state.lifecycle.isActive) return false;
     return !state.execution.taskStreamConnected;
   });
 

--- a/packages/ui/build-sessions/src/state/createBuildSessionWorkerEventAdapter.ts
+++ b/packages/ui/build-sessions/src/state/createBuildSessionWorkerEventAdapter.ts
@@ -7,27 +7,19 @@ import type {
 import type { BuildSessionStateEvent } from './createBuildSessionStateAtoms.js';
 
 type RuntimeLike = BuildSessionRuntimeRecord;
-type TaskEventLike = BuildTaskUpdateEvent;
 type ProgressLike = BuildProgressEvent;
 
-type AdapterConfig<StageId extends string, SessionPhase extends string, TaskSummary extends BuildTaskSummary> = {
-  deleteEventTargetStages: readonly StageId[];
+type AdapterConfig<StageId extends string, SessionPhase extends string> = {
+  stages: readonly StageId[];
   resolveStageId: (value: unknown) => StageId;
   mapRuntimeStatusToPhase: (status: RuntimeLike['status']) => SessionPhase;
-  mapProgressPhaseToSessionPhase: (phase: ProgressLike['phase']) => SessionPhase;
   mapSessionRecordStatusToPhase: (status: unknown) => SessionPhase;
-  resolveRuntimeEventVersion: (record: RuntimeLike) => number;
-  resolveSessionRecordEventVersion: (sessionRecord: Record<string, unknown>) => number;
-  resolveTaskSnapshotEventVersion: (event: TaskEventLike) => number;
-  resolveTaskUpdateEventVersion: (task: TaskSummary) => number;
-  resolveTaskDeleteEventVersion: (event: TaskEventLike) => number;
-  resolveProgressEventVersion: (event: ProgressLike) => number;
-  resolveHeartbeatEventVersion: (event: { nodeId: string; heartbeatAt?: number }) => number;
+  isActivePhase: (phase: SessionPhase) => boolean;
   resolveProgressValue: (event: ProgressLike) => number;
 };
 
-type Dispatch<StageId extends string, SessionPhase extends string, TaskSummary extends BuildTaskSummary> = (
-  event: BuildSessionStateEvent<StageId, SessionPhase, TaskSummary>,
+type Dispatch<StageId extends string, SessionPhase extends string> = (
+  event: BuildSessionStateEvent<StageId, SessionPhase, BuildTaskSummary>,
 ) => void;
 
 export type BuildSessionWorkerEventAdapter = {
@@ -59,154 +51,128 @@ const asOptionalFiniteNumber = (value: unknown): number | undefined => {
   return value;
 };
 
+const requireFiniteNumber = (value: unknown, label: string): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`[buildSessionWorkerEventAdapter] ${label} must be a finite number, received ${String(value)}`);
+  }
+  return value;
+};
+
 export const createBuildSessionWorkerEventAdapter = <
   StageId extends string,
   SessionPhase extends string,
-  TaskSummary extends BuildTaskSummary = BuildTaskSummary,
 >(
   nodeId: string,
-  dispatch: Dispatch<StageId, SessionPhase, TaskSummary>,
-  config: AdapterConfig<StageId, SessionPhase, TaskSummary>,
+  dispatch: Dispatch<StageId, SessionPhase>,
+  config: AdapterConfig<StageId, SessionPhase>,
 ): BuildSessionWorkerEventAdapter => {
-  const dispatchRuntimeSnapshot = (params: {
-    eventVersion: number;
-    nodeId: string;
-    sessionId?: string;
-    phase: SessionPhase;
-    isActive: boolean;
-    startedAt?: number;
-    heartbeatAt?: number;
-    completedAt?: number;
-  }) => {
-    const { eventVersion, ...payload } = params;
-    dispatch({
-      type: 'runtimeSnapshotReceived',
-      eventVersion,
-      payload,
-    });
-  };
-
   return {
     onRuntimeRecord: (record) => {
       if (String(record.nodeId) !== String(nodeId)) return;
-      dispatchRuntimeSnapshot({
-        eventVersion: config.resolveRuntimeEventVersion(record),
-        nodeId: String(record.nodeId),
-        sessionId: String(record.nodeId),
-        phase: config.mapRuntimeStatusToPhase(record.status),
-        isActive: record.isActive,
-        startedAt: record.startedAt,
-        heartbeatAt: record.lastHeartbeatAt,
-        completedAt: record.completedAt,
+      const phase = config.mapRuntimeStatusToPhase(record.status);
+      dispatch({
+        type: 'sessionStatusUpdated',
+        payload: {
+          nodeId: String(record.nodeId),
+          phase,
+          isActive: record.isActive,
+          startedAt: record.startedAt,
+          completedAt: record.completedAt,
+        },
       });
     },
+
     onSessionState: (event) => {
       if (String(event.nodeId) !== String(nodeId)) return;
       const sessionRecord = event.sessionRecord;
       if (!sessionRecord || typeof sessionRecord !== 'object') return;
-      const rawStageId = (sessionRecord as { stageId?: unknown }).stageId;
+      const phase = config.mapSessionRecordStatusToPhase((sessionRecord as { status?: unknown }).status);
+      const stopReason = (sessionRecord as { stopReason?: unknown }).stopReason;
       dispatch({
-        type: 'sessionRecordReceived',
-        eventVersion: config.resolveSessionRecordEventVersion(sessionRecord),
+        type: 'sessionStatusUpdated',
         payload: {
           nodeId: String(event.nodeId),
-          phase: config.mapSessionRecordStatusToPhase((sessionRecord as { status?: unknown }).status),
-          completedAt: asOptionalFiniteNumber((sessionRecord as { completedAt?: unknown }).completedAt),
-          heartbeatAt: asOptionalFiniteNumber((sessionRecord as { stageHeartbeatAt?: unknown }).stageHeartbeatAt),
+          phase,
+          isActive: config.isActivePhase(phase),
           startedAt: asOptionalFiniteNumber((sessionRecord as { startedAt?: unknown }).startedAt),
-          stageId: rawStageId === undefined ? undefined : config.resolveStageId(rawStageId),
-          stopReason: typeof (sessionRecord as { stopReason?: unknown }).stopReason === 'string'
-            ? (sessionRecord as { stopReason?: string }).stopReason
-            : undefined,
-          inactiveMs: asOptionalFiniteNumber((sessionRecord as { inactiveMs?: unknown }).inactiveMs),
-          stageStartedAt: asOptionalFiniteNumber((sessionRecord as { stageStartedAt?: unknown }).stageStartedAt),
-          stageInactiveMs: asOptionalFiniteNumber((sessionRecord as { stageInactiveMs?: unknown }).stageInactiveMs),
+          completedAt: asOptionalFiniteNumber((sessionRecord as { completedAt?: unknown }).completedAt),
+          stopReason: typeof stopReason === 'string' ? stopReason : undefined,
         },
       });
     },
+
     onTaskEvent: (event) => {
       if (String(event.nodeId) !== String(nodeId)) return;
       if (event.type === 'snapshot') {
-        const baseEventVersion = config.resolveTaskSnapshotEventVersion(event);
-        const grouped = new Map<StageId, TaskSummary[]>();
+        // Group tasks by stage and emit one stageSnapshotUpdated per stage
+        const grouped = new Map<StageId, BuildTaskSummary[]>();
         for (const rawTask of event.tasks) {
-          const task = asTaskSummary(rawTask) as TaskSummary;
+          const task = asTaskSummary(rawTask);
           const stageId = config.resolveStageId(task.stage);
           const current = grouped.get(stageId) ?? [];
           current.push(task);
           grouped.set(stageId, current);
         }
-        let eventVersion = baseEventVersion;
-        for (const stageId of config.deleteEventTargetStages) {
+        // Emit snapshot for all known stages (empty array = zero tasks for that stage)
+        for (const stageId of config.stages) {
           const tasks = grouped.get(stageId) ?? [];
+          // Use max task version as stageStartedAt proxy when not available from event
+          const explicitVersion = (event as { version?: unknown }).version;
+          const stageStartedAt = typeof explicitVersion === 'number' && Number.isFinite(explicitVersion)
+            ? explicitVersion
+            : tasks.length > 0
+              ? tasks.reduce((max, t) => Math.max(max, t.version), Number.MIN_SAFE_INTEGER)
+              : Date.now();
           dispatch({
-            type: 'taskSnapshotReceived',
-            eventVersion,
+            type: 'stageSnapshotUpdated',
             payload: {
               stageId,
               tasks,
-            },
-          });
-          eventVersion += 1;
-        }
-        return;
-      }
-      if (event.type === 'update') {
-        const task = asTaskSummary(event.task) as TaskSummary;
-        dispatch({
-          type: 'taskUpdated',
-          eventVersion: config.resolveTaskUpdateEventVersion(task),
-          payload: {
-            stageId: config.resolveStageId(task.stage),
-            task,
-          },
-        });
-        return;
-      }
-      if (event.type === 'delete') {
-        const eventVersion = config.resolveTaskDeleteEventVersion(event);
-        for (const stageId of config.deleteEventTargetStages) {
-          dispatch({
-            type: 'taskDeleted',
-            eventVersion,
-            payload: {
-              stageId,
-              taskId: event.taskId,
+              stageStartedAt,
+              stageInactiveMs: 0,
+              stageCompletedAt: undefined,
             },
           });
         }
+        return;
       }
+      // 'update' and 'delete' events are not supported in the new design.
+      // The Worker always sends full snapshots; incremental updates are not used.
+      throw new Error(
+        `[buildSessionWorkerEventAdapter] unexpected task event type: ${String((event as { type: unknown }).type)}. Only 'snapshot' is supported.`,
+      );
     },
+
     onProgressEvent: (event) => {
       if (String(event.nodeId) !== String(nodeId)) return;
       const payload = event.payload as Record<string, unknown> | undefined;
       dispatch({
-        type: 'progressReceived',
-        eventVersion: config.resolveProgressEventVersion(event),
+        type: 'taskProgressUpdated',
         payload: {
           stageId: config.resolveStageId(event.stage),
           value: config.resolveProgressValue(event),
-          phase: config.mapProgressPhaseToSessionPhase(event.phase),
           message: event.message,
           metadata: payload?.meta as Record<string, unknown> | undefined,
         },
       });
     },
+
     onTaskStreamConnectionChanged: (connected) => {
       dispatch({
         type: 'taskStreamConnectionChanged',
         payload: { connected },
       });
     },
+
     onHeartbeat: (event) => {
       if (String(event.nodeId) !== String(nodeId)) return;
-      dispatchRuntimeSnapshot({
-        eventVersion: config.resolveHeartbeatEventVersion(event),
-        nodeId: String(nodeId),
-        sessionId: String(nodeId),
-        phase: config.mapRuntimeStatusToPhase('running'),
-        isActive: true,
-        heartbeatAt: event.heartbeatAt,
+      const heartbeatAt = requireFiniteNumber(event.heartbeatAt, 'heartbeatAt');
+      dispatch({
+        type: 'heartbeat',
+        payload: {
+          nodeId: String(nodeId),
+          heartbeatAt,
+        },
       });
     },
   };

--- a/plugins/location-plugin/src/ui/components/steps/useLocationSelectionStep.ts
+++ b/plugins/location-plugin/src/ui/components/steps/useLocationSelectionStep.ts
@@ -86,14 +86,13 @@ export const useLocationSelectionStep = ({ draft, onUpdate, buildSelectionRecord
   }, [draft.ideGsmFileName, draft.ideGsmSources, draft.tabularSourceId]);
   const [availabilityByCountry, setAvailabilityByCountry] = useState<Record<string, boolean[]>>({});
   const parseInFlightRef = useRef(false);
+  // Tracks whether the initial auto-selection from availability has already been applied.
+  // Once set, user interactions (including deselect-all) must not be overwritten by re-parsing.
+  const initializedRef = useRef(false);
   const typeIndex = useMemo(
     () => new Map(BASE_LOCATION_TYPES.map((type, index) => [type.id, index])),
     [],
   );
-
-  const hasSelection = useMemo(() => (
-    Object.values(selectionByCountries).some((row) => Array.isArray(row) && row.some(Boolean))
-  ), [selectionByCountries]);
 
   const hasAvailability = useMemo(
     () => Object.keys(availabilityByCountry).length > 0,
@@ -105,7 +104,8 @@ export const useLocationSelectionStep = ({ draft, onUpdate, buildSelectionRecord
     const sources = ideGsmSources.filter((source) => source.tabularSourceId);
     if (sources.length === 0) return;
     if (parseInFlightRef.current) return;
-    if (hasSelection && hasAvailability) return;
+    // Skip if availability is already parsed; re-parsing must not overwrite user interactions.
+    if (hasAvailability) return;
     parseInFlightRef.current = true;
     const run = async () => {
       try {
@@ -120,7 +120,9 @@ export const useLocationSelectionStep = ({ draft, onUpdate, buildSelectionRecord
         const points = parsedList.flatMap((parsed) => parsed.points);
         const availabilityMap = buildAvailabilityMapFromIdeGsmPoints(points, BASE_LOCATION_TYPES);
         setAvailabilityByCountry(availabilityMap);
-        if (!hasSelection) {
+        // Apply initial auto-selection only once; subsequent user changes must not be overwritten.
+        if (!initializedRef.current) {
+          initializedRef.current = true;
           const selectionMap = buildSelectionMapFromAvailability(availabilityMap);
           onUpdate({ selectedArrayByCountries: selectionMap });
         }
@@ -139,10 +141,8 @@ export const useLocationSelectionStep = ({ draft, onUpdate, buildSelectionRecord
   }, [
     draft.dataSource,
     hasAvailability,
-    hasSelection,
     ideGsmSources,
     onUpdate,
-    selectionByCountries,
     t,
     tabularApi,
   ]);

--- a/plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts
+++ b/plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts
@@ -4,28 +4,15 @@ import type { ShapeBuildStopReason } from '@hierarchidb/shape-api';
 import type { TaskListViewPhase } from './shapeBuildProgressTypes';
 import type { BuildStatus } from '@hierarchidb/ui-build-progress/build-status';
 import {
-  createBuildSessionStateTreeAtoms,
-  type BuildSessionStateTreeEvent,
-  type BuildSessionTaskItem,
-  type BuildSessionTaskStatus,
-  type BuildSessionStateTreeLifecyclePhase,
+  createBuildSessionStateAtoms,
+  type BuildSessionLifecyclePhase,
+  type BuildSessionStateEvent,
 } from '@hierarchidb/ui-build-sessions';
-import type { BuildSessionLifecyclePhase } from '@hierarchidb/ui-build-sessions';
 
 export type ShapeStageId = 'source' | 'geometry' | 'tileEmit';
 export type ShapeSessionPhase = BuildSessionLifecyclePhase;
 type ShapeTaskSummary = BuildTaskSummary;
-type ShapeStateTreeEvent = BuildSessionStateTreeEvent<ShapeStageId>;
-
-const shapeStateTree = createBuildSessionStateTreeAtoms<ShapeStageId>({
-  nodeId: '',
-  stageIds: ['source', 'geometry', 'tileEmit'] as const,
-  defaultActiveStageId: 'source',
-  initialSession: {
-    phase: 'idle',
-    isActive: false,
-  },
-});
+type ShapeStateEvent = BuildSessionStateEvent<ShapeStageId, ShapeSessionPhase, ShapeTaskSummary>;
 
 const resolveShapeStageId = (value: unknown): ShapeStageId => {
   if (value === 'source' || value === 'geometry' || value === 'tileEmit') {
@@ -41,43 +28,6 @@ const assertProgressRange = (value: number): number => {
   return value;
 };
 
-const mapSessionPhaseToTreePhase = (
-  phase: ShapeSessionPhase,
-): BuildSessionStateTreeLifecyclePhase => {
-  if (phase === 'idle') return 'idle';
-  if (phase === 'starting') return 'starting';
-  if (phase === 'running') return 'running';
-  if (phase === 'pausing') return 'pausing';
-  if (phase === 'paused') return 'paused';
-  if (phase === 'resuming') return 'resuming';
-  if (phase === 'finalizing') return 'finalizing';
-  if (phase === 'completed') return 'completed';
-  if (phase === 'failed') return 'failed';
-  throw new Error(`[shape buildSessionStateAtoms] unsupported lifecycle phase: ${String(phase)}`);
-};
-
-const mapBuildStatusToTreeTaskStatus = (
-  status: BuildTaskSummary['status'],
-): BuildSessionTaskStatus => {
-  if (status === 'queued') return 'queued';
-  if (status === 'running') return 'running';
-  if (status === 'completed') return 'completed';
-  if (status === 'failed') return 'failed';
-  if (status === 'recycled') return 'recycled';
-  throw new Error(`[shape buildSessionStateAtoms] unsupported task status for state-tree: ${String(status)}`);
-};
-
-const mapTreeTaskStatusToBuildStatus = (
-  status: BuildSessionTaskStatus,
-): BuildTaskSummary['status'] => {
-  if (status === 'queued') return 'queued';
-  if (status === 'running') return 'running';
-  if (status === 'completed') return 'completed';
-  if (status === 'failed') return 'failed';
-  if (status === 'recycled') return 'recycled';
-  throw new Error(`[shape buildSessionStateAtoms] unsupported task status for legacy state: ${String(status)}`);
-};
-
 const isActivePhase = (phase: ShapeSessionPhase): boolean => (
   phase === 'starting'
   || phase === 'running'
@@ -86,15 +36,24 @@ const isActivePhase = (phase: ShapeSessionPhase): boolean => (
   || phase === 'finalizing'
 );
 
+// --- createBuildSessionStateAtoms instance ---
+
+const shapeSessionAtoms = createBuildSessionStateAtoms<ShapeStageId, ShapeSessionPhase, ShapeTaskSummary>({
+  stages: ['source', 'geometry', 'tileEmit'] as const,
+  defaultStageId: 'source',
+  idlePhase: 'idle',
+  resolveTaskStageId: (task) => resolveShapeStageId(task.stage),
+  isTerminalTaskStatus: (status) => (
+    status === 'completed' || status === 'failed' || status === 'recycled'
+  ),
+  isRunningTaskStatus: (status) => status === 'running',
+  isQueuedTaskStatus: (status) => status === 'queued',
+});
+
+// --- Lifecycle extras (stopReason, criticalError) ---
+
 type LifecycleExtras = {
-  startedAt?: number;
-  heartbeatAt?: number;
-  completedAt?: number;
-  stageId?: ShapeStageId;
   stopReason?: ShapeBuildStopReason;
-  inactiveMs?: number;
-  stageStartedAt?: number;
-  stageInactiveMs?: number;
   criticalError?: {
     message: string;
     error: string;
@@ -103,26 +62,9 @@ type LifecycleExtras = {
   };
 };
 
-type StageProgress = {
-  value: number;
-  phase: ShapeSessionPhase;
-  message?: string;
-  metadata?: Record<string, unknown>;
-};
-
 type StageUiSyncPhase = 'ui-initializing' | 'running';
 
-const initialLifecycleExtras = (): LifecycleExtras => ({
-  startedAt: undefined,
-  heartbeatAt: undefined,
-  completedAt: undefined,
-});
-
-const initialStageProgress = (): Record<ShapeStageId, StageProgress> => ({
-  source: { value: 0, phase: 'idle' },
-  geometry: { value: 0, phase: 'idle' },
-  tileEmit: { value: 0, phase: 'idle' },
-});
+const initialLifecycleExtras = (): LifecycleExtras => ({});
 
 const initialUiSyncPhaseByStage = (): Record<ShapeStageId, StageUiSyncPhase> => ({
   source: 'ui-initializing',
@@ -131,94 +73,52 @@ const initialUiSyncPhaseByStage = (): Record<ShapeStageId, StageUiSyncPhase> => 
 });
 
 const lifecycleExtrasAtom = atom<LifecycleExtras>(initialLifecycleExtras());
-const stageProgressAtom = atom<Record<ShapeStageId, StageProgress>>(initialStageProgress());
-const taskStreamConnectedAtom = atom(false);
 const uiSyncPhaseByStageAtom = atom<Record<ShapeStageId, StageUiSyncPhase>>(initialUiSyncPhaseByStage());
 
-const toTaskItem = (task: BuildTaskSummary): BuildSessionTaskItem<ShapeStageId> => ({
-  taskId: task.taskId,
-  version: task.version,
-  stage: resolveShapeStageId(task.stage),
-  status: mapBuildStatusToTreeTaskStatus(task.status),
-  progress: assertProgressRange(task.progress),
-  index: typeof task.sequence === 'number' ? task.sequence : Number.MAX_SAFE_INTEGER,
-  message: (() => {
-    const value = (task as unknown as { title?: unknown }).title;
-    return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
-  })(),
-  display: task.display,
-  metadata: task.metadata,
-});
+// --- Canonical 4-event types (Worker → UI) ---
 
-type ShapeRuntimeSnapshotEvent = {
-  type: 'runtimeSnapshotReceived';
-  eventVersion: number;
+type ShapeSessionStatusUpdatedEvent = {
+  type: 'sessionStatusUpdated';
   payload: {
     nodeId: string;
-    sessionId?: string;
     phase: ShapeSessionPhase;
     isActive: boolean;
     startedAt?: number;
-    heartbeatAt?: number;
     completedAt?: number;
+    stopReason?: ShapeBuildStopReason;
   };
 };
 
-type ShapeSessionRecordEvent = {
-  type: 'sessionRecordReceived';
-  eventVersion: number;
+type ShapeHeartbeatEvent = {
+  type: 'heartbeat';
   payload: {
     nodeId: string;
-    phase: ShapeSessionPhase;
-    completedAt?: number;
-    heartbeatAt?: number;
-    startedAt?: number;
-    stageId?: ShapeStageId;
-    stopReason?: ShapeBuildStopReason;
-    inactiveMs?: number;
-    stageStartedAt?: number;
-    stageInactiveMs?: number;
+    heartbeatAt: number;
   };
 };
 
-type ShapeTaskSnapshotEvent = {
-  type: 'taskSnapshotReceived';
-  eventVersion: number;
+type ShapeStageSnapshotUpdatedEvent = {
+  type: 'stageSnapshotUpdated';
   payload: {
     stageId: ShapeStageId;
     tasks: ShapeTaskSummary[];
+    stageStartedAt: number;
+    stageInactiveMs: number;
+    stageCompletedAt?: number;
   };
 };
 
-type ShapeTaskUpdatedEvent = {
-  type: 'taskUpdated';
-  eventVersion: number;
-  payload: {
-    stageId: ShapeStageId;
-    task: ShapeTaskSummary;
-  };
-};
-
-type ShapeTaskDeletedEvent = {
-  type: 'taskDeleted';
-  eventVersion: number;
-  payload: {
-    stageId: ShapeStageId;
-    taskId: string;
-  };
-};
-
-type ShapeProgressEvent = {
-  type: 'progressReceived';
-  eventVersion: number;
+type ShapeTaskProgressUpdatedEvent = {
+  type: 'taskProgressUpdated';
   payload: {
     stageId: ShapeStageId;
     value: number;
-    phase: ShapeSessionPhase;
     message?: string;
     metadata?: Record<string, unknown>;
   };
 };
+
+// --- UI-internal events ---
 
 type ShapeTaskStreamConnectionEvent = {
   type: 'taskStreamConnectionChanged';
@@ -260,50 +160,138 @@ type ShapeResetEvent = {
 };
 
 export type ShapeBuildSessionStateEvent =
-  | ShapeRuntimeSnapshotEvent
-  | ShapeSessionRecordEvent
-  | ShapeTaskSnapshotEvent
-  | ShapeTaskUpdatedEvent
-  | ShapeTaskDeletedEvent
-  | ShapeProgressEvent
+  | ShapeSessionStatusUpdatedEvent
+  | ShapeHeartbeatEvent
+  | ShapeStageSnapshotUpdatedEvent
+  | ShapeTaskProgressUpdatedEvent
   | ShapeTaskStreamConnectionEvent
   | ShapeViewSelectionChangedEvent
   | ShapeUiSyncPhaseChangedEvent
   | ShapeCriticalErrorEvent
   | ShapeResetEvent;
 
-const dispatchTreeEventAtom = shapeStateTree.dispatchBuildSessionStateTreeEventAtom;
 type ShapeBuildSessionNonResetEvent = Exclude<ShapeBuildSessionStateEvent, ShapeResetEvent>;
 
+// --- Derived read atoms ---
+
 export const buildSessionRuntimeAtom = atom((get) => {
-  const tree = get(shapeStateTree.buildSessionStateTreeAtom);
-  const lifecycleExtras = get(lifecycleExtrasAtom);
+  const state = get(shapeSessionAtoms.buildSessionStateAtom);
+  const extras = get(lifecycleExtrasAtom);
   return {
-    phase: tree.session.phase as ShapeSessionPhase,
-    isActive: tree.session.isActive,
-    activeStageId: tree.ui.activeStageId,
-    lastAcceptedEventVersion: tree.meta.lastAcceptedEventVersion,
-    startedAt: lifecycleExtras.startedAt,
-    heartbeatAt: lifecycleExtras.heartbeatAt,
-    completedAt: lifecycleExtras.completedAt,
-    stageId: lifecycleExtras.stageId,
-    stopReason: lifecycleExtras.stopReason,
-    inactiveMs: lifecycleExtras.inactiveMs,
-    stageStartedAt: lifecycleExtras.stageStartedAt,
-    stageInactiveMs: lifecycleExtras.stageInactiveMs,
-    criticalError: lifecycleExtras.criticalError,
+    phase: state.lifecycle.phase,
+    isActive: state.lifecycle.isActive,
+    activeStageId: state.view.activeStageId,
+    startedAt: state.lifecycle.startedAt,
+    heartbeatAt: state.lifecycle.heartbeatAt,
+    completedAt: state.lifecycle.completedAt,
+    criticalError: extras.criticalError,
+    stopReason: extras.stopReason,
   };
 });
 
-export const buildSessionTaskStreamConnectedAtom = atom((get) => get(taskStreamConnectedAtom));
+export const buildSessionTaskStreamConnectedAtom = atom((get) => (
+  get(shapeSessionAtoms.buildSessionStateAtom).execution.taskStreamConnected
+));
+
+export const buildSessionStartButtonLoadingAtom = shapeSessionAtoms.buildSessionStartButtonLoadingAtom;
+
+export const buildSessionStageCountersAtom = shapeSessionAtoms.buildSessionStageCountersAtom;
+
+export const buildSessionTasksByStageAtom = atom<Record<ShapeStageId, BuildTaskSummary[]>>((get) => {
+  const state = get(shapeSessionAtoms.buildSessionStateAtom);
+  const toSummary = (stageId: ShapeStageId): BuildTaskSummary[] => {
+    const stage = state.execution.stages[stageId];
+    return stage.taskOrder
+      .map((taskId) => stage.tasksById[taskId])
+      .filter((task): task is ShapeTaskSummary => task !== undefined);
+  };
+  return {
+    source: toSummary('source'),
+    geometry: toSummary('geometry'),
+    tileEmit: toSummary('tileEmit'),
+  };
+});
+
+export const buildSessionStageProgressAtom = atom<Record<ShapeStageId, number>>((get) => {
+  const state = get(shapeSessionAtoms.buildSessionStateAtom);
+  return {
+    source: state.execution.stages.source.progress.value,
+    geometry: state.execution.stages.geometry.progress.value,
+    tileEmit: state.execution.stages.tileEmit.progress.value,
+  };
+});
+
+// --- Stage timing (derived from stageSnapshotUpdated, stored in execution.stages[x].timing) ---
+
+export const stageTimingByStageAtom = atom((get) => {
+  const state = get(shapeSessionAtoms.buildSessionStateAtom);
+  return {
+    source: state.execution.stages.source.timing,
+    geometry: state.execution.stages.geometry.timing,
+    tileEmit: state.execution.stages.tileEmit.timing,
+  };
+});
+
+const computeStageDuration = (
+  timing: { stageStartedAt: number; stageInactiveMs: number; stageCompletedAt?: number } | null,
+  now: number,
+): number => {
+  if (!timing) return 0;
+  const end = timing.stageCompletedAt ?? now;
+  return Math.max(0, end - timing.stageStartedAt - timing.stageInactiveMs);
+};
+
+// Derived atom: computed from stageTimingByStageAtom + elapsedTickMsAtom
+export const stageDurationMsByStageAtom = atom<Record<ShapeStageId, number>>((get) => {
+  const timing = get(stageTimingByStageAtom);
+  const now = get(elapsedTickMsAtom);
+  return {
+    source: computeStageDuration(timing.source, now),
+    geometry: computeStageDuration(timing.geometry, now),
+    tileEmit: computeStageDuration(timing.tileEmit, now),
+  };
+});
+
+// --- UiSyncPhase ---
+
+export const buildSessionSnapshotHandshakeReceivedAtom = atom<boolean>((get) => {
+  const uiSyncByStage = get(uiSyncPhaseByStageAtom);
+  return (
+    uiSyncByStage.source === 'running'
+    || uiSyncByStage.geometry === 'running'
+    || uiSyncByStage.tileEmit === 'running'
+  );
+});
+
+export const buildSessionTaskListViewPhaseAtom = atom<TaskListViewPhase>((get) => {
+  const runtime = get(buildSessionRuntimeAtom);
+  const state = get(shapeSessionAtoms.buildSessionStateAtom);
+  const uiSyncByStage = get(uiSyncPhaseByStageAtom);
+  const activeStageUiSyncPhase = uiSyncByStage[state.view.activeStageId];
+  const tasksByStage = get(buildSessionTasksByStageAtom);
+  const totalTasks = (
+    tasksByStage.source.length
+    + tasksByStage.geometry.length
+    + tasksByStage.tileEmit.length
+  );
+  if (totalTasks > 0) return 'streaming';
+  if (runtime.phase === 'idle') return 'idle';
+  if (isActivePhase(runtime.phase)) {
+    if (activeStageUiSyncPhase === 'ui-initializing') {
+      return 'ui-initializing';
+    }
+    return 'streaming';
+  }
+  return 'settledEmpty';
+});
+
+// --- Reset ---
 
 const resetBuildSessionStateAtom = atom(
   null,
   (_get, set) => {
-    set(dispatchTreeEventAtom, { type: 'reset' });
+    set(shapeSessionAtoms.dispatchBuildSessionEventAtom, { type: 'reset' });
     set(lifecycleExtrasAtom, initialLifecycleExtras());
-    set(stageProgressAtom, initialStageProgress());
-    set(taskStreamConnectedAtom, false);
     set(uiSyncPhaseByStageAtom, initialUiSyncPhaseByStage());
     set(pendingUserActionBaseAtom, 'none');
     set(elapsedTickMsBaseAtom, Date.now());
@@ -313,159 +301,116 @@ const resetBuildSessionStateAtom = atom(
   },
 );
 
+// --- Event dispatch ---
+
 const applyBuildSessionEventAtom = atom(
   null,
-  (get, set, event: ShapeBuildSessionNonResetEvent) => {
-
-    const beforeVersion = get(shapeStateTree.buildSessionStateTreeAtom).meta.lastAcceptedEventVersion;
-    const dispatchTreeEvent = (treeEvent: ShapeStateTreeEvent): boolean => {
-      set(dispatchTreeEventAtom, treeEvent);
-      const afterVersion = get(shapeStateTree.buildSessionStateTreeAtom).meta.lastAcceptedEventVersion;
-      return afterVersion > beforeVersion;
-    };
-
+  (_get, set, event: ShapeBuildSessionNonResetEvent) => {
     switch (event.type) {
-      case 'runtimeSnapshotReceived': {
-        const accepted = dispatchTreeEvent({
-          type: 'sessionPatched',
-          eventVersion: event.eventVersion,
+      case 'sessionStatusUpdated': {
+        const stateEvent: ShapeStateEvent = {
+          type: 'sessionStatusUpdated',
           payload: {
-            phase: mapSessionPhaseToTreePhase(event.payload.phase),
-            isActive: event.payload.isActive,
-          },
-        });
-        if (!accepted) return;
-        set(lifecycleExtrasAtom, (current) => ({
-          ...current,
-          startedAt: event.payload.startedAt ?? current.startedAt,
-          heartbeatAt: event.payload.heartbeatAt ?? current.heartbeatAt,
-          completedAt: event.payload.completedAt ?? current.completedAt,
-        }));
-        return;
-      }
-      case 'sessionRecordReceived': {
-        const accepted = dispatchTreeEvent({
-          type: 'sessionPatched',
-          eventVersion: event.eventVersion,
-          payload: {
-            phase: mapSessionPhaseToTreePhase(event.payload.phase),
-            isActive: isActivePhase(event.payload.phase),
-          },
-        });
-        if (!accepted) return;
-        set(lifecycleExtrasAtom, (current) => ({
-          ...current,
-          startedAt: event.payload.startedAt ?? current.startedAt,
-          heartbeatAt: event.payload.heartbeatAt ?? current.heartbeatAt,
-          completedAt: event.payload.completedAt ?? current.completedAt,
-          stageId: event.payload.stageId ?? current.stageId,
-          stopReason: event.payload.stopReason ?? current.stopReason,
-          inactiveMs: event.payload.inactiveMs ?? current.inactiveMs,
-          stageStartedAt: event.payload.stageStartedAt ?? current.stageStartedAt,
-          stageInactiveMs: event.payload.stageInactiveMs ?? current.stageInactiveMs,
-        }));
-        return;
-      }
-      case 'taskSnapshotReceived': {
-        dispatchTreeEvent({
-          type: 'tasksReplaced',
-          eventVersion: event.eventVersion,
-          payload: {
-            stageId: event.payload.stageId,
-            tasks: event.payload.tasks.map(toTaskItem),
-          },
-        });
-        return;
-      }
-      case 'taskUpdated': {
-        dispatchTreeEvent({
-          type: 'taskUpserted',
-          eventVersion: event.eventVersion,
-          payload: {
-            task: toTaskItem(event.payload.task),
-          },
-        });
-        return;
-      }
-      case 'taskDeleted': {
-        dispatchTreeEvent({
-          type: 'taskDeleted',
-          eventVersion: event.eventVersion,
-          payload: {
-            stageId: event.payload.stageId,
-            taskId: event.payload.taskId,
-          },
-        });
-        return;
-      }
-      case 'progressReceived': {
-        const value = assertProgressRange(event.payload.value);
-        const activeAccepted = dispatchTreeEvent({
-          type: 'activeStageChanged',
-          payload: {
-            stageId: event.payload.stageId,
-          },
-        });
-        const lifecycleAccepted = dispatchTreeEvent({
-          type: 'sessionPatched',
-          eventVersion: event.eventVersion,
-          payload: {
-            phase: mapSessionPhaseToTreePhase(event.payload.phase),
-            isActive: isActivePhase(event.payload.phase),
-          },
-        });
-        if (!activeAccepted && !lifecycleAccepted) return;
-        set(stageProgressAtom, (current) => ({
-          ...current,
-          [event.payload.stageId]: {
-            value,
+            nodeId: event.payload.nodeId,
             phase: event.payload.phase,
+            isActive: event.payload.isActive,
+            startedAt: event.payload.startedAt,
+            completedAt: event.payload.completedAt,
+            stopReason: event.payload.stopReason,
+          },
+        };
+        set(shapeSessionAtoms.dispatchBuildSessionEventAtom, stateEvent);
+        if (event.payload.stopReason !== undefined) {
+          set(lifecycleExtrasAtom, (current) => ({
+            ...current,
+            stopReason: event.payload.stopReason,
+          }));
+        }
+        return;
+      }
+
+      case 'heartbeat': {
+        const stateEvent: ShapeStateEvent = {
+          type: 'heartbeat',
+          payload: {
+            nodeId: event.payload.nodeId,
+            heartbeatAt: event.payload.heartbeatAt,
+          },
+        };
+        set(shapeSessionAtoms.dispatchBuildSessionEventAtom, stateEvent);
+        return;
+      }
+
+      case 'stageSnapshotUpdated': {
+        const stateEvent: ShapeStateEvent = {
+          type: 'stageSnapshotUpdated',
+          payload: {
+            stageId: event.payload.stageId,
+            tasks: event.payload.tasks.map((task) => {
+              assertProgressRange(task.progress);
+              return task;
+            }),
+            stageStartedAt: event.payload.stageStartedAt,
+            stageInactiveMs: event.payload.stageInactiveMs,
+            stageCompletedAt: event.payload.stageCompletedAt,
+          },
+        };
+        set(shapeSessionAtoms.dispatchBuildSessionEventAtom, stateEvent);
+        return;
+      }
+
+      case 'taskProgressUpdated': {
+        assertProgressRange(event.payload.value);
+        const stateEvent: ShapeStateEvent = {
+          type: 'taskProgressUpdated',
+          payload: {
+            stageId: event.payload.stageId,
+            value: event.payload.value,
             message: event.payload.message,
             metadata: event.payload.metadata,
           },
-        }));
+        };
+        set(shapeSessionAtoms.dispatchBuildSessionEventAtom, stateEvent);
         return;
       }
+
       case 'uiSyncPhaseChanged': {
-        set(dispatchTreeEventAtom, {
-          type: 'activeStageChanged',
+        const stateEvent: ShapeStateEvent = {
+          type: 'viewSelectionChanged',
           payload: {
-            stageId: event.payload.stageId,
+            activeStageId: event.payload.stageId,
           },
-        });
+        };
+        set(shapeSessionAtoms.dispatchBuildSessionEventAtom, stateEvent);
         set(uiSyncPhaseByStageAtom, (current) => ({
           ...current,
           [event.payload.stageId]: event.payload.phase,
         }));
         return;
       }
-      case 'taskStreamConnectionChanged':
-        set(taskStreamConnectedAtom, event.payload.connected);
-        return;
-      case 'viewSelectionChanged': {
-        if (event.payload.activeStageId) {
-          set(dispatchTreeEventAtom, {
-            type: 'activeStageChanged',
-            payload: { stageId: event.payload.activeStageId },
-          });
-        }
-        if (event.payload.selectedTaskId !== undefined) {
-          const state = get(shapeStateTree.buildSessionStateTreeAtom);
-          const targetStageId = event.payload.activeStageId ?? state.ui.activeStageId;
-          set(dispatchTreeEventAtom, {
-            type: 'stageUiPatched',
-            payload: {
-              stageId: targetStageId,
-              patch: {
-                selectedTaskId: event.payload.selectedTaskId ?? undefined,
-              },
-            },
-          });
-        }
+
+      case 'taskStreamConnectionChanged': {
+        const stateEvent: ShapeStateEvent = {
+          type: 'taskStreamConnectionChanged',
+          payload: { connected: event.payload.connected },
+        };
+        set(shapeSessionAtoms.dispatchBuildSessionEventAtom, stateEvent);
         return;
       }
+
+      case 'viewSelectionChanged': {
+        const stateEvent: ShapeStateEvent = {
+          type: 'viewSelectionChanged',
+          payload: {
+            activeStageId: event.payload.activeStageId,
+            selectedTaskId: event.payload.selectedTaskId,
+          },
+        };
+        set(shapeSessionAtoms.dispatchBuildSessionEventAtom, stateEvent);
+        return;
+      }
+
       case 'criticalError': {
-        // Log critical error for immediate visibility
         console.error('🚨 CRITICAL BUILD SESSION ERROR 🚨', {
           message: event.payload.message,
           error: event.payload.error,
@@ -473,22 +418,18 @@ const applyBuildSessionEventAtom = atom(
           timestamp: new Date(event.payload.timestamp).toISOString(),
           contractViolation: event.payload.contractViolation,
         });
-        
-        // Force session to failed state to prevent contract violation hiding
-        dispatchTreeEvent({
-          type: 'sessionPatched',
-          eventVersion: Date.now(), // Use timestamp as version for immediate processing
+        const stateEvent: ShapeStateEvent = {
+          type: 'sessionStatusUpdated',
           payload: {
+            nodeId: '',
             phase: 'failed',
             isActive: false,
           },
-        });
-        
-        // Store error details in lifecycle extras for UI access
+        };
+        set(shapeSessionAtoms.dispatchBuildSessionEventAtom, stateEvent);
         set(lifecycleExtrasAtom, (current) => ({
           ...current,
           stopReason: 'failed',
-          completedAt: event.payload.timestamp,
           criticalError: {
             message: event.payload.message,
             error: event.payload.error,
@@ -498,6 +439,7 @@ const applyBuildSessionEventAtom = atom(
         }));
         return;
       }
+
       default:
         return;
     }
@@ -515,121 +457,7 @@ export const dispatchBuildSessionEventAtom = atom(
   },
 );
 
-export const buildSessionStartButtonLoadingAtom = atom((get) => {
-  const runtime = get(buildSessionRuntimeAtom);
-  const lifecycleActive = isActivePhase(runtime.phase);
-  if (!lifecycleActive) return false;
-  return !get(buildSessionTaskStreamConnectedAtom);
-});
-
-export const buildSessionStageCountersAtom = atom((get) => {
-  const tree = get(shapeStateTree.buildSessionStateTreeAtom);
-  const countByStatus = (stageId: ShapeStageId) => {
-    let total = 0;
-    let queued = 0;
-    let running = 0;
-    let failed = 0;
-    let terminal = 0;
-    for (const taskId of tree.tasks.orderedIdsByStage[stageId]) {
-      const task = tree.tasks.byId[taskId];
-      if (!task) continue;
-      total += 1;
-      if (task.status === 'queued') queued += 1;
-      if (task.status === 'running') running += 1;
-      if (task.status === 'failed') failed += 1;
-      if (task.status === 'completed' || task.status === 'failed' || task.status === 'recycled' || task.status === 'skipped') {
-        terminal += 1;
-      }
-    }
-    return { total, running, queued, terminal, failed };
-  };
-  return {
-    source: countByStatus('source'),
-    geometry: countByStatus('geometry'),
-    tileEmit: countByStatus('tileEmit'),
-  };
-});
-
-export const buildSessionTasksByStageAtom = atom<Record<ShapeStageId, BuildTaskSummary[]>>((get) => {
-  const tree = get(shapeStateTree.buildSessionStateTreeAtom);
-  const toSummary = (taskId: string): BuildTaskSummary | undefined => {
-    const task = tree.tasks.byId[taskId];
-    if (!task) return undefined;
-    const summary = {
-      taskId: task.taskId,
-      version: task.version,
-      stage: task.stage,
-      status: mapTreeTaskStatusToBuildStatus(task.status),
-      progress: task.progress,
-      sequence: task.index,
-      metadata: task.metadata,
-      display: task.display,
-    } as BuildTaskSummary & { title?: string };
-    if (typeof task.message === 'string' && task.message.trim().length > 0) {
-      summary.title = task.message;
-    }
-    return summary;
-  };
-  return {
-    source: tree.tasks.orderedIdsByStage.source
-      .map((id) => toSummary(id))
-      .filter((task): task is BuildTaskSummary => task !== undefined),
-    geometry: tree.tasks.orderedIdsByStage.geometry
-      .map((id) => toSummary(id))
-      .filter((task): task is BuildTaskSummary => task !== undefined),
-    tileEmit: tree.tasks.orderedIdsByStage.tileEmit
-      .map((id) => toSummary(id))
-      .filter((task): task is BuildTaskSummary => task !== undefined),
-  };
-});
-
-export const buildSessionStageProgressAtom = atom<Record<ShapeStageId, number>>((get) => {
-  const progress = get(stageProgressAtom);
-  return {
-    source: progress.source.value,
-    geometry: progress.geometry.value,
-    tileEmit: progress.tileEmit.value,
-  };
-});
-
-export const buildSessionTaskListViewPhaseAtom = atom<TaskListViewPhase>((get) => {
-  const runtime = get(buildSessionRuntimeAtom);
-  const tree = get(shapeStateTree.buildSessionStateTreeAtom);
-  const uiSyncByStage = get(uiSyncPhaseByStageAtom);
-  const activeStageUiSyncPhase = uiSyncByStage[tree.ui.activeStageId];
-  const tasksByStage = get(buildSessionTasksByStageAtom);
-  const totalTasks = (
-    tasksByStage.source.length
-    + tasksByStage.geometry.length
-    + tasksByStage.tileEmit.length
-  );
-  if (totalTasks > 0) return 'streaming';
-  if (runtime.phase === 'idle') return 'idle';
-  if (
-    runtime.phase === 'starting'
-    || runtime.phase === 'running'
-    || runtime.phase === 'pausing'
-    || runtime.phase === 'resuming'
-    || runtime.phase === 'finalizing'
-  ) {
-    if (activeStageUiSyncPhase === 'ui-initializing') {
-      return 'ui-initializing';
-    }
-    return 'streaming';
-  }
-  return 'settledEmpty';
-});
-
-export const buildSessionSnapshotHandshakeReceivedAtom = atom<boolean>((get) => {
-  const uiSyncByStage = get(uiSyncPhaseByStageAtom);
-  return (
-    uiSyncByStage.source === 'running'
-    || uiSyncByStage.geometry === 'running'
-    || uiSyncByStage.tileEmit === 'running'
-  );
-});
-
-// --- (A)(B)(C) Pending user action: consolidates localStartPending, isStopRequested/isStopAccepted, requestedControlAction ---
+// --- (A)(B)(C) Pending user action ---
 
 export type PendingUserAction = 'none' | 'starting' | 'stopping' | 'pausing' | 'cancelling';
 
@@ -649,7 +477,7 @@ export const isStopRequestedInFlightAtom = atom((get) => {
   return action === 'stopping' || action === 'pausing' || action === 'cancelling';
 });
 
-// --- (D) Elapsed tick: replaces elapsedTickMs useState + totalElapsedSnapshotRef ---
+// --- (D) Elapsed tick ---
 
 const elapsedTickMsBaseAtom = atom<number>(Date.now());
 
@@ -670,7 +498,7 @@ export const totalElapsedSnapshotAtom = atom(
   },
 );
 
-// --- (E) Completion snapshot: replaces completionSnapshot/completionDialogOpen useState ---
+// --- (E) Completion snapshot ---
 
 export type CompletionSnapshotData = {
   status: BuildStatus;

--- a/plugins/shape-plugin/src/ui/atoms/buildSessionWorkerEventAdapter.ts
+++ b/plugins/shape-plugin/src/ui/atoms/buildSessionWorkerEventAdapter.ts
@@ -1,4 +1,4 @@
-import type { BuildProgressEvent, BuildTaskSummary, BuildTaskUpdateEvent } from '@hierarchidb/build-api';
+import type { BuildProgressEvent, BuildTaskSummary } from '@hierarchidb/build-api';
 import {
   createBuildSessionWorkerEventAdapter as createCommonBuildSessionWorkerEventAdapter,
   type BuildSessionStateEvent,
@@ -32,7 +32,7 @@ const isShapeBuildStopReason = (value: unknown): value is ShapeBuildStopReason =
 const toShapeEvent = (
   event: BuildSessionStateEvent<ShapeStageId, ShapeSessionPhase, BuildTaskSummary>,
 ): ShapeBuildSessionStateEvent => {
-  if (event.type !== 'sessionRecordReceived') {
+  if (event.type !== 'sessionStatusUpdated') {
     return event;
   }
   const stopReason = event.payload.stopReason;
@@ -61,65 +61,28 @@ const mapRuntimeStatusToPhase = (status: string): ShapeSessionPhase => {
   throw new Error(`[shape buildSessionWorkerEventAdapter] unsupported runtime status: ${status}`);
 };
 
-const mapProgressPhaseToSessionPhase = (phase: BuildProgressEvent['phase']): ShapeSessionPhase => {
-  if (phase === 'idle') return 'idle';
-  if (phase === 'running') return 'running';
-  if (phase === 'paused') return 'paused';
-  if (phase === 'completed') return 'completed';
-  if (phase === 'failed') return 'failed';
-  if (phase === 'queued') return 'starting';
-  throw new Error(`[shape buildSessionWorkerEventAdapter] unsupported progress phase: ${phase}`);
-};
+const isActivePhase = (phase: ShapeSessionPhase): boolean => (
+  phase === 'starting'
+  || phase === 'running'
+  || phase === 'pausing'
+  || phase === 'resuming'
+  || phase === 'finalizing'
+);
 
 export const createBuildSessionWorkerEventAdapter = (
   nodeId: string,
   dispatch: (event: ShapeBuildSessionStateEvent) => void,
 ): BuildSessionWorkerEventAdapter => {
-  return createCommonBuildSessionWorkerEventAdapter<ShapeStageId, ShapeSessionPhase, BuildTaskSummary>(
+  return createCommonBuildSessionWorkerEventAdapter<ShapeStageId, ShapeSessionPhase>(
     nodeId,
     (event) => dispatch(toShapeEvent(event)),
     {
-      deleteEventTargetStages: ['source', 'geometry', 'tileEmit'] as const,
+      stages: ['source', 'geometry', 'tileEmit'] as const,
       resolveStageId: resolveShapeStageId,
       mapRuntimeStatusToPhase: (status) => mapRuntimeStatusToPhase(String(status)),
-      mapProgressPhaseToSessionPhase,
       mapSessionRecordStatusToPhase: (status) => mapRuntimeStatusToPhase(String(status)),
-      resolveRuntimeEventVersion: (record) => asFiniteNumber(record.revision, 'runtime revision'),
-      resolveSessionRecordEventVersion: (sessionRecord) => {
-        const stageHeartbeatAt = (sessionRecord as { stageHeartbeatAt?: unknown }).stageHeartbeatAt;
-        if (typeof stageHeartbeatAt === 'number' && Number.isFinite(stageHeartbeatAt)) {
-          return stageHeartbeatAt;
-        }
-        const completedAt = (sessionRecord as { completedAt?: unknown }).completedAt;
-        if (typeof completedAt === 'number' && Number.isFinite(completedAt)) {
-          return completedAt;
-        }
-        const startedAt = (sessionRecord as { startedAt?: unknown }).startedAt;
-        if (typeof startedAt === 'number' && Number.isFinite(startedAt)) {
-          return startedAt;
-        }
-        throw new Error('[shape buildSessionWorkerEventAdapter] sessionRecord event version must come from heartbeat/completedAt/startedAt');
-      },
-      resolveTaskSnapshotEventVersion: (event: BuildTaskUpdateEvent) => {
-        if (event.type !== 'snapshot') {
-          throw new Error('[shape buildSessionWorkerEventAdapter] snapshot resolver requires snapshot event');
-        }
-        const explicitVersion = (event as { version?: unknown }).version;
-        if (typeof explicitVersion === 'number' && Number.isFinite(explicitVersion)) {
-          return explicitVersion;
-        }
-        if (event.tasks.length > 0) {
-          return event.tasks.reduce((max, task) => Math.max(max, task.version), Number.MIN_SAFE_INTEGER);
-        }
-        return asFiniteNumber((event as { version?: unknown }).version, 'task snapshot event.version');
-      },
-      resolveTaskUpdateEventVersion: (task) => asFiniteNumber(task.version, 'task.version'),
-      resolveTaskDeleteEventVersion: (event: BuildTaskUpdateEvent) => (
-        asFiniteNumber((event as { version?: unknown }).version, 'task delete event.version')
-      ),
-      resolveProgressEventVersion: (event) => asFiniteNumber(event.timestamp, 'progress timestamp'),
-      resolveHeartbeatEventVersion: (event) => asFiniteNumber(event.heartbeatAt, 'heartbeatAt'),
-      resolveProgressValue: (event) => {
+      isActivePhase,
+      resolveProgressValue: (event: BuildProgressEvent) => {
         const payload = event.payload as Record<string, unknown> | undefined;
         return asFiniteNumber(payload?.percentage, 'progress payload.percentage');
       },

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildSessionState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildSessionState.ts
@@ -73,7 +73,7 @@ export const useShapeBuildSessionState = ({
     useEffect(() => {
         if (!import.meta.env.DEV) return;
         const activeNodeIdText = activeNodeId ? String(activeNodeId) : null;
-        const stageId = runtime.stageId ?? null;
+        const stageId = runtime.activeStageId ?? null;
         const status = runtime.phase;
         const stageHeartbeatAt = runtime.heartbeatAt ?? null;
         const key = `${activeNodeIdText ?? '-'}:${status ?? '-'}:${stageId ?? '-'}:${stageHeartbeatAt ?? '-'}`;
@@ -91,7 +91,7 @@ export const useShapeBuildSessionState = ({
         activeNodeId,
         runtime.heartbeatAt,
         runtime.phase,
-        runtime.stageId,
+        runtime.activeStageId,
         isRuntimeReady,
     ]);
 

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepLogic.impl.ts
@@ -50,6 +50,8 @@ import {
   buildSessionRuntimeAtom,
   pendingUserActionAtom,
   isStopRequestedInFlightAtom,
+  stageDurationMsByStageAtom,
+  stageTimingByStageAtom,
 } from '~/ui/atoms/buildSessionStateAtoms';
 import type { PendingUserAction } from '~/ui/atoms/buildSessionStateAtoms';
 
@@ -88,6 +90,8 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
   const { t } = useTranslation('shape-plugin');
   const activeNodeId = nodeId ?? null;
   const runtime = useAtomValue(buildSessionRuntimeAtom);
+  const stageDurationMsByStage = useAtomValue(stageDurationMsByStageAtom);
+  const stageTimingByStage = useAtomValue(stageTimingByStageAtom);
 
   const releaseBuildLock = useCallback(() => { }, []);
 
@@ -252,15 +256,14 @@ export const useShapeBuildStep = ({ data, nodeId }: Args) => {
     effectiveProgress: effectiveProgress ?? null,
     effectiveStatus: effectiveStatus ?? null,
     stageFromState,
-    sessionStageDurationByStageSnapshot: null,
+    sessionStageDurationByStageSnapshot: stageDurationMsByStage,
     runtimeTiming: {
       startedAt: runtime.startedAt,
       completedAt: runtime.completedAt,
       heartbeatAt: runtime.heartbeatAt,
-      stageId: runtime.stageId,
-      inactiveMs: runtime.inactiveMs,
-      stageStartedAt: runtime.stageStartedAt,
-      stageInactiveMs: runtime.stageInactiveMs,
+      stageId: runtime.activeStageId,
+      stageStartedAt: stageTimingByStage[runtime.activeStageId]?.stageStartedAt,
+      stageInactiveMs: stageTimingByStage[runtime.activeStageId]?.stageInactiveMs,
     },
     activeNodeId,
   });

--- a/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStageState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/internal/useShapeBuildStepStageState.ts
@@ -107,12 +107,10 @@ export const resolveTaskListViewPhase = (input: {
 
 export const shouldClearPersistedTasksOnReset = (input: {
   runtimePhase: string;
-  lastAcceptedEventVersion: number;
   taskCount: number;
 }): boolean => (
   input.taskCount === 0
   && input.runtimePhase === 'idle'
-  && input.lastAcceptedEventVersion === 0
 );
 
 export const useShapeBuildStepStageState = ({
@@ -263,13 +261,12 @@ export const useShapeBuildStepStageState = ({
   useEffect(() => {
     if (!shouldClearPersistedTasksOnReset({
       runtimePhase: runtime.phase,
-      lastAcceptedEventVersion: runtime.lastAcceptedEventVersion,
       taskCount: tasks.length,
     })) {
       return;
     }
     setPersistedTasks([]);
-  }, [runtime.lastAcceptedEventVersion, runtime.phase, tasks.length]);
+  }, [runtime.phase, tasks.length]);
 
   const rawDisplayTasks = tasks.length > 0 ? tasks : persistedTasks;
   const displayTasks = useMemo<ShapeBuildTaskSummary[]>(() => (

--- a/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgress/useBuildProgress.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useBuildProgress/useBuildProgress.ts
@@ -101,7 +101,7 @@ export function useBuildProgress(
       skipped: 0,
       percentage: stageProgress[activeStageId],
       stage: activeStageId,
-      timestamp: runtime.lastAcceptedEventVersion,
+      timestamp: Date.now(),
       message: undefined,
       progressTaskId: progressTask?.taskId,
       progressTaskStatus: progressTask?.status,
@@ -110,7 +110,7 @@ export function useBuildProgress(
       progressTaskDisplay: progressTask?.display,
       stageTotals,
     };
-  }, [counters, nodeId, runtime.activeStageId, runtime.lastAcceptedEventVersion, stageProgress, tasksByStage]);
+  }, [counters, nodeId, runtime.activeStageId, stageProgress, tasksByStage]);
 
   const derivedStatus = useMemo<BuildProgressStatus | null>(() => {
     if (!nodeId) return null;
@@ -129,9 +129,9 @@ export function useBuildProgress(
       progress: progress?.percentage,
       hasErrors: status === 'failed',
       error: null,
-      lastUpdated: runtime.lastAcceptedEventVersion,
+      lastUpdated: Date.now(),
     };
-  }, [nodeId, progress?.percentage, runtime.activeStageId, runtime.lastAcceptedEventVersion, runtime.phase]);
+  }, [nodeId, progress?.percentage, runtime.activeStageId, runtime.phase]);
 
   const error: Error | null = null;
   const subscribe = () => { };


### PR DESCRIPTION
Closes #1026

## Changes
- `useLocationSelectionStep.ts`: fix ide-gsm parse `useEffect`
  - Replace `if (hasSelection && hasAvailability) return` with `if (hasAvailability) return`
  - Add `initializedRef` to apply auto-selection only on first parse
  - Remove `hasSelection` / `selectionByCountries` from dependency array (no longer referenced)
  - Remove now-unused `hasSelection` useMemo

## Verification
- `pnpm -w turbo run typecheck --filter @hierarchidb/location-plugin`: 92/92 exit 0