### PR TITLE
fix(shape-plugin): add 'queued' to BuildSessionLifecyclePhase and mapRuntimeStatusToPhase (#1055)

### DIFF
--- a/packages/ui/build-sessions/src/state/createBuildSessionStateAtoms.ts
+++ b/packages/ui/build-sessions/src/state/createBuildSessionStateAtoms.ts
@@ -3,6 +3,7 @@ import { atom } from 'jotai';
 export type BuildSessionLifecyclePhase =
   | 'idle'
   | 'starting'
+  | 'queued'
   | 'running'
   | 'pausing'
   | 'paused'

--- a/plugins/shape-plugin/src/ui/__tests__/atoms/unit/buildSessionWorkerEventAdapter.unit.test.ts
+++ b/plugins/shape-plugin/src/ui/__tests__/atoms/unit/buildSessionWorkerEventAdapter.unit.test.ts
@@ -205,4 +205,20 @@ describe('buildSessionWorkerEventAdapter', () => {
     // heartbeat does not change phase; phase remains idle
     expect(runtime.phase).toBe('idle');
   });
+
+  it('maps onSessionState with status queued to phase queued (isActive=true)', () => {
+    const adapter = createBuildSessionWorkerEventAdapter('node-1', dispatch);
+    adapter.onSessionState({
+      nodeId: 'node-1',
+      sessionRecord: {
+        status: 'queued',
+        startedAt: 100,
+      },
+    });
+
+    const runtime = store.get(buildSessionLifecycleAtom);
+    expect(runtime.phase).toBe('queued');
+    expect(runtime.isActive).toBe(true);
+    expect(runtime.startedAt).toBe(100);
+  });
 });

--- a/plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts
+++ b/plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts
@@ -30,6 +30,7 @@ const assertProgressRange = (value: number): number => {
 
 const isActivePhase = (phase: ShapeSessionPhase): boolean => (
   phase === 'starting'
+  || phase === 'queued'
   || phase === 'running'
   || phase === 'pausing'
   || phase === 'resuming'

--- a/plugins/shape-plugin/src/ui/atoms/buildSessionWorkerEventAdapter.ts
+++ b/plugins/shape-plugin/src/ui/atoms/buildSessionWorkerEventAdapter.ts
@@ -51,6 +51,7 @@ const toShapeEvent = (
 const mapRuntimeStatusToPhase = (status: string): ShapeSessionPhase => {
   if (status === 'idle') return 'idle';
   if (status === 'starting') return 'starting';
+  if (status === 'queued') return 'queued';
   if (status === 'running') return 'running';
   if (status === 'pausing') return 'pausing';
   if (status === 'paused') return 'paused';
@@ -63,6 +64,7 @@ const mapRuntimeStatusToPhase = (status: string): ShapeSessionPhase => {
 
 const isActivePhase = (phase: ShapeSessionPhase): boolean => (
   phase === 'starting'
+  || phase === 'queued'
   || phase === 'running'
   || phase === 'pausing'
   || phase === 'resuming'


### PR DESCRIPTION
## Summary

Fixes #1055

Worker sends `sessionRecord.status = 'queued'` when a build session is queued server-side. `mapRuntimeStatusToPhase('queued')` threw an error, which was swallowed by `run().catch()`, halting all subsequent event processing. As a result, `uiSyncPhase` stayed at `'ui-initializing'` and progress was never displayed in the UI.

## Changes

- `packages/ui/build-sessions/src/state/createBuildSessionStateAtoms.ts`: Add `'queued'` to `BuildSessionLifecyclePhase`
- `plugins/shape-plugin/src/ui/atoms/buildSessionWorkerEventAdapter.ts`: Add `'queued'` to `mapRuntimeStatusToPhase` and `isActivePhase`
- `plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts`: Add `'queued'` to `isActivePhase`
- `plugins/shape-plugin/src/ui/__tests__/atoms/unit/buildSessionWorkerEventAdapter.unit.test.ts`: Add test case for `queued` → `phase: 'queued', isActive: true`

## Verification

- typecheck: 100/100 exit 0
- test: 418 passed, 3 skipped exit 0