### PR TITLE
fix(shape-plugin): fix computeStageDuration call sites to use computeCompletedStageDuration (#1066)

### DIFF
--- a/plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts
+++ b/plugins/shape-plugin/src/ui/atoms/buildSessionStateAtoms.ts
@@ -250,9 +250,9 @@ const computeCompletedStageDuration = (
 export const stageDurationMsByStageAtom = atom<Record<ShapeStageId, number>>((get) => {
   const timing = get(stageTimingByStageAtom);
   return {
-    source: computeStageDuration(timing.source),
-    geometry: computeStageDuration(timing.geometry),
-    tileEmit: computeStageDuration(timing.tileEmit),
+    source: computeCompletedStageDuration(timing.source),
+    geometry: computeCompletedStageDuration(timing.geometry),
+    tileEmit: computeCompletedStageDuration(timing.tileEmit),
   };
 });
 


### PR DESCRIPTION
## 原因
#1058 で `computeStageDuration` → `computeCompletedStageDuration` にリネームしたが、`stageDurationMsByStageAtom` 内の呼び出し3箇所が更新されなかった。

## 発生範囲
`buildSessionStateAtoms.ts` L253-255（`stageDurationMsByStageAtom`）

## 修正
`computeStageDuration` → `computeCompletedStageDuration` に3箇所置換

Closes #1066