### PR TITLE
fix(shape-plugin): replace seqNum gap-check with FIFO+version-gate for Worker→UI events

### DIFF
--- a/plugins/shape-plugin/src/__tests__/property/eventDeliveryExtendedScenarios.property.test.ts
+++ b/plugins/shape-plugin/src/__tests__/property/eventDeliveryExtendedScenarios.property.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../worker/api/eventBuffering';
 import {
     UIEventBufferManager,
-    type SequencedEvent as UISequencedEvent,
+    type BufferedEvent,
 } from '../../ui/components/build-progress/eventBufferingUI';
 
 // Test utilities
@@ -29,13 +29,13 @@ const createSequencedEvent = (
     timestamp: timestamp ?? Date.now(),
 });
 
-const createUISequencedEvent = (
-    seqNum: number,
+const createUIBufferedEvent = (
     notificationType: NotificationType,
     timestamp?: number,
-    payload: unknown = { test: true }
-): UISequencedEvent => ({
-    seqNum,
+    payload: unknown = { test: true },
+    version?: number
+): BufferedEvent => ({
+    version,
     notificationType,
     payload,
     timestamp: timestamp ?? Date.now(),
@@ -65,55 +65,54 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                         workerCount: fc.integer({ min: 2, max: MAX_PARALLEL_WORKERS }),
                         eventsPerWorker: fc.integer({ min: 1, max: 10 }),
                         notificationTypes: fc.array(
-                            fc.constantFrom('session-state', 'stage-snapshot', 'task-progress'),
-                            { minLength: 1, maxLength: 3 }
+                            fc.constantFrom('session-state', 'stage-snapshot'),
+                            { minLength: 1, maxLength: 2 }
                         ),
                     }),
                     ({ workerCount, eventsPerWorker, notificationTypes }) => {
                         const monitor = new EventDeliveryMonitor();
                         const bufferManager = new UIEventBufferManager();
-                        
+
                         // Simulate parallel workers emitting events
                         const allEvents: SequencedEvent[] = [];
-                        
+
                         for (let workerId = 0; workerId < workerCount; workerId++) {
                             for (let eventIdx = 0; eventIdx < eventsPerWorker; eventIdx++) {
                                 notificationTypes.forEach((notificationType) => {
                                     // Generate distributed sequence numbers
                                     const seqNum = workerId + (eventIdx * workerCount);
                                     const event = createSequencedEvent(seqNum, notificationType);
-                                    
+
                                     // Log emission
                                     monitor.logEventEmission(event);
-                                    
-                                    // Buffer in UI
-                                    const uiEvent = createUISequencedEvent(seqNum, notificationType);
-                                    bufferManager.bufferEvent(uiEvent);
-                                    
-                                    // Log buffering
-                                    const bufferStatus = bufferManager.getBufferStatus(notificationType);
-                                    monitor.logEventBuffering(event, bufferStatus.bufferedCount);
-                                    
+
+                                    // Enqueue into FIFO (session-state / stage-snapshot only)
+                                    const uiEvent = createUIBufferedEvent(notificationType as 'session-state' | 'stage-snapshot');
+                                    bufferManager.enqueue(uiEvent);
+
+                                    // Log buffering with size=1 per event
+                                    monitor.logEventBuffering(event, 1);
+
                                     allEvents.push(event);
                                 });
                             }
                         }
-                        
+
                         // Process all events
                         monitor.logEventReception(allEvents, 'success');
-                        
+
                         // Verify metrics consistency
                         const metrics = monitor.getMetrics();
                         const expectedEmissions = workerCount * eventsPerWorker * notificationTypes.length;
-                        
+
                         expect(metrics.totalEventsEmitted).toBe(expectedEmissions);
                         expect(metrics.totalEventsBuffered).toBe(expectedEmissions);
                         expect(metrics.totalEventsFlushed).toBe(expectedEmissions);
-                        
-                        // Verify no sequence number collisions in buffer
+
+                        // Verify FIFO queues can be drained without error
                         notificationTypes.forEach((type) => {
-                            const bufferStatus = bufferManager.getBufferStatus(type);
-                            expect(bufferStatus.hasGaps).toBe(false);
+                            const flushed = bufferManager.flushFifo(type as 'session-state' | 'stage-snapshot');
+                            expect(Array.isArray(flushed)).toBe(true);
                         });
                     }
                 ),
@@ -131,22 +130,22 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                     ({ totalWorkers, eventsPerWorker }) => {
                         const monitor = new EventDeliveryMonitor();
                         const generatedSeqNums: number[] = [];
-                        
+
                         // Simulate distributed sequence number generation
                         for (let workerId = 0; workerId < totalWorkers; workerId++) {
                             for (let eventCount = 0; eventCount < eventsPerWorker; eventCount++) {
                                 const seqNum = workerId + (eventCount * totalWorkers);
                                 const event = createSequencedEvent(seqNum, 'session-state');
-                                
+
                                 monitor.logEventEmission(event);
                                 generatedSeqNums.push(seqNum);
                             }
                         }
-                        
+
                         // Verify no duplicates
                         const uniqueSeqNums = new Set(generatedSeqNums);
                         expect(uniqueSeqNums.size).toBe(generatedSeqNums.length);
-                        
+
                         // Verify proper distribution
                         const sortedSeqNums = [...generatedSeqNums].sort((a, b) => a - b);
                         for (let i = 1; i < sortedSeqNums.length; i++) {
@@ -173,30 +172,30 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                     }),
                     ({ successfulEvents, failedEvents, errorTypes }) => {
                         const monitor = new EventDeliveryMonitor();
-                        
+
                         // Process successful events
                         const successEvents = Array.from({ length: successfulEvents }, (_, i) =>
                             createSequencedEvent(i, 'session-state')
                         );
                         monitor.logEventReception(successEvents, 'success');
-                        
+
                         // Process failed events with different error types
                         errorTypes.forEach((errorType, typeIndex) => {
                             const errorEvents = Array.from({ length: failedEvents }, (_, i) =>
                                 createSequencedEvent(successfulEvents + typeIndex * failedEvents + i, 'task-progress')
                             );
-                            
+
                             const error = new Error(`${errorType} error occurred`);
                             monitor.logEventReception(errorEvents, 'error', error);
                         });
-                        
+
                         // Verify metrics account for all events
                         const metrics = monitor.getMetrics();
                         const expectedTotal = successfulEvents + (failedEvents * errorTypes.length);
-                        
+
                         expect(metrics.totalEventsFlushed).toBe(expectedTotal);
                         expect(metrics.averageDeliveryLatency).toBeGreaterThanOrEqual(0);
-                        
+
                         // Memory usage should be within bounds even with errors
                         expect(metrics.memoryUsage.latencyEntriesCount).toBe(expectedTotal);
                     }
@@ -216,14 +215,14 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                     ({ subscriberCount, failingSubscriberIndex, eventCount }) => {
                         const nodeId = 'test-node';
                         const callbackResults: boolean[] = [];
-                        
+
                         // Set up multiple subscribers
                         const unsubscribeFunctions: (() => void)[] = [];
-                        
+
                         for (let i = 0; i < subscriberCount; i++) {
                             const shouldFail = i === failingSubscriberIndex % subscriberCount;
-                            
-                            const callback = (event: SequencedEvent) => {
+
+                            const callback = (_event: SequencedEvent) => {
                                 if (shouldFail) {
                                     callbackResults.push(false);
                                     throw new Error(`Subscriber ${i} failed`);
@@ -231,11 +230,11 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                                     callbackResults.push(true);
                                 }
                             };
-                            
+
                             const unsubscribe = unconditionalEventStreamer.subscribe(nodeId, 'session-state', callback);
                             unsubscribeFunctions.push(unsubscribe);
                         }
-                        
+
                         // Emit events
                         for (let i = 0; i < eventCount; i++) {
                             unconditionalEventStreamer.emitEvent(nodeId, 'session-state', {
@@ -244,13 +243,13 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                                 state: 'running',
                             });
                         }
-                        
+
                         // Verify that non-failing subscribers still received events
                         const successfulCalls = callbackResults.filter(result => result === true);
                         const expectedSuccessfulCalls = (subscriberCount - 1) * eventCount;
-                        
+
                         expect(successfulCalls.length).toBe(expectedSuccessfulCalls);
-                        
+
                         // Cleanup
                         unsubscribeFunctions.forEach(unsubscribe => unsubscribe());
                     }
@@ -273,33 +272,33 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                             maxLatencyEntries: 2000,
                             cleanupThreshold: 1500,
                         });
-                        
+
                         const _startTime = Date.now();
-                        
+
                         // Process multiple batches
                         for (let batch = 0; batch < batchCount; batch++) {
                             const events = Array.from({ length: batchSize }, (_, i) =>
                                 createSequencedEvent(batch * batchSize + i, 'session-state')
                             );
-                            
+
                             // Simulate processing time
                             vi.advanceTimersByTime(10);
-                            
+
                             monitor.logEventReception(events, 'success');
                         }
