### PR TITLE
fix(shape-plugin,build-sessions): fix criticalError nodeId hardcode and stageStartedAt fallback

### DIFF
--- a/packages/ui/build-sessions/src/state/createBuildSessionStateAtoms.ts
+++ b/packages/ui/build-sessions/src/state/createBuildSessionStateAtoms.ts
@@ -20,7 +20,7 @@ type BaseTaskSummary = {
 };
 
 type StageTiming = {
-  stageStartedAt: number;
+  stageStartedAt: number | undefined;
   stageInactiveMs: number;
   stageCompletedAt?: number;
 };
@@ -105,7 +105,7 @@ type StageSnapshotUpdatedEvent<StageId extends string, TaskSummary extends BaseT
   payload: {
     stageId: StageId;
     tasks: TaskSummary[];
-    stageStartedAt: number;
+    stageStartedAt: number | undefined;
     stageInactiveMs: number;
     stageCompletedAt?: number;
   };
@@ -320,7 +320,10 @@ export const createBuildSessionStateAtoms = <
       }
 
       case 'stageSnapshotUpdated': {
-        assertFiniteNumber(event.payload.stageStartedAt, 'stageStartedAt');
+        // stageStartedAt may be undefined when the stage has not yet started
+        if (event.payload.stageStartedAt !== undefined) {
+          assertFiniteNumber(event.payload.stageStartedAt, 'stageStartedAt');
+        }
         assertFiniteNumber(event.payload.stageInactiveMs, 'stageInactiveMs');
         if (event.payload.stageCompletedAt !== undefined) {
           assertFiniteNumber(event.payload.stageCompletedAt, 'stageCompletedAt');

--- a/packages/ui/build-sessions/src/state/createBuildSessionWorkerEventAdapter.ts
+++ b/packages/ui/build-sessions/src/state/createBuildSessionWorkerEventAdapter.ts
@@ -116,13 +116,12 @@ export const createBuildSessionWorkerEventAdapter = <
         // Emit snapshot for all known stages (empty array = zero tasks for that stage)
         for (const stageId of config.stages) {
           const tasks = grouped.get(stageId) ?? [];
-          // Use max task version as stageStartedAt proxy when not available from event
+          // stageStartedAt is undefined when the stage has not yet started;
+          // no fallback is applied (Date.now() or similar defaults are contract violations).
           const explicitVersion = (event as { version?: unknown }).version;
           const stageStartedAt = typeof explicitVersion === 'number' && Number.isFinite(explicitVersion)
             ? explicitVersion
-            : tasks.length > 0
-              ? tasks.reduce((max, t) => Math.max(max, t.version), Number.MIN_SAFE_INTEGER)
-              : Date.now();
+            : undefined;
           dispatch({
             type: 'stageSnapshotUpdated',
             payload: {

--- a/plugins/shape-plugin/src/ui/__tests__/atoms/unit/buildSessionStateAtoms.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/atoms/unit/buildSessionStateAtoms.unit.test.ts
@@ -288,6 +288,7 @@ describe('criticalError event', () => {
     store.set(dispatchBuildSessionEventAtom, {
       type: 'criticalError',
       payload: {
+        nodeId: 'node-1',
         message: 'contract violation',
         error: 'Error: bad value',
         errorName: 'Error',

--- a/plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts
+++ b/plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts
@@ -102,7 +102,7 @@ type ShapeStageSnapshotUpdatedEvent = {
   payload: {
     stageId: ShapeStageId;
     tasks: ShapeTaskSummary[];
-    stageStartedAt: number;
+    stageStartedAt: number | undefined;
     stageInactiveMs: number;
     stageCompletedAt?: number;
   };
@@ -146,6 +146,7 @@ type ShapeUiSyncPhaseChangedEvent = {
 type ShapeCriticalErrorEvent = {
   type: 'criticalError';
   payload: {
+    nodeId: string;
     message: string;
     error: string;
     errorName: string;
@@ -233,10 +234,11 @@ export const stageTimingByStageAtom = atom((get) => {
 });
 
 const computeStageDuration = (
-  timing: { stageStartedAt: number; stageInactiveMs: number; stageCompletedAt?: number } | null,
+  timing: { stageStartedAt: number | undefined; stageInactiveMs: number; stageCompletedAt?: number } | null,
   now: number,
 ): number => {
   if (!timing) return 0;
+  if (timing.stageStartedAt === undefined) return 0;
   const end = timing.stageCompletedAt ?? now;
   return Math.max(0, end - timing.stageStartedAt - timing.stageInactiveMs);
 };
@@ -421,7 +423,7 @@ const applyBuildSessionEventAtom = atom(
         const stateEvent: ShapeStateEvent = {
           type: 'sessionStatusUpdated',
           payload: {
-            nodeId: '',
+            nodeId: event.payload.nodeId,
             phase: 'failed',
             isActive: false,
             completedAt: event.payload.timestamp,


### PR DESCRIPTION
Closes #1032

## Changes

- `criticalError` case: replace hardcoded `nodeId: ''` with `event.payload.nodeId` (added `nodeId: string` to `ShapeCriticalErrorEvent.payload`)
- `stageStartedAt`: changed type from `number` to `number | undefined` in `StageTiming`, `StageSnapshotUpdatedEvent`, and `ShapeStageSnapshotUpdatedEvent`
- `createBuildSessionWorkerEventAdapter`: removed `Date.now()` fallback — `stageStartedAt` is now `undefined` when not yet started
- `computeStageDuration`: returns 0 when `stageStartedAt` is `undefined`
- Tests: added `nodeId` to `criticalError` dispatch payloads