-                        
+
                         const _endTime = Date.now();
                         const totalEvents = batchSize * batchCount;
-                        
+
                         // Verify all events were processed
                         const metrics = monitor.getMetrics();
                         expect(metrics.totalEventsFlushed).toBe(totalEvents);
-                        
+
                         // Verify memory management kicked in if needed
                         if (totalEvents > 1500) {
                             expect(metrics.memoryUsage.latencyEntriesCount).toBeLessThanOrEqual(1500);
                         }
-                        
+
                         // Verify latency calculation is reasonable
                         expect(metrics.averageDeliveryLatency).toBeGreaterThanOrEqual(0);
                         expect(metrics.averageDeliveryLatency).toBeLessThan(1000); // Should be reasonable
@@ -309,45 +308,45 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
             );
         });
 
-        it('should handle rapid successive events efficiently', () => {
+        it('should handle rapid successive task-progress events efficiently', () => {
             fc.assert(
                 fc.property(
-                    fc.integer({ min: 100, max: 500 }),
+                    fc.integer({ min: 10, max: 50 }),
                     (eventCount) => {
                         const monitor = new EventDeliveryMonitor();
                         const bufferManager = new UIEventBufferManager();
-                        
-                        // Emit events rapidly
+
+                        // Emit task-progress events with increasing versions
+                        let acceptedCount = 0;
                         for (let i = 0; i < eventCount; i++) {
                             const event = createSequencedEvent(i, 'task-progress');
-                            
                             monitor.logEventEmission(event);
-                            
-                            const uiEvent = createUISequencedEvent(i, 'task-progress');
-                            bufferManager.bufferEvent(uiEvent);
-                            
-                            const bufferStatus = bufferManager.getBufferStatus('task-progress');
-                            monitor.logEventBuffering(event, bufferStatus.bufferedCount);
-                            
+
+                            // task-progress uses version-based gate
+                            const uiEvent = createUIBufferedEvent('task-progress', undefined, { value: i }, i);
+                            const accepted = bufferManager.applyTaskProgress(uiEvent);
+                            if (accepted !== undefined) {
+                                acceptedCount++;
+                                monitor.logEventBuffering(event, acceptedCount);
+                            }
+
                             // Advance time slightly
                             vi.advanceTimersByTime(1);
                         }
-                        
-                        // Process all at once
+
+                        // Process all emitted events
                         const allEvents = Array.from({ length: eventCount }, (_, i) =>
                             createSequencedEvent(i, 'task-progress')
                         );
                         monitor.logEventReception(allEvents, 'success');
-                        
-                        // Verify consistency
+
+                        // Verify emission count
                         const metrics = monitor.getMetrics();
                         expect(metrics.totalEventsEmitted).toBe(eventCount);
-                        expect(metrics.totalEventsBuffered).toBe(eventCount);
                         expect(metrics.totalEventsFlushed).toBe(eventCount);
-                        
-                        // Verify buffer is properly ordered
-                        const gaps = bufferManager.detectGaps('task-progress');
-                        expect(gaps.length).toBe(0);
+
+                        // All events with increasing versions should be accepted
+                        expect(acceptedCount).toBe(eventCount);
                     }
                 ),
                 { numRuns: 20 } // Fewer runs for performance tests
@@ -356,46 +355,43 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
     });
 
     describe('Property 27: Edge Cases and Invalid Data', () => {
-        it('should handle invalid sequence numbers gracefully', () => {
+        it('should reject invalid task-progress versions', () => {
             fc.assert(
                 fc.property(
                     fc.array(
                         fc.record({
-                            seqNum: fc.oneof(
-                                fc.integer({ min: -100, max: -1 }), // Negative numbers
-                                fc.constant(NaN), // NaN
-                                fc.constant(Infinity), // Infinity
-                                fc.constant(-Infinity), // -Infinity
-                                fc.constant(Math.fround(0.5)) // Non-integers
+                            version: fc.oneof(
+                                fc.constant(NaN),
+                                fc.constant(Infinity),
+                                fc.constant(-Infinity),
+                                fc.integer({ min: -100, max: -1 }),
                             ),
-                            notificationType: fc.constantFrom('session-state', 'stage-snapshot', 'task-progress'),
+                            notificationType: fc.constant('task-progress' as const),
                         }),
                         { minLength: 1, maxLength: 5 }
                     ),
                     (invalidEvents) => {
                         const bufferManager = new UIEventBufferManager();
                         let errorCount = 0;
-                        
+
                         invalidEvents.forEach((eventData) => {
                             try {
-                                const event = createUISequencedEvent(eventData.seqNum, eventData.notificationType);
-                                bufferManager.bufferEvent(event);
-                                // If no error is thrown, the implementation accepts invalid seqNums
-                                // This is acceptable behavior - just verify the buffer state
+                                const event = createUIBufferedEvent(
+                                    eventData.notificationType,
+                                    undefined,
+                                    { test: true },
+                                    eventData.version
+                                );
+                                bufferManager.applyTaskProgress(event);
                             } catch (error) {
                                 errorCount++;
                                 expect(error).toBeInstanceOf(Error);
-                                expect((error as Error).message).toContain('Invalid seqNum');
+                                expect((error as Error).message).toContain('Invalid task-progress version');
                             }
                         });
-                        
-                        // The implementation may or may not throw errors for invalid seqNums
-                        // This is acceptable - we just verify it doesn't crash
-                        expect(errorCount).toBeLessThanOrEqual(invalidEvents.length);
-                        
-                        // Buffer state should remain consistent
-                        const bufferStatus = bufferManager.getBufferStatus('session-state');
-                        expect(typeof bufferStatus.bufferedCount).toBe('number');
+
+                        // All invalid versions must throw
+                        expect(errorCount).toBe(invalidEvents.length);
                     }
                 ),
                 { numRuns: PROPERTY_TEST_RUNS }
@@ -408,10 +404,10 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                     fc.constantFrom('success', 'error'),
                     (processingStatus) => {
                         const monitor = new EventDeliveryMonitor();
-                        
+
                         // Process empty array
                         monitor.logEventReception([], processingStatus);
-                        
+
                         // Verify metrics are updated correctly
                         const metrics = monitor.getMetrics();
                         expect(metrics.totalEventsFlushed).toBe(0);
@@ -443,7 +439,7 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                     ),
                     (eventData) => {
                         const monitor = new EventDeliveryMonitor();
-                        
+
                         // Create events with various payload types
                         const events = eventData.map((data) => ({
                             seqNum: data.seqNum,
@@ -451,12 +447,12 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                             payload: data.payload,
                             timestamp: Date.now(),
                         }));
-                        
+
                         // Should not throw errors regardless of payload content
                         expect(() => {
                             monitor.logEventReception(events, 'success');
                         }).not.toThrow();
-                        
+
                         // Verify metrics are still accurate
                         const metrics = monitor.getMetrics();
                         expect(metrics.totalEventsFlushed).toBe(events.length);
@@ -485,16 +481,16 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                     ),
                     (eventData) => {
                         const monitor = new EventDeliveryMonitor();
-                        
+
                         const events = eventData.map((data) =>
                             createSequencedEvent(data.seqNum, 'session-state', data.timestamp)
                         );
-                        
+
                         // Should handle extreme timestamps without errors
                         expect(() => {
                             monitor.logEventReception(events, 'success');
                         }).not.toThrow();
-                        
+
                         // Verify latency calculation handles extreme values
                         const metrics = monitor.getMetrics();
                         expect(Number.isFinite(metrics.averageDeliveryLatency)).toBe(true);

--- a/plugins/shape-plugin/src/__tests__/property/eventDeliveryMonitoringAccuracy.property.test.ts
+++ b/plugins/shape-plugin/src/__tests__/property/eventDeliveryMonitoringAccuracy.property.test.ts
@@ -13,7 +13,8 @@ import {
 } from '../../worker/api/eventBuffering';
 import {
     UIEventBufferManager,
-    type SequencedEvent as UISequencedEvent,
+    type BufferedEvent,
+    type NotificationType as UINotificationType,
 } from '../../ui/components/build-progress/eventBufferingUI';
 
 // Test utilities
@@ -29,13 +30,13 @@ const createSequencedEvent = (
     timestamp: timestamp ?? Date.now(),
 });
 
-const createUISequencedEvent = (
-    seqNum: number,
-    notificationType: NotificationType,
+const createUIBufferedEvent = (
+    notificationType: UINotificationType,
     timestamp?: number,
-    payload: unknown = { test: true }
-): UISequencedEvent => ({
-    seqNum,
+    payload: unknown = { test: true },
+    version?: number
+): BufferedEvent => ({
+    version,
     notificationType,
     payload,
     timestamp: timestamp ?? Date.now(),
@@ -72,7 +73,7 @@ describe('Property 23: Event Delivery Monitoring Accuracy', () => {
                     (events) => {
                         // Create fresh monitor for each test
                         const monitor = new EventDeliveryMonitor();
-                        
+
                         // Track emissions
                         events.forEach((eventData) => {
                             const event = createSequencedEvent(eventData.seqNum, eventData.notificationType);
@@ -102,7 +103,7 @@ describe('Property 23: Event Delivery Monitoring Accuracy', () => {
                     (events) => {
                         // Create fresh monitor for each test
                         const monitor = new EventDeliveryMonitor();
-                        
+
                         // Track buffering
                         events.forEach((eventData) => {
                             const event = createSequencedEvent(eventData.seqNum, eventData.notificationType);
@@ -171,7 +172,7 @@ describe('Property 23: Event Delivery Monitoring Accuracy', () => {
 
                         scenarios.forEach((scenario) => {
                             const processingTime = scenario.emissionTime + scenario.processingDelay;
-                            
+
                             // Create events with emission timestamp
                             const events = Array.from({ length: scenario.eventCount }, (_, i) =>
                                 createSequencedEvent(i, 'session-state', scenario.emissionTime)
@@ -222,7 +223,7 @@ describe('Property 23: Event Delivery Monitoring Accuracy', () => {
                     (bufferUpdates) => {
                         // Create fresh monitor for each test
                         const monitor = new EventDeliveryMonitor();
-                        const expectedBufferSizes: Record<NotificationType, number> = {
+                        const expectedBufferSizes: Partial<Record<NotificationType, number>> = {
                             'session-state': 0,
                             'stage-snapshot': 0,
                             'task-progress': 0,
@@ -254,8 +255,8 @@ describe('Property 23: Event Delivery Monitoring Accuracy', () => {
                 fc.property(
                     fc.array(
                         fc.record({
-                            notificationType: fc.constantFrom('session-state', 'stage-snapshot', 'task-progress'),
-                            seqNum: fc.integer({ min: 0, max: 20 }),
+                            notificationType: fc.constantFrom('session-state', 'stage-snapshot'),
+                            version: fc.integer({ min: 0, max: 20 }),
                         }),
                         { minLength: 1, maxLength: 8 }
                     ),
@@ -263,28 +264,23 @@ describe('Property 23: Event Delivery Monitoring Accuracy', () => {
                         // Create fresh instances for each test
                         const monitor = new EventDeliveryMonitor();
                         const bufferManager = new UIEventBufferManager();
-                        
+
                         // Buffer events in UI buffer manager and track with monitor
-                        eventData.forEach((data) => {
-                            const uiEvent = createUISequencedEvent(data.seqNum, data.notificationType);
-                            
-                            // Buffer in UI manager
-                            bufferManager.bufferEvent(uiEvent);
-                            
-                            // Get actual buffer size after buffering
-                            const bufferStatus = bufferManager.getBufferStatus(data.notificationType);
-                            
-                            // Log with monitor using the actual buffer size
-                            const workerEvent = createSequencedEvent(data.seqNum, data.notificationType);
-                            monitor.logEventBuffering(workerEvent, bufferStatus.bufferedCount);
+                        // Only session-state and stage-snapshot use FIFO enqueue
+                        eventData.forEach((data, index) => {
+                            const uiEvent = createUIBufferedEvent(data.notificationType);
+
+                            // Enqueue into FIFO
+                            bufferManager.enqueue(uiEvent);
+
+                            // Log with monitor using the current queue depth (index + 1 per type)
+                            const workerEvent = createSequencedEvent(index, data.notificationType);
+                            monitor.logEventBuffering(workerEvent, 1);
                         });
 
-                        // Verify monitor reflects actual buffer sizes
+                        // Verify monitor reflects total buffered count
                         const metrics = monitor.getMetrics();
-                        (['session-state', 'stage-snapshot', 'task-progress'] as NotificationType[]).forEach((type) => {
-                            const bufferStatus = bufferManager.getBufferStatus(type);
-                            expect(metrics.bufferUtilization[type]).toBe(bufferStatus.bufferedCount);
-                        });
+                        expect(metrics.totalEventsBuffered).toBe(eventData.length);
                     }
                 ),
                 { numRuns: PROPERTY_TEST_RUNS }
@@ -304,7 +300,7 @@ describe('Property 23: Event Delivery Monitoring Accuracy', () => {
                     ({ emissionCount, bufferingCount, processingCount }) => {
                         // Create fresh monitor for each test
                         const monitor = new EventDeliveryMonitor();
-                        
+
                         // Generate some activity
                         for (let i = 0; i < emissionCount; i++) {
                             const event = createSequencedEvent(i, 'session-state');
@@ -359,7 +355,7 @@ describe('Property 23: Event Delivery Monitoring Accuracy', () => {
                     ({ preResetActivity, postResetActivity }) => {
                         // Create fresh monitor for each test
                         const monitor = new EventDeliveryMonitor();
-                        
+
                         // Pre-reset activity
                         for (let i = 0; i < preResetActivity; i++) {
                             const event = createSequencedEvent(i, 'session-state');

--- a/plugins/shape-plugin/src/ui/components/build-progress/__tests__/unit/eventBufferingUI.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/__tests__/unit/eventBufferingUI.unit.test.ts
@@ -1,383 +1,210 @@
 /**
- * Unit tests for UI-side event buffering with seqNum ordering
+ * Unit tests for UI-side event buffering.
+ *
+ * session-state / stage-snapshot: FIFO — all events returned in arrival order.
+ * task-progress: version-based gate — stale and post-final events are dropped.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
     UIEventBufferManager,
     ImmediateHeartbeatProcessor,
-    type SequencedEvent,
-    type NotificationType
+    type BufferedEvent,
 } from '../../eventBufferingUI';
 
-describe('UIEventBufferManager', () => {
-    let bufferManager: UIEventBufferManager;
+const makeEvent = (
+    notificationType: BufferedEvent['notificationType'],
+    payload: unknown,
+    version?: number,
+): BufferedEvent => ({
+    version,
+    notificationType,
+    payload,
+    timestamp: Date.now(),
+});
+
+describe('UIEventBufferManager — FIFO queues (session-state / stage-snapshot)', () => {
+    let mgr: UIEventBufferManager;
 
     beforeEach(() => {
-        bufferManager = new UIEventBufferManager();
+        mgr = new UIEventBufferManager();
     });
 
-    describe('bufferEvent', () => {
-        it('should buffer events in seqNum order', () => {
-            const events: SequencedEvent[] = [
-                { seqNum: 3, notificationType: 'session-state', payload: 'event3', timestamp: Date.now() },
-                { seqNum: 1, notificationType: 'session-state', payload: 'event1', timestamp: Date.now() },
-                { seqNum: 2, notificationType: 'session-state', payload: 'event2', timestamp: Date.now() },
-            ];
+    it('returns events in arrival order regardless of version', () => {
+        mgr.enqueue(makeEvent('session-state', 'a'));
+        mgr.enqueue(makeEvent('session-state', 'b'));
+        mgr.enqueue(makeEvent('session-state', 'c'));
 
-            for (const event of events) {
-                bufferManager.bufferEvent(event);
-            }
+        const flushed = mgr.flushFifo('session-state');
+        expect(flushed.map((e) => e.payload)).toEqual(['a', 'b', 'c']);
+    });
 
-            const status = bufferManager.getBufferStatus('session-state');
-            expect(status.bufferedCount).toBe(3);
-        });
+    it('flushFifo drains the queue completely', () => {
+        mgr.enqueue(makeEvent('stage-snapshot', 'snap1'));
+        mgr.enqueue(makeEvent('stage-snapshot', 'snap2'));
 
-        it('should reject invalid seqNum', () => {
-            const invalidEvents = [
-                { seqNum: -1, notificationType: 'session-state' as NotificationType, payload: 'invalid', timestamp: Date.now() },
-                { seqNum: NaN, notificationType: 'session-state' as NotificationType, payload: 'invalid', timestamp: Date.now() },
-                { seqNum: Infinity, notificationType: 'session-state' as NotificationType, payload: 'invalid', timestamp: Date.now() },
-            ];
+        const first = mgr.flushFifo('stage-snapshot');
+        expect(first).toHaveLength(2);
 
-            for (const event of invalidEvents) {
-                expect(() => bufferManager.bufferEvent(event)).toThrow('Invalid seqNum');
-            }
-        });
+        const second = mgr.flushFifo('stage-snapshot');
+        expect(second).toHaveLength(0);
+    });
 
-        it('should reject unknown notification types', () => {
-            const invalidEvent = {
-                seqNum: 1,
-                notificationType: 'unknown-type' as NotificationType,
-                payload: 'invalid',
+    it('session-state and stage-snapshot queues are independent', () => {
+        mgr.enqueue(makeEvent('session-state', 'ss1'));
+        mgr.enqueue(makeEvent('stage-snapshot', 'sn1'));
+        mgr.enqueue(makeEvent('session-state', 'ss2'));
+
+        expect(mgr.flushFifo('session-state').map((e) => e.payload)).toEqual(['ss1', 'ss2']);
+        expect(mgr.flushFifo('stage-snapshot').map((e) => e.payload)).toEqual(['sn1']);
+    });
+
+    it('enqueue rejects task-progress (must use applyTaskProgress)', () => {
+        expect(() => mgr.enqueue(makeEvent('task-progress', {}))).toThrow(
+            'task-progress must be applied via applyTaskProgress',
+        );
+    });
+
+    it('enqueue rejects unknown notification type', () => {
+        expect(() =>
+            mgr.enqueue({
+                version: undefined,
+                notificationType: 'unknown' as BufferedEvent['notificationType'],
+                payload: {},
                 timestamp: Date.now(),
-            };
-
-            expect(() => bufferManager.bufferEvent(invalidEvent)).toThrow('Unknown notification type');
-        });
+            }),
+        ).toThrow('Unknown notification type');
     });
 
-    describe('flushBuffer', () => {
-        it('should flush consecutive events starting from expected seqNum', () => {
-            const events: SequencedEvent[] = [
-                { seqNum: 0, notificationType: 'session-state', payload: 'event0', timestamp: Date.now() },
-                { seqNum: 1, notificationType: 'session-state', payload: 'event1', timestamp: Date.now() },
-                { seqNum: 4, notificationType: 'session-state', payload: 'event4', timestamp: Date.now() },
-                { seqNum: 2, notificationType: 'session-state', payload: 'event2', timestamp: Date.now() },
-            ];
+    it('reset clears all queues', () => {
+        mgr.enqueue(makeEvent('session-state', 'x'));
+        mgr.enqueue(makeEvent('stage-snapshot', 'y'));
+        mgr.reset();
 
-            for (const event of events) {
-                bufferManager.bufferEvent(event);
-            }
+        expect(mgr.flushFifo('session-state')).toHaveLength(0);
+        expect(mgr.flushFifo('stage-snapshot')).toHaveLength(0);
+    });
+});
 
-            // First flush should return events 0, 1, 2 (consecutive from start, gap at 3)
-            const flushed1 = bufferManager.flushBuffer('session-state');
-            expect(flushed1).toHaveLength(3);
-            expect(flushed1.map(e => e.seqNum)).toEqual([0, 1, 2]);
-            expect(flushed1.map(e => e.payload)).toEqual(['event0', 'event1', 'event2']);
+describe('UIEventBufferManager — task-progress version gating', () => {
+    let mgr: UIEventBufferManager;
 
-            // Buffer should still contain event 4 (gap at seqNum 3)
-            const status = bufferManager.getBufferStatus('session-state');
-            expect(status.bufferedCount).toBe(1);
-            expect(status.lastAppliedSeqNum).toBe(2);
-
-            // Add event 5 to extend the gap
-            bufferManager.bufferEvent({ seqNum: 5, notificationType: 'session-state', payload: 'event5', timestamp: Date.now() });
-
-            // Second flush should return nothing (gap at seqNum 3)
-            const flushed2 = bufferManager.flushBuffer('session-state');
-            expect(flushed2).toHaveLength(0);
-
-            // Add missing event 3
-            bufferManager.bufferEvent({ seqNum: 3, notificationType: 'session-state', payload: 'event3', timestamp: Date.now() });
-
-            // Third flush should return events 3, 4, 5 (consecutive after gap filled)
-            const flushed3 = bufferManager.flushBuffer('session-state');
-            expect(flushed3).toHaveLength(3);
-            expect(flushed3.map(e => e.seqNum)).toEqual([3, 4, 5]);
-            expect(flushed3.map(e => e.payload)).toEqual(['event3', 'event4', 'event5']);
-
-            // Buffer should now be empty
-            const finalStatus = bufferManager.getBufferStatus('session-state');
-            expect(finalStatus.bufferedCount).toBe(0);
-            expect(finalStatus.lastAppliedSeqNum).toBe(5);
-        });
-
-        it('should handle empty buffer', () => {
-            const flushed = bufferManager.flushBuffer('session-state');
-            expect(flushed).toHaveLength(0);
-        });
-
-        it('should handle buffer with gap at beginning', () => {
-            bufferManager.bufferEvent({ seqNum: 2, notificationType: 'session-state', payload: 'event2', timestamp: Date.now() });
-
-            const flushed = bufferManager.flushBuffer('session-state');
-            expect(flushed).toHaveLength(0); // Gap at seqNum 0, 1
-
-            const status = bufferManager.getBufferStatus('session-state');
-            expect(status.bufferedCount).toBe(1);
-            expect(status.lastAppliedSeqNum).toBe(null);
-        });
+    beforeEach(() => {
+        mgr = new UIEventBufferManager();
     });
 
-    describe('detectGaps', () => {
-        it('should detect gaps at beginning', () => {
-            bufferManager.bufferEvent({ seqNum: 2, notificationType: 'session-state', payload: 'event2', timestamp: Date.now() });
-
-            const gaps = bufferManager.detectGaps('session-state');
-            expect(gaps).toEqual([0, 1]);
-        });
-
-        it('should detect gaps between events', () => {
-            const events: SequencedEvent[] = [
-                { seqNum: 0, notificationType: 'session-state', payload: 'event0', timestamp: Date.now() },
-                { seqNum: 3, notificationType: 'session-state', payload: 'event3', timestamp: Date.now() },
-                { seqNum: 6, notificationType: 'session-state', payload: 'event6', timestamp: Date.now() },
-            ];
-
-            for (const event of events) {
-                bufferManager.bufferEvent(event);
-            }
-
-            // Flush first event
-            bufferManager.flushBuffer('session-state');
-
-            const gaps = bufferManager.detectGaps('session-state');
-            expect(gaps).toEqual([1, 2, 4, 5]); // Missing 1,2 between 0,3 and 4,5 between 3,6
-        });
-
-        it('should return empty array for consecutive events', () => {
-            const events: SequencedEvent[] = [
-                { seqNum: 0, notificationType: 'session-state', payload: 'event0', timestamp: Date.now() },
-                { seqNum: 1, notificationType: 'session-state', payload: 'event1', timestamp: Date.now() },
-                { seqNum: 2, notificationType: 'session-state', payload: 'event2', timestamp: Date.now() },
-            ];
-
-            for (const event of events) {
-                bufferManager.bufferEvent(event);
-            }
-
-            const gaps = bufferManager.detectGaps('session-state');
-            expect(gaps).toEqual([]);
-        });
-
-        it('should return empty array for empty buffer', () => {
-            const gaps = bufferManager.detectGaps('session-state');
-            expect(gaps).toEqual([]);
-        });
+    it('accepts event when no version info (undefined)', () => {
+        const ev = makeEvent('task-progress', { value: 50 });
+        expect(mgr.applyTaskProgress(ev)).toBe(ev);
     });
 
-    describe('getBufferStatus', () => {
-        it('should return correct status for empty buffer', () => {
-            const status = bufferManager.getBufferStatus('session-state');
-            expect(status).toEqual({
-                bufferedCount: 0,
-                lastAppliedSeqNum: null,
-                hasGaps: false,
-            });
-        });
-
-        it('should return correct status after buffering and flushing', () => {
-            const events: SequencedEvent[] = [
-                { seqNum: 0, notificationType: 'session-state', payload: 'event0', timestamp: Date.now() },
-                { seqNum: 2, notificationType: 'session-state', payload: 'event2', timestamp: Date.now() },
-            ];
-
-            for (const event of events) {
-                bufferManager.bufferEvent(event);
-            }
-
-            // Before flush
-            let status = bufferManager.getBufferStatus('session-state');
-            expect(status.bufferedCount).toBe(2);
-            expect(status.hasGaps).toBe(true); // Gap at seqNum 1
-
-            // After flush
-            bufferManager.flushBuffer('session-state');
-            status = bufferManager.getBufferStatus('session-state');
-            expect(status.bufferedCount).toBe(1); // Only event 2 remains
-            expect(status.lastAppliedSeqNum).toBe(0); // Only event 0 was flushed
-            expect(status.hasGaps).toBe(true); // Still gap at seqNum 1
-        });
+    it('accepts first versioned event', () => {
+        const ev = makeEvent('task-progress', { value: 30 }, 5);
+        expect(mgr.applyTaskProgress(ev)).toBe(ev);
+        expect(mgr.getTaskProgressState().lastAppliedVersion).toBe(5);
     });
 
-    describe('reset', () => {
-        it('should reset all buffers', () => {
-            const events: SequencedEvent[] = [
-                { seqNum: 0, notificationType: 'session-state', payload: 'event0', timestamp: Date.now() },
-                { seqNum: 1, notificationType: 'stage-snapshot', payload: 'event1', timestamp: Date.now() },
-                { seqNum: 2, notificationType: 'task-progress', payload: 'event2', timestamp: Date.now() },
-            ];
-
-            for (const event of events) {
-                bufferManager.bufferEvent(event);
-            }
-
-            bufferManager.reset();
-
-            const notificationTypes: NotificationType[] = ['session-state', 'stage-snapshot', 'task-progress'];
-            for (const type of notificationTypes) {
-                const status = bufferManager.getBufferStatus(type);
-                expect(status).toEqual({
-                    bufferedCount: 0,
-                    lastAppliedSeqNum: null,
-                    hasGaps: false,
-                });
-            }
-        });
+    it('accepts higher version', () => {
+        mgr.applyTaskProgress(makeEvent('task-progress', { value: 10 }, 3));
+        const ev = makeEvent('task-progress', { value: 20 }, 6);
+        expect(mgr.applyTaskProgress(ev)).toBe(ev);
+        expect(mgr.getTaskProgressState().lastAppliedVersion).toBe(6);
     });
 
-    describe('per-notification-type isolation', () => {
-        it('should maintain separate buffers for each notification type', () => {
-            const events: SequencedEvent[] = [
-                { seqNum: 0, notificationType: 'session-state', payload: 'session0', timestamp: Date.now() },
-                { seqNum: 0, notificationType: 'stage-snapshot', payload: 'snapshot0', timestamp: Date.now() },
-                { seqNum: 0, notificationType: 'task-progress', payload: 'progress0', timestamp: Date.now() },
-                { seqNum: 1, notificationType: 'session-state', payload: 'session1', timestamp: Date.now() },
-            ];
+    it('drops equal version (duplicate)', () => {
+        mgr.applyTaskProgress(makeEvent('task-progress', { value: 10 }, 3));
+        expect(mgr.applyTaskProgress(makeEvent('task-progress', { value: 10 }, 3))).toBeUndefined();
+    });
 
-            for (const event of events) {
-                bufferManager.bufferEvent(event);
-            }
+    it('drops lower version (stale / out-of-order)', () => {
+        mgr.applyTaskProgress(makeEvent('task-progress', { value: 50 }, 9));
+        expect(mgr.applyTaskProgress(makeEvent('task-progress', { value: 40 }, 6))).toBeUndefined();
+    });
 
-            // Each type should have independent seqNum sequences
-            const sessionFlushed = bufferManager.flushBuffer('session-state');
-            expect(sessionFlushed).toHaveLength(2);
-            expect(sessionFlushed.map(e => e.payload)).toEqual(['session0', 'session1']);
+    it('marks finalReached when value=100 is applied', () => {
+        mgr.applyTaskProgress(makeEvent('task-progress', { value: 100 }, 10));
+        expect(mgr.getTaskProgressState().finalReached).toBe(true);
+    });
 
-            const snapshotFlushed = bufferManager.flushBuffer('stage-snapshot');
-            expect(snapshotFlushed).toHaveLength(1);
-            expect(snapshotFlushed[0].payload).toBe('snapshot0');
+    it('drops all events after value=100 (final state protection)', () => {
+        mgr.applyTaskProgress(makeEvent('task-progress', { value: 100 }, 10));
+        // Higher version but after final — must be dropped
+        expect(mgr.applyTaskProgress(makeEvent('task-progress', { value: 80 }, 13))).toBeUndefined();
+        expect(mgr.applyTaskProgress(makeEvent('task-progress', { value: 100 }, 16))).toBeUndefined();
+    });
 
-            const progressFlushed = bufferManager.flushBuffer('task-progress');
-            expect(progressFlushed).toHaveLength(1);
-            expect(progressFlushed[0].payload).toBe('progress0');
-        });
+    it('marks finalReached for undefined-version event with value=100', () => {
+        mgr.applyTaskProgress(makeEvent('task-progress', { value: 100 }));
+        expect(mgr.getTaskProgressState().finalReached).toBe(true);
+        expect(mgr.applyTaskProgress(makeEvent('task-progress', { value: 50 }))).toBeUndefined();
+    });
+
+    it('throws on invalid version (negative)', () => {
+        expect(() => mgr.applyTaskProgress(makeEvent('task-progress', { value: 10 }, -1))).toThrow(
+            'Invalid task-progress version',
+        );
+    });
+
+    it('throws on invalid version (NaN)', () => {
+        expect(() => mgr.applyTaskProgress(makeEvent('task-progress', { value: 10 }, NaN))).toThrow(
+            'Invalid task-progress version',
+        );
+    });
+
+    it('throws when called with wrong notification type', () => {
+        expect(() =>
+            mgr.applyTaskProgress(makeEvent('session-state', {})),
+        ).toThrow('applyTaskProgress called with wrong type');
+    });
+
+    it('reset clears version state', () => {
+        mgr.applyTaskProgress(makeEvent('task-progress', { value: 100 }, 5));
+        mgr.reset();
+        const state = mgr.getTaskProgressState();
+        expect(state.lastAppliedVersion).toBeUndefined();
+        expect(state.finalReached).toBe(false);
+        // Should accept again after reset
+        expect(mgr.applyTaskProgress(makeEvent('task-progress', { value: 50 }, 3))).toBeDefined();
+    });
+
+    it('parallel worker interleaving: Worker0=0,3,6 Worker1=1,4,7 Worker2=2,5,8', () => {
+        // Simulate 3 parallel workers emitting interleaved versions
+        const versions = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+        const accepted: number[] = [];
+        for (const v of versions) {
+            const result = mgr.applyTaskProgress(makeEvent('task-progress', { value: v * 10 }, v));
+            if (result) accepted.push(v);
+        }
+        expect(accepted).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    });
+
+    it('out-of-order delivery: later version arrives first, earlier is dropped', () => {
+        mgr.applyTaskProgress(makeEvent('task-progress', { value: 60 }, 6));
+        // version 3 arrives late — stale
+        expect(mgr.applyTaskProgress(makeEvent('task-progress', { value: 30 }, 3))).toBeUndefined();
+        // version 9 is fine
+        expect(mgr.applyTaskProgress(makeEvent('task-progress', { value: 90 }, 9))).toBeDefined();
     });
 });
 
 describe('ImmediateHeartbeatProcessor', () => {
-    it('should process heartbeat events immediately', () => {
-        const processedEvents: Array<{ nodeId: string; heartbeatAt?: number }> = [];
-        const processor = new ImmediateHeartbeatProcessor((event) => {
-            processedEvents.push(event);
-        });
+    it('passes heartbeat events through immediately', () => {
+        const received: Array<{ nodeId: string; heartbeatAt?: number }> = [];
+        const proc = new ImmediateHeartbeatProcessor((e) => received.push(e));
 
-        const heartbeatEvents = [
-            { nodeId: 'node1', heartbeatAt: 1000 },
-            { nodeId: 'node1', heartbeatAt: 2000 },
-            { nodeId: 'node1', heartbeatAt: 3000 },
-        ];
+        proc.processHeartbeat({ nodeId: 'n1', heartbeatAt: 1000 });
+        proc.processHeartbeat({ nodeId: 'n1', heartbeatAt: 2000 });
 
-        for (const event of heartbeatEvents) {
-            processor.processHeartbeat(event);
-        }
-
-        expect(processedEvents).toEqual(heartbeatEvents);
+        expect(received).toEqual([
+            { nodeId: 'n1', heartbeatAt: 1000 },
+            { nodeId: 'n1', heartbeatAt: 2000 },
+        ]);
     });
 
-    it('should handle heartbeat events without heartbeatAt', () => {
-        const processedEvents: Array<{ nodeId: string; heartbeatAt?: number }> = [];
-        const processor = new ImmediateHeartbeatProcessor((event) => {
-            processedEvents.push(event);
-        });
-
-        const event = { nodeId: 'node1' };
-        processor.processHeartbeat(event);
-
-        expect(processedEvents).toEqual([event]);
+    it('handles heartbeat without heartbeatAt', () => {
+        const received: Array<{ nodeId: string; heartbeatAt?: number }> = [];
+        const proc = new ImmediateHeartbeatProcessor((e) => received.push(e));
+        proc.processHeartbeat({ nodeId: 'n1' });
+        expect(received).toEqual([{ nodeId: 'n1' }]);
     });
 });
-    describe('buffer size limits', () => {
-        let bufferManager: UIEventBufferManager;
-
-        beforeEach(() => {
-            bufferManager = new UIEventBufferManager();
-        });
-
-        it('should enforce buffer size limits and cleanup old events', () => {
-            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-            
-            // Fill buffer beyond MAX_BUFFER_SIZE (1000)
-            for (let i = 0; i < 1100; i++) {
-                bufferManager.bufferEvent({
-                    seqNum: i,
-                    notificationType: 'session-state',
-                    payload: `event${i}`,
-                    timestamp: Date.now()
-                });
-            }
-
-            // Buffer should be cleaned up when it exceeds MAX_BUFFER_SIZE
-            // The cleanup happens after insertion, so final size may vary slightly
-            const status = bufferManager.getBufferStatus('session-state');
-            expect(status.bufferedCount).toBeLessThanOrEqual(1000);
-            expect(status.bufferedCount).toBeGreaterThan(800);
-            
-            // Should have logged warning about buffer overflow
-            expect(consoleSpy).toHaveBeenCalledWith(
-                expect.stringContaining('[UIEventBufferManager] Buffer overflow for session-state, removed')
-            );
-            
-            consoleSpy.mockRestore();
-        });
-
-        it('should maintain seqNum ordering after buffer cleanup', () => {
-            // Fill buffer with events in reverse order
-            for (let i = 1100; i >= 0; i--) {
-                bufferManager.bufferEvent({
-                    seqNum: i,
-                    notificationType: 'session-state',
-                    payload: `event${i}`,
-                    timestamp: Date.now()
-                });
-            }
-
-            // Buffer should be cleaned up but maintain ordering
-            const status = bufferManager.getBufferStatus('session-state');
-            expect(status.bufferedCount).toBeLessThanOrEqual(1000);
-            expect(status.bufferedCount).toBeGreaterThan(800);
-            
-            // Flush should still work correctly with remaining events
-            const flushed = bufferManager.flushBuffer('session-state');
-            expect(flushed.length).toBeGreaterThan(0);
-            
-            // Verify ordering is maintained
-            for (let i = 1; i < flushed.length; i++) {
-                expect(flushed[i].seqNum).toBeGreaterThan(flushed[i - 1].seqNum);
-            }
-        });
-
-        it('should handle buffer cleanup for different notification types independently', () => {
-            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-            
-            // Fill session-state buffer beyond limit
-            for (let i = 0; i < 1100; i++) {
-                bufferManager.bufferEvent({
-                    seqNum: i,
-                    notificationType: 'session-state',
-                    payload: `session${i}`,
-                    timestamp: Date.now()
-                });
-            }
-
-            // Add some events to other buffers (should not be affected)
-            for (let i = 0; i < 10; i++) {
-                bufferManager.bufferEvent({
-                    seqNum: i,
-                    notificationType: 'stage-snapshot',
-                    payload: `snapshot${i}`,
-                    timestamp: Date.now()
-                });
-            }
-
-            const sessionStatus = bufferManager.getBufferStatus('session-state');
-            const snapshotStatus = bufferManager.getBufferStatus('stage-snapshot');
-            
-            expect(sessionStatus.bufferedCount).toBeLessThanOrEqual(1000); // Cleaned up
-            expect(sessionStatus.bufferedCount).toBeGreaterThan(800);
-            expect(snapshotStatus.bufferedCount).toBe(10); // Unaffected
-            
-            consoleSpy.mockRestore();
-        });
-    });

--- a/plugins/shape-plugin/src/ui/components/build-progress/eventBufferingUI.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/eventBufferingUI.ts
@@ -1,219 +1,167 @@
 /**
- * UI-side event buffering with seqNum-based ordering
- * Implements per-notification-type buffering with sequence number ordering
+ * UI-side event buffering for Worker→UI event delivery.
+ *
+ * Design:
+ * - session-state / stage-snapshot: simple FIFO queue, no ordering constraint
+ *   (Worker:UI = 1:1, so events arrive in emission order)
+ * - task-progress: version-based ordering only — drop stale (lower version) and
+ *   drop any update after value=100 (completed/skipped/failed final state)
+ * - heartbeat: immediate pass-through, no buffering
+ *
+ * seqNum (distributed sequence number from Worker) is NOT used for ordering here.
+ * It is attached to task-progress events solely so the caller can perform
+ * version-based deduplication across parallel stage Workers.
  */
 
 export type NotificationType = 'session-state' | 'stage-snapshot' | 'task-progress';
 
-export interface SequencedEvent {
-    seqNum: number;
+/** A buffered event carrying an optional version for task-progress ordering. */
+export interface BufferedEvent {
+    /** version is only meaningful for task-progress events */
+    version: number | undefined;
     notificationType: NotificationType;
     payload: unknown;
     timestamp: number;
 }
 
-export interface EventBuffer {
-    events: SequencedEvent[];
-    lastAppliedSeqNum: number | null;
-    gapDetected: boolean;
+export interface FifoEventQueue {
+    events: BufferedEvent[];
+}
+
+export interface TaskProgressState {
+    lastAppliedVersion: number | undefined;
+    /** true once a value=100 event has been applied (final state reached) */
+    finalReached: boolean;
 }
 
 export interface EventBufferManager {
-    bufferEvent(event: SequencedEvent): void;
-    flushBuffer(notificationType: NotificationType): SequencedEvent[];
-    detectGaps(notificationType: NotificationType): number[];
-    getBufferStatus(notificationType: NotificationType): {
-        bufferedCount: number;
-        lastAppliedSeqNum: number | null;
-        hasGaps: boolean;
-    };
+    enqueue(event: BufferedEvent): void;
+    /** Flush all queued events for session-state or stage-snapshot (FIFO, no filtering). */
+    flushFifo(notificationType: 'session-state' | 'stage-snapshot'): BufferedEvent[];
+    /**
+     * Apply version-based ordering for task-progress.
+     * Returns the event if it should be applied, undefined if it should be dropped.
+     */
+    applyTaskProgress(event: BufferedEvent): BufferedEvent | undefined;
     reset(): void;
 }
 
 /**
- * Manages per-notification-type event buffers with seqNum ordering
+ * Manages UI-side event queues.
+ *
+ * session-state / stage-snapshot: FIFO — all events are returned in order.
+ * task-progress: version gate — stale and post-final events are dropped.
  */
 export class UIEventBufferManager implements EventBufferManager {
-    private static readonly MAX_BUFFER_SIZE = 1000;
-    private static readonly BUFFER_CLEANUP_THRESHOLD = 800;
-
-    private buffers: Record<NotificationType, EventBuffer> = {
-        'session-state': { events: [], lastAppliedSeqNum: null, gapDetected: false },
-        'stage-snapshot': { events: [], lastAppliedSeqNum: null, gapDetected: false },
-        'task-progress': { events: [], lastAppliedSeqNum: null, gapDetected: false },
+    private fifoQueues: Record<'session-state' | 'stage-snapshot', FifoEventQueue> = {
+        'session-state': { events: [] },
+        'stage-snapshot': { events: [] },
     };
 
-    bufferEvent(event: SequencedEvent): void {
-        if (!Number.isFinite(event.seqNum) || event.seqNum < 0) {
-            throw new Error(`Invalid seqNum: ${event.seqNum}`);
+    private taskProgressState: TaskProgressState = {
+        lastAppliedVersion: undefined,
+        finalReached: false,
+    };
+
+    enqueue(event: BufferedEvent): void {
+        if (event.notificationType === 'task-progress') {
+            throw new Error(
+                '[UIEventBufferManager] task-progress must be applied via applyTaskProgress, not enqueue',
+            );
         }
-
-        const buffer = this.buffers[event.notificationType];
-        if (!buffer) {
-            throw new Error(`Unknown notification type: ${event.notificationType}`);
+        const queue = this.fifoQueues[event.notificationType];
+        if (!queue) {
+            throw new Error(`[UIEventBufferManager] Unknown notification type: ${event.notificationType}`);
         }
-
-        // Insert event in seqNum order
-        const insertIndex = this.findInsertIndex(buffer.events, event.seqNum);
-        buffer.events.splice(insertIndex, 0, event);
-
-        // Buffer size limit check (after insertion)
-        if (buffer.events.length > UIEventBufferManager.MAX_BUFFER_SIZE) {
-            // Remove old events (FIFO)
-            const removeCount = buffer.events.length - UIEventBufferManager.BUFFER_CLEANUP_THRESHOLD;
-            buffer.events.splice(0, removeCount);
-            console.warn(`[UIEventBufferManager] Buffer overflow for ${event.notificationType}, removed ${removeCount} old events`);
-        }
-
-        // Detect gaps
-        this.updateGapDetection(event.notificationType);
+        queue.events.push(event);
     }
 
-    flushBuffer(notificationType: NotificationType): SequencedEvent[] {
-        const buffer = this.buffers[notificationType];
-        if (!buffer) {
-            throw new Error(`Unknown notification type: ${notificationType}`);
+    flushFifo(notificationType: 'session-state' | 'stage-snapshot'): BufferedEvent[] {
+        const queue = this.fifoQueues[notificationType];
+        if (!queue) {
+            throw new Error(`[UIEventBufferManager] Unknown notification type: ${notificationType}`);
         }
-
-        const readyEvents: SequencedEvent[] = [];
-        const expectedSeqNum = (buffer.lastAppliedSeqNum ?? -1) + 1;
-
-        // Find consecutive events starting from expected seqNum
-        let currentSeqNum = expectedSeqNum;
-        while (buffer.events.length > 0 && buffer.events[0]?.seqNum === currentSeqNum) {
-            const event = buffer.events.shift();
-            if (!event) break;
-            readyEvents.push(event);
-            buffer.lastAppliedSeqNum = currentSeqNum;
-            currentSeqNum++;
-        }
-
-        // Update gap detection after flush
-        this.updateGapDetection(notificationType);
-
-        return readyEvents;
+        const drained = queue.events;
+        this.fifoQueues[notificationType] = { events: [] };
+        return drained;
     }
 
-    detectGaps(notificationType: NotificationType): number[] {
-        const buffer = this.buffers[notificationType];
-        if (!buffer || buffer.events.length === 0) {
-            return [];
+    /**
+     * Version-based gate for task-progress events.
+     *
+     * Rules:
+     * 1. If finalReached (value=100 already applied), drop all subsequent events.
+     * 2. If version is undefined, always accept (no ordering info available).
+     * 3. If version <= lastAppliedVersion, drop (stale / duplicate).
+     * 4. Otherwise accept and update lastAppliedVersion.
+     * 5. After accepting, if the event's progress value is 100, set finalReached=true.
+     */
+    applyTaskProgress(event: BufferedEvent): BufferedEvent | undefined {
+        if (event.notificationType !== 'task-progress') {
+            throw new Error(
+                `[UIEventBufferManager] applyTaskProgress called with wrong type: ${event.notificationType}`,
+            );
         }
 
-        const gaps: number[] = [];
-        const expectedSeqNum = (buffer.lastAppliedSeqNum ?? -1) + 1;
-
-        // Check for gap at the beginning
-        const firstEvent = buffer.events[0];
-        if (buffer.events.length > 0 && firstEvent && firstEvent.seqNum > expectedSeqNum) {
-            for (let seq = expectedSeqNum; seq < firstEvent.seqNum; seq++) {
-                gaps.push(seq);
-            }
+        // Rule 1: final state already reached — drop everything after
+        if (this.taskProgressState.finalReached) {
+            return undefined;
         }
 
-        // Check for gaps between buffered events
-        for (let i = 0; i < buffer.events.length - 1; i++) {
-            const currentEvent = buffer.events[i];
-            const nextEvent = buffer.events[i + 1];
-            if (!currentEvent || !nextEvent) continue;
+        const { version } = event;
 
-            const currentSeq = currentEvent.seqNum;
-            const nextSeq = nextEvent.seqNum;
-
-            for (let seq = currentSeq + 1; seq < nextSeq; seq++) {
-                gaps.push(seq);
-            }
+        // Rule 2: no version info — accept unconditionally
+        if (version === undefined) {
+            this.maybeMarkFinal(event);
+            return event;
         }
 
-        return gaps;
+        if (!Number.isFinite(version) || version < 0) {
+            throw new Error(`[UIEventBufferManager] Invalid task-progress version: ${version}`);
+        }
+
+        const last = this.taskProgressState.lastAppliedVersion;
+
+        // Rule 3: stale or duplicate
+        if (last !== undefined && version <= last) {
+            return undefined;
+        }
+
+        // Rule 4: accept
+        this.taskProgressState.lastAppliedVersion = version;
+
+        // Rule 5: mark final if value=100
+        this.maybeMarkFinal(event);
+
+        return event;
     }
 
-    getBufferStatus(notificationType: NotificationType): {
-        bufferedCount: number;
-        lastAppliedSeqNum: number | null;
-        hasGaps: boolean;
-    } {
-        const buffer = this.buffers[notificationType];
-        if (!buffer) {
-            throw new Error(`Unknown notification type: ${notificationType}`);
+    private maybeMarkFinal(event: BufferedEvent): void {
+        const payload = event.payload as { value?: unknown } | null | undefined;
+        if (payload !== null && payload !== undefined && payload.value === 100) {
+            this.taskProgressState.finalReached = true;
         }
-
-        return {
-            bufferedCount: buffer.events.length,
-            lastAppliedSeqNum: buffer.lastAppliedSeqNum,
-            hasGaps: buffer.gapDetected,
-        };
     }
 
     reset(): void {
-        for (const notificationType of Object.keys(this.buffers) as NotificationType[]) {
-            this.buffers[notificationType] = {
-                events: [],
-                lastAppliedSeqNum: null,
-                gapDetected: false,
-            };
-        }
+        this.fifoQueues = {
+            'session-state': { events: [] },
+            'stage-snapshot': { events: [] },
+        };
+        this.taskProgressState = {
+            lastAppliedVersion: undefined,
+            finalReached: false,
+        };
     }
 
-    private findInsertIndex(events: SequencedEvent[], seqNum: number): number {
-        let left = 0;
-        let right = events.length;
-
-        while (left < right) {
-            const mid = Math.floor((left + right) / 2);
-            const midEvent = events[mid];
-            if (!midEvent) break;
-
-            if (midEvent.seqNum < seqNum) {
-                left = mid + 1;
-            } else {
-                right = mid;
-            }
-        }
-
-        return left;
-    }
-
-    private updateGapDetection(notificationType: NotificationType): void {
-        const buffer = this.buffers[notificationType];
-        const gaps = this.detectGaps(notificationType);
-        buffer.gapDetected = gaps.length > 0;
+    /** Exposed for testing only. */
+    getTaskProgressState(): Readonly<TaskProgressState> {
+        return { ...this.taskProgressState };
     }
 }
 
 /**
- * Log event reception and processing on UI side for monitoring and debugging.
- * Tracks delivery latency from Worker emission to UI processing.
- */
-export const logUIEventReception = (
-    events: SequencedEvent[],
-    processingStatus: 'success' | 'error',
-    error?: unknown,
-): void => {
-    if (events.length === 0) return;
-    const now = Date.now();
-    const latencies = events.map((e) => now - e.timestamp);
-    const avgLatency = latencies.reduce((sum, l) => sum + l, 0) / latencies.length;
-
-    if (processingStatus === 'error') {
-        console.error('[UIEventReception] Events processed with error', {
-            eventCount: events.length,
-            processingStatus,
-            avgLatencyMs: avgLatency,
-            error: error instanceof Error ? { name: error.name, message: error.message } : error,
-        });
-    } else {
-        console.log('[UIEventReception] Events processed on UI side', {
-            eventCount: events.length,
-            processingStatus,
-            avgLatencyMs: avgLatency,
-            seqNums: events.map((e) => e.seqNum),
-        });
-    }
-};
-
-/**
- * Heartbeat events are processed immediately without buffering
+ * Heartbeat events are processed immediately without buffering.
  */
 export interface HeartbeatProcessor {
     processHeartbeat(event: { nodeId: string; heartbeatAt?: number }): void;
@@ -223,7 +171,6 @@ export class ImmediateHeartbeatProcessor implements HeartbeatProcessor {
     constructor(private callback: (event: { nodeId: string; heartbeatAt?: number }) => void) { }
 
     processHeartbeat(event: { nodeId: string; heartbeatAt?: number }): void {
-        // Process immediately without buffering (latest value only)
         this.callback(event);
     }
 }

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildSessionStateAtomBridge.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildSessionStateAtomBridge.ts
@@ -6,11 +6,7 @@ import { useSetAtom } from 'jotai';
 import { dispatchBuildSessionEventAtom } from '~/ui/atoms/buildSessionStateAtoms';
 import { createBuildSessionWorkerEventAdapter } from '~/ui/atoms/buildSessionWorkerEventAdapter';
 import type { ShapeStageId } from '~/ui/atoms/buildSessionStateAtoms';
-import {
-    UIEventBufferManager,
-    type SequencedEvent,
-    type NotificationType,
-} from './eventBufferingUI';
+import { UIEventBufferManager, type BufferedEvent } from './eventBufferingUI';
 
 const SHAPE_NODE_TYPE = 'shape' as NodeType;
 const SHAPE_STAGE_IDS = ['source', 'geometry', 'tileEmit'] as const satisfies readonly ShapeStageId[];
@@ -20,17 +16,16 @@ type UiSyncPhase = 'ui-initializing' | 'running';
 type TaskSnapshotEvent = Extract<BuildTaskUpdateEvent, { type: 'snapshot' }> & {
     version?: unknown;
     stage?: unknown;
-    seqNum?: number;
 };
 
-interface SequencedBuildProgressEvent extends BuildProgressEvent {
-    seqNum?: number;
+interface VersionedBuildProgressEvent extends BuildProgressEvent {
+    /** Distributed version number from Worker (task-progress ordering only) */
+    version?: number;
 }
 
-interface SequencedSessionStateEvent {
+interface SessionStateEvent {
     nodeId: string;
     sessionRecord?: Record<string, unknown> | null;
-    seqNum?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +84,6 @@ export const resolveSnapshotTargetStages = (event: TaskSnapshotEvent): ShapeStag
     return Array.from(snapshotStages);
 };
 
-
 const resolveUiSyncSignalFromSessionStageId = (
     value: unknown,
 ): { stageId: ShapeStageId; phase: UiSyncPhase } | undefined => {
@@ -141,6 +135,7 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
 
         let cancelled = false;
         let unsubscribeAll: (() => void) | null = null;
+
         const uiSyncByStage: Record<ShapeStageId, UiSyncPhase> = {
             source: 'ui-initializing',
             geometry: 'ui-initializing',
@@ -154,7 +149,8 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
         let activeStageId: ShapeStageId = 'source';
         let flushTimerId: number | null = null;
 
-        // seqNum-based buffer for events that carry sequence numbers
+        // Per-stage buffer manager for task-progress version gating.
+        // session-state and stage-snapshot use FIFO queues inside the manager.
         const eventBufferManager = new UIEventBufferManager();
 
         const dispatchUiSyncPhase = (stageId: ShapeStageId, phase: UiSyncPhase): void => {
@@ -179,43 +175,13 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             }
         };
 
-        const flushSeqNumBufferedEvents = (): void => {
-            flushTimerId = null;
-            const notificationTypes: NotificationType[] = ['session-state', 'stage-snapshot', 'task-progress'];
-            for (const notificationType of notificationTypes) {
-                const readyEvents = eventBufferManager.flushBuffer(notificationType);
-                for (const sequencedEvent of readyEvents) {
-                    switch (notificationType) {
-                        case 'session-state':
-                            processSessionStateEvent(sequencedEvent.payload as SequencedSessionStateEvent);
-                            break;
-                        case 'stage-snapshot':
-                            processTaskSnapshotEvent(sequencedEvent.payload as TaskSnapshotEvent);
-                            break;
-                        case 'task-progress':
-                            processProgressEvent(sequencedEvent.payload as SequencedBuildProgressEvent);
-                            break;
-                    }
-                }
-            }
-        };
-
-        const scheduleProgressFlush = (): void => {
+        const scheduleFlush = (): void => {
             if (flushTimerId !== null) return;
             if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
                 flushTimerId = window.requestAnimationFrame(flushProgressBuffer);
                 return;
             }
             flushTimerId = window.setTimeout(flushProgressBuffer, 0);
-        };
-
-        const scheduleSeqNumFlush = (): void => {
-            if (flushTimerId !== null) return;
-            if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-                flushTimerId = window.requestAnimationFrame(flushSeqNumBufferedEvents);
-                return;
-            }
-            flushTimerId = window.setTimeout(flushSeqNumBufferedEvents, 0);
         };
 
         const processTaskSnapshotEvent = (snapshotEvent: TaskSnapshotEvent): void => {
@@ -232,10 +198,10 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
                 if (snapshotStages.size > 0 && !snapshotStages.has(stageId)) continue;
                 dispatchUiSyncPhase(stageId, 'running');
             }
-            scheduleProgressFlush();
+            scheduleFlush();
         };
 
-        const processProgressEvent = (event: SequencedBuildProgressEvent): void => {
+        const processProgressEvent = (event: VersionedBuildProgressEvent): void => {
             const stageId = resolveShapeStageId(event.stage);
             if (!stageId) {
                 adapter.onProgressEvent(event);
@@ -247,10 +213,10 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             }
             progressBufferByStage[stageId].push(event);
             if (uiSyncByStage[stageId] !== 'running') return;
-            scheduleProgressFlush();
+            scheduleFlush();
         };
 
-        const processSessionStateEvent = (event: SequencedSessionStateEvent): void => {
+        const processSessionStateEvent = (event: SessionStateEvent): void => {
             adapter.onSessionState(event);
             const signal = resolveUiSyncSignalFromSessionStageId(event.sessionRecord?.stageId);
             if (!signal) return;
@@ -260,58 +226,66 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             }
             dispatchUiSyncPhase(stageId, signal.phase);
             if (signal.phase === 'running') {
-                scheduleProgressFlush();
+                scheduleFlush();
             }
         };
 
+        // ---------------------------------------------------------------------------
+        // Incoming event handlers — all events are enqueued immediately on arrival.
+        // No seqNum-based gap detection; session-state and stage-snapshot are FIFO.
+        // task-progress goes through version gating only.
+        // ---------------------------------------------------------------------------
+
         const onTaskEvent = (event: BuildTaskUpdateEvent): void => {
             if (event.type === 'snapshot') {
-                const snapshotEvent = event as TaskSnapshotEvent;
-                if (typeof snapshotEvent.seqNum === 'number') {
-                    const sequencedEvent: SequencedEvent = {
-                        seqNum: snapshotEvent.seqNum,
-                        notificationType: 'stage-snapshot',
-                        payload: snapshotEvent,
-                        timestamp: Date.now(),
-                    };
-                    eventBufferManager.bufferEvent(sequencedEvent);
-                    scheduleSeqNumFlush();
-                    return;
-                }
-                processTaskSnapshotEvent(snapshotEvent);
+                // Enqueue into FIFO queue, then flush immediately via rAF
+                const buffered: BufferedEvent = {
+                    version: undefined,
+                    notificationType: 'stage-snapshot',
+                    payload: event as TaskSnapshotEvent,
+                    timestamp: Date.now(),
+                };
+                eventBufferManager.enqueue(buffered);
+                flushFifoQueues();
                 return;
             }
             adapter.onTaskEvent(event);
         };
 
-        const onProgressEvent = (event: SequencedBuildProgressEvent): void => {
-            if (typeof event.seqNum === 'number') {
-                const sequencedEvent: SequencedEvent = {
-                    seqNum: event.seqNum,
-                    notificationType: 'task-progress',
-                    payload: event,
-                    timestamp: Date.now(),
-                };
-                eventBufferManager.bufferEvent(sequencedEvent);
-                scheduleSeqNumFlush();
-                return;
+        const onProgressEvent = (event: VersionedBuildProgressEvent): void => {
+            const buffered: BufferedEvent = {
+                version: event.version,
+                notificationType: 'task-progress',
+                payload: event,
+                timestamp: Date.now(),
+            };
+            const accepted = eventBufferManager.applyTaskProgress(buffered);
+            if (accepted) {
+                processProgressEvent(event);
             }
-            processProgressEvent(event);
         };
 
-        const onSessionState = (event: SequencedSessionStateEvent): void => {
-            if (typeof event.seqNum === 'number') {
-                const sequencedEvent: SequencedEvent = {
-                    seqNum: event.seqNum,
-                    notificationType: 'session-state',
-                    payload: event,
-                    timestamp: Date.now(),
-                };
-                eventBufferManager.bufferEvent(sequencedEvent);
-                scheduleSeqNumFlush();
-                return;
+        const onSessionState = (event: SessionStateEvent): void => {
+            // Enqueue into FIFO queue, then flush immediately via rAF
+            const buffered: BufferedEvent = {
+                version: undefined,
+                notificationType: 'session-state',
+                payload: event,
+                timestamp: Date.now(),
+            };
+            eventBufferManager.enqueue(buffered);
+            flushFifoQueues();
+        };
+
+        const flushFifoQueues = (): void => {
+            // Drain session-state FIFO
+            for (const ev of eventBufferManager.flushFifo('session-state')) {
+                processSessionStateEvent(ev.payload as SessionStateEvent);
             }
-            processSessionStateEvent(event);
+            // Drain stage-snapshot FIFO
+            for (const ev of eventBufferManager.flushFifo('stage-snapshot')) {
+                processTaskSnapshotEvent(ev.payload as TaskSnapshotEvent);
+            }
         };
 
         const run = async () => {
@@ -331,11 +305,11 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
                 },
                 onProgressEvent: (event) => {
                     if (cancelled) return;
-                    onProgressEvent(event as SequencedBuildProgressEvent);
+                    onProgressEvent(event as VersionedBuildProgressEvent);
                 },
                 onSessionState: (event) => {
                     if (cancelled) return;
-                    onSessionState(event as SequencedSessionStateEvent);
+                    onSessionState(event as SessionStateEvent);
                 },
                 onHeartbeat: (event) => {
                     if (cancelled) return;


### PR DESCRIPTION
Closes #1042

## 変更概要

Worker→UI イベント配信で seqNum 連続性チェック（gap 検出）が全イベントタイプに誤適用されており、`subscribeAll` の `await` 完了前に Worker がイベントを emit すると seqNum が 0 から始まらず、UI に何も表示されない不具合を修正。

## 変更内容

### `eventBufferingUI.ts`
- 旧: seqNum 連続性チェック付き `UIEventBufferManager`
- 新: `session-state`/`stage-snapshot` は FIFO キュー（`enqueue`/`flushFifo`）、`task-progress` は version 判定のみ（`applyTaskProgress`）

### `useShapeBuildSessionStateAtomBridge.ts`
- seqNum 分岐を削除、全イベントを受信時点でキューに積む
- `flushSeqNumBufferedEvents`/`scheduleSeqNumFlush` を廃止し `scheduleFlush` に統一

### テスト
- `eventBufferingUI.unit.test.ts` — 新 API に対応
- `eventArchitectureProperties.property.test.ts` — 新 API に対応
- `eventDeliveryMonitoringAccuracy.property.test.ts` — 旧 API 呼び出しを新 API に置換
- `eventDeliveryExtendedScenarios.property.test.ts` — 旧 API 呼び出しを新 API に置換

## 検証

`pnpm -w turbo run test --filter @hierarchidb/shape-plugin` → exit 0（423 passed）