### PR TITLE
refactor(shape-plugin): align Worker→UI events to 4-event spec (#1074)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@
 - 常に圧縮・明確化を優先し、重複記述を残さない。
 - 不具合報告では必ず「原因 / 発生範囲 / 修正方法 / 適用範囲」を示す。
 
+## 仕様書の更新ルール（必須）
+
+- 実装上の判断（設計変更・仕様の解釈確定・矛盾解消）が会話またはコードで確定したら、対応する `docs/` 配下の仕様書を**同じタイミングで**更新する。
+- 仕様書の更新を後回しにすることを禁止する。「あとで直す」は仕様書と実装の乖離を生む。
+- 仕様書に矛盾を発見した場合は、実装に着手する前にユーザーに報告し、仕様書を修正してから実装する。
+
 ## 高優先ルール（非交渉）
 
 - 契約違反の隠蔽を禁止する（高優先）。
@@ -27,12 +33,13 @@
 
 ## 実装着手ゲート（順番固定）
 
-1. DoD を提示し、ユーザー承認を得る。
-2. `gh issue create` で Issue を起票。
-3. Issue を Project に追加し `Status=Doing` を設定。
-4. ブランチ作成（`<type>/<scope>/<slug>`）。
-5. `TASKS.md` の `Doing` に `#<issue> / branch / start` を1行記録。
-6. ここまで完了後に、コード編集・検証コマンドを開始する。
+1. **仕様書・設計書の確認（必須）**: 対象コンポーネント・機能に関連する `docs/` 配下の仕様書・設計書を必ず読む。仕様書が存在するにもかかわらず参照せずに実装・修正を行うことを禁止する。仕様書と実装の乖離を発見した場合は、修正前にユーザーに報告する。
+2. DoD を提示し、ユーザー承認を得る。
+3. `gh issue create` で Issue を起票。
+4. Issue を Project に追加し `Status=Doing` を設定。
+5. ブランチ作成（`<type>/<scope>/<slug>`）。
+6. `TASKS.md` の `Doing` に `#<issue> / branch / start` を1行記録。
+7. ここまで完了後に、コード編集・検証コマンドを開始する。
 
 ## 起票失敗時の扱い
 
@@ -42,6 +49,8 @@
 
 ## 禁止事項
 
+- 仕様書・設計書を参照せずに実装・修正を行うこと（`docs/` 配下に関連文書が存在する場合）。
+- 仕様書と実装の乖離をユーザーに報告せずに放置・隠蔽すること。
 - Issue 未起票の実装・修正・コミット。
 - Issue番号なし PR 作成。
 - `TASKS.md` の台帳化（Done 詳細・検証本文の持ち込み）。
@@ -141,6 +150,16 @@
 - `docs/ts-file-naming-guideline.md`
 - `docs/draft-dialog-hosting.md`
 - `PLANS.md`（大規模変更時の ExecPlan）
+
+## 仕様書・設計書の所在（shape plugin）
+
+実装・修正・調査の際は以下を最初に参照すること。
+
+- `docs/build-session-spec.md` — ビルドセッションライフサイクル・タスクステータス・ステージ進行規則
+- `docs/build-session-worker-ui-event-spec.md` — Worker→UI イベントの正規仕様（イベント型・ペイロード契約・UI atom 更新規則）
+- `docs/build-session-worker-ui-event-design.md` — 同仕様の設計詳細
+- `docs/shape-build-session-ssot-execplan.md` — SSOT リファクタの ExecPlan
+- `docs/vt-shape-pipeline-design.md` — shape パイプライン設計
 
 ## Git ワークツリー運用（並列作業・標準手順）
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,8 @@
 # TASKS.md
 
 ## Doing
+- #1074 / `refactor/shape-plugin/worker-ui-event-spec-alignment` / 2026-03-15 開始
+- #1068 / `fix/shape-plugin/remove-stale-elapsed-code-1068` / 2026-03-15 開始
 - #1066 / `fix/shape-plugin/compute-stage-duration-rename-1066` / 2026-03-15 開始
 - #1047 / `fix/shape-plugin/remove-sequenced-event-wrapper` / 2026-03-14 開始
 - #1030 / `fix/shape-plugin/task-failure-error-message` / 2026-03-14 開始
@@ -29,6 +31,20 @@
 - 2026-03-09: mapでshape-styler同一フォルダ紐付け実装着手 blocked（`gh issue create` 実行時 `gh: command not found`、`apt-get install gh` はプロキシ 403 で失敗）。解除条件: `gh` CLI を利用可能にする（プリインストールまたは実行可能パス提供）。
 
 ## 今日の運用ログ
+
+- 2026-03-15: #1072 computeCompletedStageDuration 純粋関数化・as never キャスト除去・PR #1073作成
+  - buildSessionStateAtoms.ts: stageCompletedAt undefined 時に Date.now() ではなく 0 を返すよう修正
+  - eventBuffering.unit.test.ts: as never → SessionStateChangeEvent/SessionHeartbeatEvent/TaskProgressEvent 正型に置換
+  - eventDeliveryExtendedScenarios.property.test.ts: makeTaskEvent version を number | undefined に変更
+  - eventArchitectureProperties.property.test.ts: as never → as unknown as EventPayload/SessionHeartbeatEvent に変更
+  - レビュー対応: emitHeartbeat を heartbeatAt → timestamp/isActive/lastActivity 正型に修正、nodeIdStr → nodeId に修正
+  - test: 442 passed | 3 skipped exit 0
+
+
+  - useBuildProgressPanelStateSideEffects/RuntimeState から setTotalElapsedSnapshot 関連削除
+  - eventBuffering.ts アンサブスクライブ関数修正
+  - 旧API テスト6ファイルを現行 API（UIEventBufferManager/unconditionalEventStreamer）に書き直し
+  - test: 442 passed | 3 skipped exit 0、typecheck: 100/100 exit 0
 
 - 2026-03-15: #1066 computeStageDuration 呼び出し箇所修正・PR #1067作成
   - stageDurationMsByStageAtom の3箇所を computeCompletedStageDuration に修正（#1058 リネーム漏れ）

--- a/docs/build-session-worker-ui-event-design.md
+++ b/docs/build-session-worker-ui-event-design.md
@@ -56,11 +56,10 @@ frequently; must not carry any information beyond the progress value itself.
 |---|---|---|
 | `stageId` | `StageId` | Stage the task belongs to |
 | `value` | `number` | Progress 0–100 (finite; outside range is a contract violation) |
-| `phase` | `SessionPhase` | Current session phase at time of emission |
 | `message` | `string \| undefined` | Optional human-readable label |
 | `metadata` | `Record<string, unknown> \| undefined` | Optional opaque metadata |
 
-**UI effect**: Update the `progress` field of the corresponding stage atom entry.
+**Note**: `phase` is intentionally absent. It was erroneously included in the original design. Session phase is managed exclusively by `sessionStatusUpdated`.
 
 ---
 
@@ -192,16 +191,17 @@ remainingMs = averageMs × (total - done - recycled)
 `recycled` tasks are excluded from both the elapsed-time denominator and the
 remaining-count numerator because no processing time was spent on them.
 
+`done` = `completed` + `failed` + `skipped`. Failed tasks are counted as done because processing time was spent on them and they will not be retried in the current session.
+
 ---
 
 ## Event Version Ordering
 
-- `stageSnapshotUpdated`, `taskProgressUpdated`, `sessionStatusUpdated` each carry
-  `eventVersion: number`.
-- Events are accepted only if `eventVersion > lastAccepted` per event stream.
-- `heartbeat` does not carry `eventVersion`; it is always applied unconditionally.
-- `lastAcceptedEventVersion` is removed from the top-level `meta` object. Version
-  tracking is internal to the reducer and not exposed in the public state shape.
+`eventVersion` fields are **not used**. All events are applied unconditionally in FIFO order per channel. The adapter does not perform deduplication or version gating.
+
+`heartbeat` is always applied unconditionally.
+
+`lastAcceptedEventVersion` is removed from the top-level `meta` object. Version tracking is not part of the design.
 
 ---
 

--- a/docs/build-session-worker-ui-event-spec.md
+++ b/docs/build-session-worker-ui-event-spec.md
@@ -33,11 +33,15 @@ type SessionStatusUpdatedEvent = {
     startedAt?: number;            // session start timestamp (ms)
     completedAt?: number;          // session end timestamp (ms, terminal states only)
     stopReason?: string;           // e.g. 'user-pause' | 'failed' | 'completed' | 'route-leave'
+    stageId?: StageId;             // current stage at time of event (undefined if no stage is active)
+    inactiveMs?: number;           // cumulative session-level inactive duration (ms)
+    stageStartedAt?: number;       // current stage start timestamp (ms)
+    stageInactiveMs?: number;      // cumulative inactive duration for current stage (ms)
   };
 };
 ```
 
-**UI-side effect**: Update `lifecycle.phase`, `lifecycle.isActive`, `lifecycle.startedAt`, `lifecycle.completedAt`, `lifecycleExtras.stopReason`.
+**UI-side effect**: Update `lifecycle.phase`, `lifecycle.isActive`, `lifecycle.startedAt`, `lifecycle.completedAt`, `lifecycleExtras.stopReason`, `lifecycleExtras.stageId`, `lifecycleExtras.inactiveMs`, `lifecycleExtras.stageStartedAt`, `lifecycleExtras.stageInactiveMs`.
 
 **Deduplication**: None. Every emission is applied unconditionally. The caller (adapter) is responsible for not emitting duplicate events.
 
@@ -71,10 +75,12 @@ type HeartbeatEvent = {
 
 Replaces: `taskSnapshotReceived`, `taskUpdated`, `taskDeleted`
 
-**When emitted**: Whenever the Worker has a new authoritative task list for a stage. This includes:
-- Initial snapshot on subscription start
+**When emitted**: Whenever the Worker has a new authoritative task list for a stage that has already started. This includes:
+- Initial snapshot on subscription start (only for stages that have started)
 - After any task status change (the Worker sends the full updated list)
 - When all tasks for a stage are removed (empty array)
+
+**Not emitted**: For stages that have not yet started. A stage that has not started has no `stageStartedAt` and no tasks; emitting a snapshot for it would require a sentinel value, which is a contract violation.
 
 **Payload**:
 
@@ -84,7 +90,7 @@ type StageSnapshotUpdatedEvent = {
   payload: {
     stageId: StageId;
     tasks: TaskSummary[];          // full replacement — empty array means zero tasks
-    stageStartedAt: number;        // timestamp when this stage first started (ms)
+    stageStartedAt: number;        // timestamp when this stage first started (ms); required — only emitted after stage has started
     stageInactiveMs: number;       // cumulative inactive (paused) duration for this stage (ms)
     stageCompletedAt?: number;     // timestamp when this stage last completed (ms); undefined if currently active
   };
@@ -134,7 +140,7 @@ type TaskProgressUpdatedEvent = {
 
 **UI-side effect**: Update `stageProgressAtom[stageId].value` and `.message` / `.metadata`.
 
-**Removed from payload**: `phase` (was previously included in `progressReceived`). Session phase is managed exclusively by `sessionStatusUpdated`. Mixing phase into progress events was the source of redundant phase updates.
+**Removed from payload**: `phase` (was previously included in `progressReceived` and erroneously retained in the design doc). Session phase is managed exclusively by `sessionStatusUpdated`. Mixing phase into progress events is the source of redundant phase updates.
 
 ---
 
@@ -252,4 +258,4 @@ The `BuildSessionWorkerEventAdapter` translates raw Worker wire events into the 
 3. Mapping Worker-side status strings to `SessionPhase` — unknown values throw.
 4. Splitting a multi-stage task snapshot into per-stage `stageSnapshotUpdated` events.
 
-The adapter does **not** perform deduplication or version gating. That responsibility is removed.
+The adapter does **not** perform deduplication or version gating. That responsibility is removed. `eventVersion` fields are not used; each event stream is applied unconditionally in FIFO order.

--- a/packages/ui/build-sessions/src/state/createBuildSessionWorkerEventAdapter.ts
+++ b/packages/ui/build-sessions/src/state/createBuildSessionWorkerEventAdapter.ts
@@ -1,34 +1,72 @@
 import type {
-  BuildProgressEvent,
   BuildSessionRuntimeRecord,
   BuildTaskSummary,
-  BuildTaskUpdateEvent,
 } from '@hierarchidb/build-api';
 import type { BuildSessionStateEvent } from './createBuildSessionStateAtoms.js';
 
 type RuntimeLike = BuildSessionRuntimeRecord;
-type ProgressLike = BuildProgressEvent;
 
 type AdapterConfig<StageId extends string, SessionPhase extends string> = {
   stages: readonly StageId[];
   resolveStageId: (value: unknown) => StageId;
   mapRuntimeStatusToPhase: (status: RuntimeLike['status']) => SessionPhase;
   mapSessionRecordStatusToPhase: (status: unknown) => SessionPhase;
-  isActivePhase: (phase: SessionPhase) => boolean;
-  resolveProgressValue: (event: ProgressLike) => number;
 };
 
 type Dispatch<StageId extends string, SessionPhase extends string> = (
   event: BuildSessionStateEvent<StageId, SessionPhase, BuildTaskSummary>,
 ) => void;
 
+// Canonical Worker→UI event types accepted by the adapter.
+// These match the 4-event spec in docs/build-session-worker-ui-event-spec.md.
+export type AdapterSessionStatusUpdatedEvent = {
+  type: 'sessionStatusUpdated';
+  payload: {
+    nodeId: string;
+    phase: string;
+    isActive: boolean;
+    startedAt?: number;
+    completedAt?: number;
+    stopReason?: string;
+  };
+};
+
+export type AdapterStageSnapshotUpdatedEvent = {
+  type: 'stageSnapshotUpdated';
+  payload: {
+    stageId: string;
+    tasks: BuildTaskSummary[];
+    stageStartedAt: number;
+    stageInactiveMs: number;
+    stageCompletedAt?: number;
+  };
+};
+
+export type AdapterTaskProgressUpdatedEvent = {
+  type: 'taskProgressUpdated';
+  payload: {
+    stageId: string;
+    value: number;
+    message?: string;
+    metadata?: Record<string, unknown>;
+  };
+};
+
+export type AdapterHeartbeatEvent = {
+  type: 'heartbeat';
+  payload: {
+    nodeId: string;
+    heartbeatAt: number;
+  };
+};
+
 export type BuildSessionWorkerEventAdapter = {
   onRuntimeRecord: (record: BuildSessionRuntimeRecord) => void;
-  onSessionState: (event: { nodeId: string; sessionRecord?: Record<string, unknown> | null }) => void;
-  onTaskEvent: (event: BuildTaskUpdateEvent) => void;
-  onProgressEvent: (event: BuildProgressEvent) => void;
+  onSessionState: (event: AdapterSessionStatusUpdatedEvent) => void;
+  onTaskEvent: (event: AdapterStageSnapshotUpdatedEvent) => void;
+  onProgressEvent: (event: AdapterTaskProgressUpdatedEvent) => void;
   onTaskStreamConnectionChanged: (connected: boolean) => void;
-  onHeartbeat: (event: { nodeId: string; heartbeatAt?: number }) => void;
+  onHeartbeat: (event: AdapterHeartbeatEvent) => void;
 };
 
 const asTaskSummary = (task: BuildTaskSummary): BuildTaskSummary => {
@@ -42,13 +80,6 @@ const asTaskSummary = (task: BuildTaskSummary): BuildTaskSummary => {
     throw new Error(`[buildSessionWorkerEventAdapter] invalid task.progress: ${String(task.progress)}`);
   }
   return task;
-};
-
-const asOptionalFiniteNumber = (value: unknown): number | undefined => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return undefined;
-  }
-  return value;
 };
 
 const requireFiniteNumber = (value: unknown, label: string): number => {
@@ -83,75 +114,45 @@ export const createBuildSessionWorkerEventAdapter = <
     },
 
     onSessionState: (event) => {
-      if (String(event.nodeId) !== String(nodeId)) return;
-      const sessionRecord = event.sessionRecord;
-      if (!sessionRecord || typeof sessionRecord !== 'object') return;
-      const phase = config.mapSessionRecordStatusToPhase((sessionRecord as { status?: unknown }).status);
-      const stopReason = (sessionRecord as { stopReason?: unknown }).stopReason;
+      if (String(event.payload.nodeId) !== String(nodeId)) return;
+      const phase = config.mapSessionRecordStatusToPhase(event.payload.phase);
       dispatch({
         type: 'sessionStatusUpdated',
         payload: {
-          nodeId: String(event.nodeId),
+          nodeId: String(event.payload.nodeId),
           phase,
-          isActive: config.isActivePhase(phase),
-          startedAt: asOptionalFiniteNumber((sessionRecord as { startedAt?: unknown }).startedAt),
-          completedAt: asOptionalFiniteNumber((sessionRecord as { completedAt?: unknown }).completedAt),
-          stopReason: typeof stopReason === 'string' ? stopReason : undefined,
+          isActive: event.payload.isActive,
+          startedAt: event.payload.startedAt,
+          completedAt: event.payload.completedAt,
+          stopReason: event.payload.stopReason,
         },
       });
     },
 
     onTaskEvent: (event) => {
-      if (String(event.nodeId) !== String(nodeId)) return;
-      if (event.type === 'snapshot') {
-        // Group tasks by stage and emit one stageSnapshotUpdated per stage
-        const grouped = new Map<StageId, BuildTaskSummary[]>();
-        for (const rawTask of event.tasks) {
-          const task = asTaskSummary(rawTask);
-          const stageId = config.resolveStageId(task.stage);
-          const current = grouped.get(stageId) ?? [];
-          current.push(task);
-          grouped.set(stageId, current);
-        }
-        // Emit snapshot for all known stages (empty array = zero tasks for that stage)
-        for (const stageId of config.stages) {
-          const tasks = grouped.get(stageId) ?? [];
-          // stageStartedAt is undefined when the stage has not yet started;
-          // no fallback is applied (Date.now() or similar defaults are contract violations).
-          const explicitVersion = (event as { version?: unknown }).version;
-          const stageStartedAt = typeof explicitVersion === 'number' && Number.isFinite(explicitVersion)
-            ? explicitVersion
-            : undefined;
-          dispatch({
-            type: 'stageSnapshotUpdated',
-            payload: {
-              stageId,
-              tasks,
-              stageStartedAt,
-              stageInactiveMs: 0,
-              stageCompletedAt: undefined,
-            },
-          });
-        }
-        return;
-      }
-      // 'update' and 'delete' events are not supported in the new design.
-      // The Worker always sends full snapshots; incremental updates are not used.
-      throw new Error(
-        `[buildSessionWorkerEventAdapter] unexpected task event type: ${String((event as { type: unknown }).type)}. Only 'snapshot' is supported.`,
-      );
+      const stageId = config.resolveStageId(event.payload.stageId);
+      const tasks = event.payload.tasks.map((rawTask) => asTaskSummary(rawTask));
+      dispatch({
+        type: 'stageSnapshotUpdated',
+        payload: {
+          stageId,
+          tasks,
+          stageStartedAt: event.payload.stageStartedAt,
+          stageInactiveMs: event.payload.stageInactiveMs,
+          stageCompletedAt: event.payload.stageCompletedAt,
+        },
+      });
     },
 
     onProgressEvent: (event) => {
-      if (String(event.nodeId) !== String(nodeId)) return;
-      const payload = event.payload as Record<string, unknown> | undefined;
+      const stageId = config.resolveStageId(event.payload.stageId);
       dispatch({
         type: 'taskProgressUpdated',
         payload: {
-          stageId: config.resolveStageId(event.stage),
-          value: config.resolveProgressValue(event),
-          message: event.message,
-          metadata: payload?.meta as Record<string, unknown> | undefined,
+          stageId,
+          value: event.payload.value,
+          message: event.payload.message,
+          metadata: event.payload.metadata,
         },
       });
     },
@@ -164,8 +165,8 @@ export const createBuildSessionWorkerEventAdapter = <
     },
 
     onHeartbeat: (event) => {
-      if (String(event.nodeId) !== String(nodeId)) return;
-      const heartbeatAt = requireFiniteNumber(event.heartbeatAt, 'heartbeatAt');
+      if (String(event.payload.nodeId) !== String(nodeId)) return;
+      const heartbeatAt = requireFiniteNumber(event.payload.heartbeatAt, 'heartbeatAt');
       dispatch({
         type: 'heartbeat',
         payload: {

--- a/packages/ui/worker-client/src/workerBridge.ts
+++ b/packages/ui/worker-client/src/workerBridge.ts
@@ -69,11 +69,11 @@ export interface BuildWorkerBridge {
     nodeType: NodeType,
     nodeId: NodeId,
     handlers: {
-      onTaskEvent: (event: BuildTaskUpdateEvent) => void;
-      onProgressEvent: (event: BuildProgressEvent) => void;
-      onSessionState: (event: { nodeId: string; sessionRecord?: Record<string, unknown> | null }) => void;
-      onHeartbeat: (event: { nodeId: string; heartbeatAt?: number }) => void;
-      onWorkerLog: (event: { level?: string; message?: string; data?: unknown }) => void;
+      onTaskEvent: (event: unknown) => void;
+      onProgressEvent: (event: unknown) => void;
+      onSessionState: (event: unknown) => void;
+      onHeartbeat: (event: unknown) => void;
+      onWorkerLog: (event: unknown) => void;
     }
   ): Promise<() => void>;
   subscribeWorkerLog(
@@ -371,11 +371,11 @@ class WorkerBridgeImpl implements BuildWorkerBridge {
     nodeType: NodeType,
     nodeId: NodeId,
     handlers: {
-      onTaskEvent: (event: BuildTaskUpdateEvent) => void;
-      onProgressEvent: (event: BuildProgressEvent) => void;
-      onSessionState: (event: { nodeId: string; sessionRecord?: Record<string, unknown> | null }) => void;
-      onHeartbeat: (event: { nodeId: string; heartbeatAt?: number }) => void;
-      onWorkerLog: (event: { level?: string; message?: string; data?: unknown }) => void;
+      onTaskEvent: (event: unknown) => void;
+      onProgressEvent: (event: unknown) => void;
+      onSessionState: (event: unknown) => void;
+      onHeartbeat: (event: unknown) => void;
+      onWorkerLog: (event: unknown) => void;
     }
   ): Promise<() => void> {
     const api = await ensureWorkerAPI();

--- a/plugins/shape-plugin/src/__tests__/property/eventDeliveryExtendedScenarios.property.test.ts
+++ b/plugins/shape-plugin/src/__tests__/property/eventDeliveryExtendedScenarios.property.test.ts
@@ -11,19 +11,25 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import fc from 'fast-check';
 import { unconditionalEventStreamer } from '../../worker/api/eventBuffering';
-import type { NotificationType, EventPayload } from '../../worker/api/eventBuffering';
 import {
     UIEventBufferManager,
     type BufferedEvent,
 } from '../../ui/components/build-progress/eventBufferingUI';
 import type { NodeId } from '@hierarchidb/core-types';
+import type { SessionStatusUpdatedEvent } from '../../common/types/session-events';
 
 const toNodeId = (s: string): NodeId => s as NodeId;
 
 const PROPERTY_TEST_RUNS = 50;
 
-const makeSessionEvent = (): EventPayload =>
-    ({ nodeId: 'n' as NodeId, sessionId: 's', state: 'running' } as EventPayload);
+const makeSessionEvent = (): SessionStatusUpdatedEvent => ({
+    type: 'sessionStatusUpdated',
+    payload: {
+        nodeId: 'n',
+        phase: 'running',
+        isActive: true,
+    },
+});
 
 const makeBufferedEvent = (
     notificationType: 'session-state' | 'stage-snapshot',
@@ -72,11 +78,7 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
 
                         const payload = makeSessionEvent();
                         for (let k = 0; k < eventCount; k++) {
-                            unconditionalEventStreamer.emitEvent(
-                                node,
-                                'session-state',
-                                payload as Exclude<EventPayload, import('~/common/types/session-events').SessionHeartbeatEvent>,
-                            );
+                            unconditionalEventStreamer.emitEvent(node, 'session-state', payload);
                         }
 
                         for (let i = 0; i < subscriberCount; i++) {
@@ -110,11 +112,7 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
 
                         const payload = makeSessionEvent();
                         for (let k = 0; k < eventCount; k++) {
-                            unconditionalEventStreamer.emitEvent(
-                                nodeA,
-                                'session-state',
-                                payload as Exclude<EventPayload, import('~/common/types/session-events').SessionHeartbeatEvent>,
-                            );
+                            unconditionalEventStreamer.emitEvent(nodeA, 'session-state', payload);
                         }
 
                         expect(countA).toBe(eventCount);
@@ -186,11 +184,7 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
 
                         const payload = makeSessionEvent();
                         for (let k = 0; k < eventCount; k++) {
-                            unconditionalEventStreamer.emitEvent(
-                                node,
-                                'session-state',
-                                payload as Exclude<EventPayload, import('~/common/types/session-events').SessionHeartbeatEvent>,
-                            );
+                            unconditionalEventStreamer.emitEvent(node, 'session-state', payload);
                         }
 
                         // Non-failing subscribers must still receive all events
@@ -316,11 +310,7 @@ describe('Property 24-27: Extended Event Delivery Scenarios', () => {
                         const payload = makeSessionEvent();
                         expect(() => {
                             for (let k = 0; k < eventCount; k++) {
-                                unconditionalEventStreamer.emitEvent(
-                                    node,
-                                    'session-state',
-                                    payload as Exclude<EventPayload, import('~/common/types/session-events').SessionHeartbeatEvent>,
-                                );
+                                unconditionalEventStreamer.emitEvent(node, 'session-state', payload);
                             }
                         }).not.toThrow();
                     },

--- a/plugins/shape-plugin/src/__tests__/unit/eventBuffering.unit.test.ts
+++ b/plugins/shape-plugin/src/__tests__/unit/eventBuffering.unit.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { unconditionalEventStreamer } from '../../worker/api/eventBuffering';
-import type { SessionStateChangeEvent, SessionHeartbeatEvent, TaskProgressEvent } from '../../common/types/session-events';
+import type { SessionStatusUpdatedEvent, HeartbeatEvent, TaskProgressUpdatedEvent } from '../../common/types/session-events';
 import type { NodeId } from '@hierarchidb/core-types';
 
 describe('UnconditionalEventStreamer', () => {
@@ -31,11 +31,13 @@ describe('UnconditionalEventStreamer', () => {
             unconditionalEventStreamer.subscribe(testNodeId, 'session-state', anotherSuccessfulCallback);
 
             // Emit event
-            const testEvent: SessionStateChangeEvent = {
-                nodeId: testNodeId,
-                timestamp: Date.now(),
-                currentStatus: 'running',
-                sessionRecord: { status: 'running' } as SessionStateChangeEvent['sessionRecord'],
+            const testEvent: SessionStatusUpdatedEvent = {
+                type: 'sessionStatusUpdated',
+                payload: {
+                    nodeId: String(testNodeId),
+                    phase: 'running',
+                    isActive: true,
+                },
             };
 
             unconditionalEventStreamer.emitEvent(testNodeId, 'session-state', testEvent);
@@ -75,11 +77,12 @@ describe('UnconditionalEventStreamer', () => {
             unconditionalEventStreamer.subscribe(testNodeId, 'heartbeat', failingCallback);
 
             // Emit heartbeat event
-            const heartbeatEvent: SessionHeartbeatEvent = {
-                nodeId: testNodeId,
-                timestamp: Date.now(),
-                isActive: true,
-                lastActivity: Date.now(),
+            const heartbeatEvent: HeartbeatEvent = {
+                type: 'heartbeat',
+                payload: {
+                    nodeId: String(testNodeId),
+                    heartbeatAt: Date.now(),
+                },
             };
 
             unconditionalEventStreamer.emitHeartbeat(testNodeId, heartbeatEvent);
@@ -113,11 +116,13 @@ describe('UnconditionalEventStreamer', () => {
 
             unconditionalEventStreamer.subscribe(testNodeId, 'session-state', failingCallback);
 
-            const testEvent: SessionStateChangeEvent = {
-                nodeId: testNodeId,
-                timestamp: Date.now(),
-                currentStatus: 'running',
-                sessionRecord: { status: 'running' } as SessionStateChangeEvent['sessionRecord'],
+            const testEvent: SessionStatusUpdatedEvent = {
+                type: 'sessionStatusUpdated',
+                payload: {
+                    nodeId: String(testNodeId),
+                    phase: 'running',
+                    isActive: true,
+                },
             };
 
             unconditionalEventStreamer.emitEvent(testNodeId, 'session-state', testEvent);
@@ -151,11 +156,13 @@ describe('UnconditionalEventStreamer', () => {
 
             // Emit multiple events
             for (let i = 0; i < 3; i++) {
-                const testEvent: SessionStateChangeEvent = {
-                    nodeId: testNodeId,
-                    timestamp: Date.now(),
-                    currentStatus: 'running',
-                    sessionRecord: { status: 'running' } as SessionStateChangeEvent['sessionRecord'],
+                const testEvent: SessionStatusUpdatedEvent = {
+                    type: 'sessionStatusUpdated',
+                    payload: {
+                        nodeId: String(testNodeId),
+                        phase: 'running',
+                        isActive: true,
+                    },
                 };
                 unconditionalEventStreamer.emitEvent(testNodeId, 'session-state', testEvent);
             }
@@ -182,20 +189,21 @@ describe('UnconditionalEventStreamer', () => {
             unconditionalEventStreamer.subscribe(testNodeId, 'session-state', callback2);
             unconditionalEventStreamer.subscribe(testNodeId, 'task-progress', callback3);
 
-            const sessionEvent: SessionStateChangeEvent = {
-                nodeId: testNodeId,
-                timestamp: Date.now(),
-                currentStatus: 'running',
-                sessionRecord: { status: 'running' } as SessionStateChangeEvent['sessionRecord'],
+            const sessionEvent: SessionStatusUpdatedEvent = {
+                type: 'sessionStatusUpdated',
+                payload: {
+                    nodeId: String(testNodeId),
+                    phase: 'running',
+                    isActive: true,
+                },
             };
 
-            const progressEvent: TaskProgressEvent = {
-                nodeId: testNodeId,
-                timestamp: Date.now(),
-                taskId: 'task-1',
-                stage: 'source',
-                progress: 50,
-                status: 'running',
+            const progressEvent: TaskProgressUpdatedEvent = {
+                type: 'taskProgressUpdated',
+                payload: {
+                    stageId: 'source',
+                    value: 50,
+                },
             };
 
             unconditionalEventStreamer.emitEvent(testNodeId, 'session-state', sessionEvent);

--- a/plugins/shape-plugin/src/common/types/session-events.ts
+++ b/plugins/shape-plugin/src/common/types/session-events.ts
@@ -1,52 +1,97 @@
 import type { NodeId } from '@hierarchidb/core-types';
-import type { ShapeBuildSessionRecord } from '@hierarchidb/shape-api';
 
 /**
- * Session state change event for real-time subscription
+ * Session lifecycle phase — canonical set per build-session-worker-ui-event-spec.md
  */
-export interface SessionStateChangeEvent {
-    nodeId: NodeId;
-    timestamp: number;
-    previousStatus?: ShapeBuildSessionRecord['status'];
-    currentStatus: ShapeBuildSessionRecord['status'];
-    sessionRecord: ShapeBuildSessionRecord;
+export type SessionPhase =
+    | 'idle'
+    | 'starting'
+    | 'running'
+    | 'pausing'
+    | 'paused'
+    | 'resuming'
+    | 'finalizing'
+    | 'completed'
+    | 'failed';
+
+/**
+ * sessionStatusUpdated — replaces runtimeSnapshotReceived + sessionRecordReceived.
+ * Emitted on every lifecycle phase change and on initial subscription.
+ */
+export interface SessionStatusUpdatedEvent {
+    type: 'sessionStatusUpdated';
+    payload: {
+        nodeId: string;
+        phase: SessionPhase;
+        isActive: boolean;
+        startedAt?: number;
+        completedAt?: number;
+        stopReason?: string;
+        stageId?: string;
+        inactiveMs?: number;
+        stageStartedAt?: number;
+        stageInactiveMs?: number;
+    };
 }
 
 /**
- * Stage snapshot replacement event
+ * stageSnapshotUpdated — replaces taskSnapshotReceived + taskUpdated + taskDeleted.
+ * Full replacement of the task list for one stage that has already started.
+ * Must NOT be emitted for stages that have not yet started (stageStartedAt required).
  */
-export interface StageSnapshotEvent {
-    nodeId: NodeId;
-    timestamp: number;
-    stageId: string;
-    snapshot: Record<string, unknown>;
+export interface StageSnapshotUpdatedEvent {
+    type: 'stageSnapshotUpdated';
+    payload: {
+        stageId: string;
+        tasks: TaskSummary[];
+        stageStartedAt: number;   // required — only emitted after stage has started
+        stageInactiveMs: number;
+        stageCompletedAt?: number;
+    };
 }
 
 /**
- * Heartbeat event (1 second interval)
+ * taskProgressUpdated — replaces progressReceived.
+ * Progress value for a single task from a parallel worker.
+ * phase field is intentionally absent (managed by sessionStatusUpdated only).
  */
-export interface SessionHeartbeatEvent {
-    nodeId: NodeId;
-    timestamp: number;
-    isActive: boolean;
-    lastActivity: number;
+export interface TaskProgressUpdatedEvent {
+    type: 'taskProgressUpdated';
+    payload: {
+        stageId: string;
+        value: number;            // finite, 0..100 — violation throws
+        message?: string;
+        metadata?: Record<string, unknown>;
+    };
 }
 
 /**
- * Task progress event (individual task updates)
+ * heartbeat — periodic liveness signal (~1 s interval).
+ * Must not carry phase or task data.
  */
-export interface TaskProgressEvent {
-    nodeId: NodeId;
-    timestamp: number;
+export interface HeartbeatEvent {
+    type: 'heartbeat';
+    payload: {
+        nodeId: string;
+        heartbeatAt: number;      // finite timestamp (ms) — violation throws
+    };
+}
+
+/**
+ * Minimal task summary carried inside StageSnapshotUpdatedEvent.
+ */
+export interface TaskSummary {
     taskId: string;
     stage: string;
-    progress: number;
     status: string;
-    metadata?: Record<string, unknown>;
+    progress: number;
+    version: number;
+    errorMessage?: string;
+    [key: string]: unknown;
 }
 
 /**
- * Worker log event (for debugging and monitoring)
+ * Worker log event (debugging / monitoring — not part of the 4-event canonical set).
  */
 export interface WorkerLogEvent {
     nodeId: NodeId;
@@ -57,7 +102,7 @@ export interface WorkerLogEvent {
 }
 
 /**
- * Critical error event (for contract violation and critical failures)
+ * Critical error event (contract violation detected in UI layer).
  */
 export interface CriticalErrorEvent {
     nodeId: NodeId;
@@ -70,58 +115,10 @@ export interface CriticalErrorEvent {
 }
 
 /**
- * Unified session event types
+ * Union of all canonical Worker→UI events.
  */
-export type SessionEvent =
-    | SessionStateChangeEvent
-    | StageSnapshotEvent
-    | SessionHeartbeatEvent
-    | TaskProgressEvent
-    | WorkerLogEvent
-    | CriticalErrorEvent;
-
-/**
- * Session event subscription callback
- */
-export type SessionEventCallback = (event: SessionEvent) => void;
-
-/**
- * Session subscription interfaces (specific callbacks for each event type)
- */
-export interface SessionStateSubscription {
-    unsubscribe?: () => void;
-    callback?: (event: SessionStateChangeEvent) => void;
-}
-
-export interface StageSnapshotSubscription {
-    unsubscribe?: () => void;
-    callback?: (event: StageSnapshotEvent) => void;
-}
-
-export interface HeartbeatSubscription {
-    unsubscribe?: () => void;
-    callback?: (event: SessionHeartbeatEvent) => void;
-}
-
-export interface TaskProgressSubscription {
-    unsubscribe?: () => void;
-    callback?: (event: TaskProgressEvent) => void;
-}
-
-export interface WorkerLogSubscription {
-    unsubscribe?: () => void;
-    callback?: (event: WorkerLogEvent) => void;
-}
-
-export interface CriticalErrorSubscription {
-    unsubscribe?: () => void;
-    callback?: (event: CriticalErrorEvent) => void;
-}
-
-/**
- * Session subscription interface (generic)
- */
-export interface SessionSubscription {
-    unsubscribe?: () => void;
-    callback?: SessionEventCallback;
-}
+export type CanonicalSessionEvent =
+    | SessionStatusUpdatedEvent
+    | StageSnapshotUpdatedEvent
+    | TaskProgressUpdatedEvent
+    | HeartbeatEvent;

--- a/plugins/shape-plugin/src/ui/atoms/buildSessionWorkerEventAdapter.ts
+++ b/plugins/shape-plugin/src/ui/atoms/buildSessionWorkerEventAdapter.ts
@@ -1,4 +1,4 @@
-import type { BuildProgressEvent, BuildTaskSummary } from '@hierarchidb/build-api';
+import type { BuildTaskSummary } from '@hierarchidb/build-api';
 import {
   createBuildSessionWorkerEventAdapter as createCommonBuildSessionWorkerEventAdapter,
   type BuildSessionStateEvent,
@@ -6,13 +6,6 @@ import {
 } from '@hierarchidb/ui-build-sessions';
 import type { ShapeBuildStopReason } from '@hierarchidb/shape-api';
 import type { ShapeBuildSessionStateEvent, ShapeSessionPhase, ShapeStageId } from './buildSessionStateAtoms';
-
-const asFiniteNumber = (value: unknown, label: string): number => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(`[shape buildSessionWorkerEventAdapter] ${label} must be a finite number, received ${String(value)}`);
-  }
-  return value;
-};
 
 const resolveShapeStageId = (value: unknown): ShapeStageId => {
   if (value === 'source' || value === 'geometry' || value === 'tileEmit') {
@@ -83,11 +76,6 @@ export const createBuildSessionWorkerEventAdapter = (
       resolveStageId: resolveShapeStageId,
       mapRuntimeStatusToPhase: (status) => mapRuntimeStatusToPhase(String(status)),
       mapSessionRecordStatusToPhase: (status) => mapRuntimeStatusToPhase(String(status)),
-      isActivePhase,
-      resolveProgressValue: (event: BuildProgressEvent) => {
-        const payload = event.payload as Record<string, unknown> | undefined;
-        return asFiniteNumber(payload?.percentage, 'progress payload.percentage');
-      },
     },
   );
 };

--- a/plugins/shape-plugin/src/ui/components/build-progress/eventArchitectureProperties.property.test.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/eventArchitectureProperties.property.test.ts
@@ -298,10 +298,11 @@ describe('Event Architecture Properties', () => {
                             eventTypes.forEach((eventType) => {
                                 if (eventType === 'heartbeat') {
                                     unconditionalEventStreamer.emitHeartbeat(nodeId, {
-                                        nodeId,
-                                        timestamp: Date.now(),
-                                        isActive: true,
-                                        lastActivity: Date.now(),
+                                        type: 'heartbeat',
+                                        payload: {
+                                            nodeId: String(nodeId),
+                                            heartbeatAt: Date.now(),
+                                        },
                                     });
                                 } else {
                                     unconditionalEventStreamer.emitEvent(

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildSessionStateAtomBridge.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildSessionStateAtomBridge.ts
@@ -1,32 +1,22 @@
 import { useEffect } from 'react';
 import type { NodeId, NodeType } from '@hierarchidb/core-types';
-import type { BuildProgressEvent, BuildTaskUpdateEvent } from '@hierarchidb/build-api';
 import { getBuildWorkerBridge } from '@hierarchidb/ui-worker-client';
 import { useSetAtom } from 'jotai';
 import { dispatchBuildSessionEventAtom } from '~/ui/atoms/buildSessionStateAtoms';
 import { createBuildSessionWorkerEventAdapter } from '~/ui/atoms/buildSessionWorkerEventAdapter';
 import type { ShapeStageId } from '~/ui/atoms/buildSessionStateAtoms';
+import type {
+    SessionStatusUpdatedEvent,
+    StageSnapshotUpdatedEvent,
+    TaskProgressUpdatedEvent,
+    HeartbeatEvent,
+} from '~/common/types/session-events';
 import { UIEventBufferManager, type BufferedEvent } from './eventBufferingUI';
 
 const SHAPE_NODE_TYPE = 'shape' as NodeType;
 const SHAPE_STAGE_IDS = ['source', 'geometry', 'tileEmit'] as const satisfies readonly ShapeStageId[];
 
 type UiSyncPhase = 'ui-initializing' | 'running';
-
-type TaskSnapshotEvent = Extract<BuildTaskUpdateEvent, { type: 'snapshot' }> & {
-    version?: unknown;
-    stage?: unknown;
-};
-
-interface VersionedBuildProgressEvent extends BuildProgressEvent {
-    /** Distributed version number from Worker (task-progress ordering only) */
-    version?: number;
-}
-
-interface SessionStateEvent {
-    nodeId: string;
-    sessionRecord?: Record<string, unknown> | null;
-}
 
 // ---------------------------------------------------------------------------
 // Exported pure functions (used by tests and internal logic)
@@ -66,13 +56,13 @@ const resolveShapeStageId = (value: unknown): ShapeStageId | undefined => {
     return undefined;
 };
 
-export const resolveSnapshotTargetStages = (event: TaskSnapshotEvent): ShapeStageId[] => {
+export const resolveSnapshotTargetStages = (event: StageSnapshotUpdatedEvent): ShapeStageId[] => {
     const snapshotStages = new Set<ShapeStageId>();
-    for (const task of event.tasks) {
+    for (const task of event.payload.tasks) {
         const stageId = resolveShapeStageId(task.stage);
         if (stageId) snapshotStages.add(stageId);
     }
-    const stageFromEvent = resolveShapeStageId(event.stage);
+    const stageFromEvent = resolveShapeStageId(event.payload.stageId);
     if (snapshotStages.size === 0 && stageFromEvent) {
         snapshotStages.add(stageFromEvent);
     }
@@ -82,40 +72,6 @@ export const resolveSnapshotTargetStages = (event: TaskSnapshotEvent): ShapeStag
         }
     }
     return Array.from(snapshotStages);
-};
-
-const resolveUiSyncSignalFromSessionStageId = (
-    value: unknown,
-): { stageId: ShapeStageId; phase: UiSyncPhase } | undefined => {
-    if (value === 'source' || value === 'geometry' || value === 'tileEmit') {
-        return { stageId: value, phase: 'running' };
-    }
-    if (value === 'source-stage') return { stageId: 'source', phase: 'running' };
-    if (value === 'geometry-stage') return { stageId: 'geometry', phase: 'running' };
-    if (value === 'tile-emit-stage') return { stageId: 'tileEmit', phase: 'running' };
-    if (typeof value !== 'string') return undefined;
-    if (!value.startsWith('ui-sync:')) return undefined;
-    const [, rawStage, rawPhase] = value.split(':');
-    const stageId = resolveShapeStageId(rawStage);
-    if (!stageId) return undefined;
-    if (rawPhase === 'ui-initializing' || rawPhase === 'running') {
-        return { stageId, phase: rawPhase };
-    }
-    return undefined;
-};
-
-const resolveSnapshotVersion = (event: TaskSnapshotEvent): number => {
-    if (event.type !== 'snapshot') {
-        throw new Error('[shape buildSessionStateAtomBridge] resolveSnapshotVersion requires snapshot event');
-    }
-    if (event.tasks.length > 0) {
-        return event.tasks.reduce((max, task) => Math.max(max, task.version), Number.MIN_SAFE_INTEGER);
-    }
-    const explicitVersion = event.version;
-    if (typeof explicitVersion !== 'number' || !Number.isFinite(explicitVersion) || explicitVersion < 0) {
-        throw new Error('[shape buildSessionStateAtomBridge] empty snapshot requires finite snapshot version');
-    }
-    return Math.floor(explicitVersion);
 };
 
 export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined): void => {
@@ -141,7 +97,7 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             geometry: 'ui-initializing',
             tileEmit: 'ui-initializing',
         };
-        const progressBufferByStage: Record<ShapeStageId, BuildProgressEvent[]> = {
+        const progressBufferByStage: Record<ShapeStageId, TaskProgressUpdatedEvent[]> = {
             source: [],
             geometry: [],
             tileEmit: [],
@@ -184,16 +140,13 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             flushTimerId = window.setTimeout(flushProgressBuffer, 0);
         };
 
-        const processTaskSnapshotEvent = (snapshotEvent: TaskSnapshotEvent): void => {
+        const processStageSnapshotEvent = (event: StageSnapshotUpdatedEvent): void => {
             const snapshotStages = new Set<ShapeStageId>();
-            for (const task of snapshotEvent.tasks) {
+            for (const task of event.payload.tasks) {
                 const stageId = resolveShapeStageId(task.stage);
                 if (stageId) snapshotStages.add(stageId);
             }
-            adapter.onTaskEvent({
-                ...snapshotEvent,
-                version: resolveSnapshotVersion(snapshotEvent),
-            } as BuildTaskUpdateEvent);
+            adapter.onTaskEvent(event);
             for (const stageId of SHAPE_STAGE_IDS) {
                 if (snapshotStages.size > 0 && !snapshotStages.has(stageId)) continue;
                 dispatchUiSyncPhase(stageId, 'running');
@@ -201,8 +154,8 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             scheduleFlush();
         };
 
-        const processProgressEvent = (event: VersionedBuildProgressEvent): void => {
-            const stageId = resolveShapeStageId(event.stage);
+        const processProgressEvent = (event: TaskProgressUpdatedEvent): void => {
+            const stageId = resolveShapeStageId(event.payload.stageId);
             if (!stageId) {
                 adapter.onProgressEvent(event);
                 return;
@@ -216,16 +169,19 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             scheduleFlush();
         };
 
-        const processSessionStateEvent = (event: SessionStateEvent): void => {
+        const processSessionStatusEvent = (event: SessionStatusUpdatedEvent): void => {
             adapter.onSessionState(event);
-            const signal = resolveUiSyncSignalFromSessionStageId(event.sessionRecord?.stageId);
-            if (!signal) return;
-            const stageId = signal.stageId;
+            // Derive UI sync signal from the canonical phase and stageId fields.
+            // 'startup:*' and 'ui-sync:*' stageId values are not part of the spec
+            // and must not be interpreted here.
+            const stageId = resolveShapeStageId(event.payload.stageId);
+            if (!stageId) return;
             if (activeStageId !== stageId) {
                 activeStageId = stageId;
             }
-            dispatchUiSyncPhase(stageId, signal.phase);
-            if (signal.phase === 'running') {
+            const phase = event.payload.phase;
+            if (phase === 'running') {
+                dispatchUiSyncPhase(stageId, 'running');
                 scheduleFlush();
             }
         };
@@ -236,23 +192,19 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
         // task-progress goes through version gating only.
         // ---------------------------------------------------------------------------
 
-        const onTaskEvent = (event: BuildTaskUpdateEvent): void => {
-            if (event.type === 'snapshot') {
-                // Enqueue into FIFO queue, then flush immediately via rAF
-                const buffered: BufferedEvent = {
-                    version: undefined,
-                    notificationType: 'stage-snapshot',
-                    payload: event as TaskSnapshotEvent,
-                    timestamp: Date.now(),
-                };
-                eventBufferManager.enqueue(buffered);
-                flushFifoQueues();
-                return;
-            }
-            adapter.onTaskEvent(event);
+        const onTaskEvent = (event: StageSnapshotUpdatedEvent): void => {
+            // Enqueue into FIFO queue, then flush immediately via rAF
+            const buffered: BufferedEvent = {
+                version: undefined,
+                notificationType: 'stage-snapshot',
+                payload: event,
+                timestamp: Date.now(),
+            };
+            eventBufferManager.enqueue(buffered);
+            flushFifoQueues();
         };
 
-        const onProgressEvent = (event: VersionedBuildProgressEvent): void => {
+        const onProgressEvent = (event: TaskProgressUpdatedEvent & { version?: number }): void => {
             const buffered: BufferedEvent = {
                 version: event.version,
                 notificationType: 'task-progress',
@@ -265,7 +217,7 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             }
         };
 
-        const onSessionState = (event: SessionStateEvent): void => {
+        const onSessionState = (event: SessionStatusUpdatedEvent): void => {
             // Enqueue into FIFO queue, then flush immediately via rAF
             const buffered: BufferedEvent = {
                 version: undefined,
@@ -280,11 +232,11 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
         const flushFifoQueues = (): void => {
             // Drain session-state FIFO
             for (const ev of eventBufferManager.flushFifo('session-state')) {
-                processSessionStateEvent(ev.payload as SessionStateEvent);
+                processSessionStatusEvent(ev.payload as SessionStatusUpdatedEvent);
             }
             // Drain stage-snapshot FIFO
             for (const ev of eventBufferManager.flushFifo('stage-snapshot')) {
-                processTaskSnapshotEvent(ev.payload as TaskSnapshotEvent);
+                processStageSnapshotEvent(ev.payload as StageSnapshotUpdatedEvent);
             }
         };
 
@@ -301,29 +253,29 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
             unsubscribeAll = await bridge.subscribeAll(SHAPE_NODE_TYPE, nodeId, {
                 onTaskEvent: (event) => {
                     if (cancelled) return;
-                    onTaskEvent(event);
+                    onTaskEvent(event as StageSnapshotUpdatedEvent);
                 },
                 onProgressEvent: (event) => {
                     if (cancelled) return;
-                    onProgressEvent(event as VersionedBuildProgressEvent);
+                    onProgressEvent(event as TaskProgressUpdatedEvent & { version?: number });
                 },
                 onSessionState: (event) => {
                     if (cancelled) return;
-                    onSessionState(event as SessionStateEvent);
+                    onSessionState(event as SessionStatusUpdatedEvent);
                 },
                 onHeartbeat: (event) => {
                     if (cancelled) return;
-                    adapter.onHeartbeat(event);
+                    adapter.onHeartbeat(event as HeartbeatEvent);
                 },
                 onWorkerLog: (event) => {
                     if (cancelled) return;
-                    const level = event.level;
+                    const level = (event as { level?: string }).level;
                     if (level === 'error') {
-                        console.error('[Worker]', event.message, event.data);
+                        console.error('[Worker]', (event as { message?: string }).message, (event as { data?: unknown }).data);
                     } else if (level === 'warn') {
-                        console.warn('[Worker]', event.message, event.data);
+                        console.warn('[Worker]', (event as { message?: string }).message, (event as { data?: unknown }).data);
                     } else {
-                        console.log('[Worker]', event.message, event.data);
+                        console.log('[Worker]', (event as { message?: string }).message, (event as { data?: unknown }).data);
                     }
                 },
             });

--- a/plugins/shape-plugin/src/worker/api/eventBuffering.ts
+++ b/plugins/shape-plugin/src/worker/api/eventBuffering.ts
@@ -9,10 +9,10 @@
 
 import type { NodeId } from '@hierarchidb/core-types';
 import type {
-    SessionStateChangeEvent,
-    StageSnapshotEvent,
-    TaskProgressEvent,
-    SessionHeartbeatEvent,
+    SessionStatusUpdatedEvent,
+    StageSnapshotUpdatedEvent,
+    TaskProgressUpdatedEvent,
+    HeartbeatEvent,
     WorkerLogEvent,
     CriticalErrorEvent,
 } from '~/common/types/session-events';
@@ -26,10 +26,10 @@ type NotificationType =
     | 'heartbeat';
 
 type EventPayload =
-    | SessionStateChangeEvent
-    | StageSnapshotEvent
-    | TaskProgressEvent
-    | SessionHeartbeatEvent
+    | SessionStatusUpdatedEvent
+    | StageSnapshotUpdatedEvent
+    | TaskProgressUpdatedEvent
+    | HeartbeatEvent
     | WorkerLogEvent
     | CriticalErrorEvent;
 
@@ -69,7 +69,7 @@ class UnconditionalEventStreamer {
     emitEvent(
         nodeId: NodeId,
         eventType: Exclude<NotificationType, 'heartbeat'>,
-        event: Exclude<EventPayload, SessionHeartbeatEvent>,
+        event: Exclude<EventPayload, HeartbeatEvent>,
     ): void {
         this.deliver(nodeId, eventType, event);
     }
@@ -77,7 +77,7 @@ class UnconditionalEventStreamer {
     /**
      * Emit a heartbeat event to all current subscribers for the given node.
      */
-    emitHeartbeat(nodeId: NodeId, event: SessionHeartbeatEvent): void {
+    emitHeartbeat(nodeId: NodeId, event: HeartbeatEvent): void {
         this.deliver(nodeId, 'heartbeat', event);
     }
 

--- a/plugins/shape-plugin/src/worker/api/eventEmission.ts
+++ b/plugins/shape-plugin/src/worker/api/eventEmission.ts
@@ -1,140 +1,137 @@
 /**
  * Event Emission
- * 
- * Handles unconditional event streaming for session state, task progress, and stage snapshots
+ *
+ * Emits the 4 canonical Worker→UI events defined in
+ * docs/build-session-worker-ui-event-spec.md:
+ *   sessionStatusUpdated, stageSnapshotUpdated, taskProgressUpdated, heartbeat
  */
 
 import type { NodeId } from '@hierarchidb/core-types';
-import type { BuildTaskUpdateEvent, TaskQueueRecord } from '@hierarchidb/build-api';
+import type { TaskQueueRecord } from '@hierarchidb/build-api';
 import type { ShapeBuildSessionRecord } from '@hierarchidb/shape-api';
 import type {
-    SessionStateChangeEvent,
-    StageSnapshotEvent,
-    TaskProgressEvent,
+    SessionPhase,
+    SessionStatusUpdatedEvent,
+    StageSnapshotUpdatedEvent,
+    TaskProgressUpdatedEvent,
+    HeartbeatEvent,
 } from '~/common/types/session-events';
-import { VtTaskQueueDb, listTasks, listTasksByStage } from '@hierarchidb/vt-orchestrator';
+import { VtTaskQueueDb, listTasksByStage } from '@hierarchidb/vt-orchestrator';
 import { unconditionalEventStreamer } from './eventBuffering.js';
 import { mapTaskQueueRecordToTaskSummary } from './taskSummaryMapping.js';
 
-export const emitSessionStateChange = (
-    nodeId: NodeId,
-    previousStatus: ShapeBuildSessionRecord['status'] | undefined,
-    currentStatus: ShapeBuildSessionRecord['status'],
-    sessionRecord: ShapeBuildSessionRecord,
-): void => {
-    const event: SessionStateChangeEvent = {
-        nodeId,
-        timestamp: Date.now(),
-        previousStatus,
-        currentStatus,
-        sessionRecord,
-    };
-
-    // Emit unconditionally regardless of UI state
-    unconditionalEventStreamer.emitEvent(nodeId, 'session-state', event);
-};
-
-export const emitTaskProgress = (
-    nodeId: NodeId,
-    taskId: string,
-    stage: string,
-    progress: number,
-    status: string,
-    metadata?: Record<string, unknown>,
-): void => {
-    const event: TaskProgressEvent = {
-        nodeId,
-        timestamp: Date.now(),
-        taskId,
-        stage,
-        progress,
-        status,
-        metadata,
-    };
-
-    // Emit unconditionally regardless of UI state
-    unconditionalEventStreamer.emitEvent(nodeId, 'task-progress', event);
-};
-
-export const emitStageSnapshot = (
-    nodeId: NodeId,
-    stageId: string,
-    snapshot: Record<string, unknown>,
-): void => {
-    const event: StageSnapshotEvent = {
-        nodeId,
-        timestamp: Date.now(),
-        stageId,
-        snapshot,
-    };
-
-    // Emit unconditionally regardless of UI state
-    unconditionalEventStreamer.emitEvent(nodeId, 'stage-snapshot', event);
-};
-
-export const emitTaskSnapshot = async (
-    nodeId: NodeId,
-    options?: { stage?: TaskQueueRecord['stage'] },
-    taskCallbacks?: Map<string, any>, // For backward compatibility
-): Promise<void> => {
-    const taskQueue = new VtTaskQueueDb();
-    const tasks = options?.stage
-        ? await listTasksByStage(taskQueue, nodeId, options.stage)
-        : await listTasks(taskQueue, nodeId);
-    const snapshot = tasks.map((task) => mapTaskQueueRecordToTaskSummary(task));
-    const snapshotVersion = snapshot.length > 0
-        ? snapshot.reduce((max, task) => Math.max(max, task.version), Number.MIN_SAFE_INTEGER)
-        : 0;
-
-    // Create stage snapshot event for unconditional streaming
-    const stageSnapshotEvent: StageSnapshotEvent = {
-        nodeId,
-        timestamp: Date.now(),
-        stageId: options?.stage ?? 'all-stages',
-        snapshot: {
-            tasks: snapshot,
-            version: snapshotVersion,
-            stage: options?.stage,
-        },
-    };
-
-    // Emit unconditionally regardless of UI state
-    unconditionalEventStreamer.emitEvent(nodeId, 'stage-snapshot', stageSnapshotEvent);
-
-    // Also maintain backward compatibility with direct task callbacks for now
-    if (taskCallbacks) {
-        const key = String(nodeId);
-        const subscription = taskCallbacks.get(key);
-        if (subscription?.callback) {
-            subscription.callback({
-                type: 'snapshot',
-                nodeId,
-                tasks: snapshot,
-                version: snapshotVersion,
-                stage: options?.stage,
-            } as BuildTaskUpdateEvent & {
-                version: number;
-                stage?: TaskQueueRecord['stage'];
-            });
+/**
+ * Maps ShapeBuildSessionRecord status to the canonical SessionPhase.
+ * Unknown values throw immediately — no fallback.
+ */
+export const mapStatusToSessionPhase = (
+    status: ShapeBuildSessionRecord['status'],
+): SessionPhase => {
+    switch (status) {
+        case 'idle': return 'idle';
+        case 'running': return 'running';
+        case 'paused': return 'paused';
+        case 'completed': return 'completed';
+        case 'failed': return 'failed';
+        default: {
+            const _exhaustive: never = status;
+            throw new Error(`[eventEmission] unknown session status: ${String(_exhaustive)}`);
         }
     }
 };
 
-export const emitProgressSnapshot = async (
+/**
+ * Emits sessionStatusUpdated.
+ * Called whenever the session lifecycle phase changes.
+ */
+export const emitSessionStatusUpdated = (
     nodeId: NodeId,
-    message?: string,
-): Promise<void> => {
-    // Create a progress snapshot event for unconditional streaming
-    const progressSnapshotEvent: StageSnapshotEvent = {
-        nodeId,
-        timestamp: Date.now(),
-        stageId: 'progress-snapshot',
-        snapshot: {
-            message: message ?? 'Progress update',
-            timestamp: Date.now(),
+    sessionRecord: ShapeBuildSessionRecord,
+): void => {
+    const phase = mapStatusToSessionPhase(sessionRecord.status);
+    const event: SessionStatusUpdatedEvent = {
+        type: 'sessionStatusUpdated',
+        payload: {
+            nodeId: String(nodeId),
+            phase,
+            isActive: sessionRecord.status === 'running',
+            startedAt: sessionRecord.startedAt,
+            completedAt: sessionRecord.completedAt,
+            stopReason: sessionRecord.stopReason,
+            stageId: sessionRecord.stageId,
+            inactiveMs: sessionRecord.inactiveMs,
+            stageStartedAt: sessionRecord.stageStartedAt,
+            stageInactiveMs: sessionRecord.stageInactiveMs,
         },
     };
+    unconditionalEventStreamer.emitEvent(nodeId, 'session-state', event);
+};
 
-    // Emit unconditionally regardless of UI state
-    unconditionalEventStreamer.emitEvent(nodeId, 'stage-snapshot', progressSnapshotEvent);
+/**
+ * Emits stageSnapshotUpdated for a stage that has already started.
+ * Must NOT be called for stages that have not yet started (stageStartedAt required).
+ */
+export const emitStageSnapshotUpdated = async (
+    nodeId: NodeId,
+    stage: TaskQueueRecord['stage'],
+    stageStartedAt: number,
+    stageInactiveMs: number,
+    stageCompletedAt?: number,
+): Promise<void> => {
+    if (!Number.isFinite(stageStartedAt)) {
+        throw new Error(`[eventEmission] stageStartedAt must be finite, received ${String(stageStartedAt)}`);
+    }
+    if (!Number.isFinite(stageInactiveMs)) {
+        throw new Error(`[eventEmission] stageInactiveMs must be finite, received ${String(stageInactiveMs)}`);
+    }
+    const taskQueue = new VtTaskQueueDb();
+    const rawTasks = await listTasksByStage(taskQueue, nodeId, stage);
+    const tasks = rawTasks.map((task) => mapTaskQueueRecordToTaskSummary(task));
+
+    const event: StageSnapshotUpdatedEvent = {
+        type: 'stageSnapshotUpdated',
+        payload: {
+            stageId: stage,
+            tasks,
+            stageStartedAt,
+            stageInactiveMs,
+            stageCompletedAt,
+        },
+    };
+    unconditionalEventStreamer.emitEvent(nodeId, 'stage-snapshot', event);
+};
+
+/**
+ * Emits taskProgressUpdated for a single task's progress value.
+ * value must be finite and in [0, 100] — violation throws.
+ */
+export const emitTaskProgressUpdated = (
+    nodeId: NodeId,
+    stageId: string,
+    value: number,
+    message?: string,
+    metadata?: Record<string, unknown>,
+): void => {
+    if (!Number.isFinite(value) || value < 0 || value > 100) {
+        throw new Error(`[eventEmission] taskProgressUpdated value must be finite 0..100, received ${String(value)}`);
+    }
+    const event: TaskProgressUpdatedEvent = {
+        type: 'taskProgressUpdated',
+        payload: { stageId, value, message, metadata },
+    };
+    unconditionalEventStreamer.emitEvent(nodeId, 'task-progress', event);
+};
+
+/**
+ * Emits heartbeat. heartbeatAt must be finite — violation throws.
+ */
+export const emitHeartbeat = (nodeId: NodeId, heartbeatAt: number): void => {
+    if (!Number.isFinite(heartbeatAt)) {
+        throw new Error(`[eventEmission] heartbeatAt must be finite, received ${String(heartbeatAt)}`);
+    }
+    const event: HeartbeatEvent = {
+        type: 'heartbeat',
+        payload: { nodeId: String(nodeId), heartbeatAt },
+    };
+    unconditionalEventStreamer.emitEvent(nodeId, 'heartbeat', event);
 };

--- a/plugins/shape-plugin/src/worker/api/shapeBuildAPI.ts
+++ b/plugins/shape-plugin/src/worker/api/shapeBuildAPI.ts
@@ -2,10 +2,10 @@ import type { NodeId } from '@hierarchidb/core-types';
 import type { BuildContinuationPolicy, BuildTaskSummary, BuildTaskUpdateEvent, BuildProgressEvent } from '@hierarchidb/build-api';
 import type { ShapeBuildSessionRecord } from '@hierarchidb/shape-api';
 import type {
-  SessionStateChangeEvent,
-  StageSnapshotEvent,
+  SessionStatusUpdatedEvent,
+  StageSnapshotUpdatedEvent,
   SessionHeartbeatEvent,
-  TaskProgressEvent,
+  TaskProgressUpdatedEvent,
   WorkerLogEvent,
 } from '~/common/types/session-events';
 import {
@@ -447,14 +447,14 @@ export const shapeBuildAPI = {
   // Real-time Session State Subscription (4 channels)
   // ===================================
 
-  subscribeToSessionState: (nodeId: NodeId, callback: (event: SessionStateChangeEvent) => void): (() => void) => {
+  subscribeToSessionState: (nodeId: NodeId, callback: (event: SessionStatusUpdatedEvent) => void): (() => void) => {
     const key = String(nodeId);
     const existing = shapeBuildRuntimeCore.sessionStateCallbacks.get(key);
     existing?.unsubscribe?.();
 
     // Subscribe to unconditional event stream
     const unsubscribeStream = unconditionalEventStreamer.subscribe(nodeId, 'session-state', (event) => {
-      callback(event as SessionStateChangeEvent);
+      callback(event as SessionStatusUpdatedEvent);
     });
 
     const unsubscribe = () => {
@@ -473,14 +473,14 @@ export const shapeBuildAPI = {
     };
   },
 
-  subscribeToStageSnapshots: (nodeId: NodeId, callback: (event: StageSnapshotEvent) => void): (() => void) => {
+  subscribeToStageSnapshots: (nodeId: NodeId, callback: (event: StageSnapshotUpdatedEvent) => void): (() => void) => {
     const key = String(nodeId);
     const existing = shapeBuildRuntimeCore.stageSnapshotCallbacks.get(key);
     existing?.unsubscribe?.();
 
     // Subscribe to unconditional event stream
     const unsubscribeStream = unconditionalEventStreamer.subscribe(nodeId, 'stage-snapshot', (event) => {
-      callback(event as StageSnapshotEvent);
+      callback(event as StageSnapshotUpdatedEvent);
     });
 
     const unsubscribe = () => {
@@ -525,14 +525,14 @@ export const shapeBuildAPI = {
     };
   },
 
-  subscribeToTaskProgress: (nodeId: NodeId, callback: (event: TaskProgressEvent) => void): (() => void) => {
+  subscribeToTaskProgress: (nodeId: NodeId, callback: (event: TaskProgressUpdatedEvent) => void): (() => void) => {
     const key = String(nodeId);
     const existing = shapeBuildRuntimeCore.taskProgressCallbacks.get(key);
     existing?.unsubscribe?.();
 
     // Subscribe to unconditional event stream
     const unsubscribeStream = unconditionalEventStreamer.subscribe(nodeId, 'task-progress', (event) => {
-      callback(event as TaskProgressEvent);
+      callback(event as TaskProgressUpdatedEvent);
     });
 
     const unsubscribe = () => {

--- a/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionControl.ts
+++ b/plugins/shape-plugin/src/worker/api/shapeBuildRuntimeExecutionControl.ts
@@ -35,7 +35,7 @@ import {
   deleteRawDataDataSourceBuffersForNodeMetadataIds,
 } from '~/services/utils/chunkStore';
 import { resolveSourceStageStrategy } from '~/services/build/strategies/resolveSourceStageStrategy';
-import { emitTaskSnapshot, emitProgressSnapshot, emitSessionStateChange } from './eventEmission.js';
+import { emitSessionStatusUpdated, emitStageSnapshotUpdated } from './eventEmission.js';
 import type { ShapeBuildStopReason, ShapeBuildSessionRecord } from '@hierarchidb/shape-api';
 import { isStopReason } from './taskQueueManagement.js';
 // Custom error types for better error classification
@@ -87,67 +87,82 @@ const clearActivePipelineRuntimeState = (_nodeId: string) => {
   // Clear the AbortController stored in PauseState so it cannot be re-triggered.
   clearSessionAbortController(_nodeId as NodeId);
   // Clear auth session context so stale session identity is not reused (#991).
-  AuthService.getSingleton().then((auth) => auth.clearBuildSessionContext()).catch(() => {});
+  AuthService.getSingleton().then((auth) => auth.clearBuildSessionContext()).catch(() => { });
 };
 
-const upsertBuildSessionSnapshot = async (data: { 
-  nodeId: NodeId; 
-  status?: ShapeBuildSessionRecord['status']; 
-  stopReason?: ShapeBuildStopReason; 
-  canResume?: boolean; 
-  startedAt?: number; 
-  completedAt?: number; 
-  selectedArrayByCountries?: any; 
-  tasks?: any[] 
+const upsertBuildSessionSnapshot = async (data: {
+  nodeId: NodeId;
+  status?: ShapeBuildSessionRecord['status'];
+  stopReason?: ShapeBuildStopReason;
+  canResume?: boolean;
+  startedAt?: number;
+  completedAt?: number;
+  selectedArrayByCountries?: any;
+  tasks?: any[]
 }): Promise<void> => {
-  try {
-    const previousSessionRecord = data.status ? await shapeQueryAPIImpl.getBuildSessionRecord(data.nodeId).catch(() => null) : null;
-    
-    await shapeMutationAPIImpl.updateBuildSession(data.nodeId, {
-      status: data.status,
-      stopReason: data.stopReason,
-      canResume: data.canResume,
-      startedAt: data.startedAt,
-      completedAt: data.completedAt,
-    });
-    
-    // Emit session state change event
-    if (data.status) {
-      const newSessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(data.nodeId).catch(() => null);
-      if (newSessionRecord) {
-        emitSessionStateChange(data.nodeId, previousSessionRecord?.status, data.status, newSessionRecord);
-      }
+  await shapeMutationAPIImpl.updateBuildSession(data.nodeId, {
+    status: data.status,
+    stopReason: data.stopReason,
+    canResume: data.canResume,
+    startedAt: data.startedAt,
+    completedAt: data.completedAt,
+  });
+
+  // Emit sessionStatusUpdated unconditionally after DB write.
+  // Re-read the record so all fields (stageId, stageStartedAt, etc.) are current.
+  // If the record is unavailable, emit with the known status directly to avoid
+  // silently dropping the event (the previous "if (newSessionRecord)" guard was
+  // the root cause of lifecycle.phase staying 'idle').
+  if (data.status) {
+    const newSessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(data.nodeId).catch(() => null);
+    if (newSessionRecord) {
+      emitSessionStatusUpdated(data.nodeId, newSessionRecord);
+    } else {
+      emitSessionStatusUpdated(data.nodeId, {
+        nodeId: data.nodeId,
+        status: data.status,
+        stopReason: data.stopReason,
+        canResume: data.canResume,
+        startedAt: data.startedAt ?? 0,
+        updatedAt: Date.now(),
+        completedAt: data.completedAt,
+        progress: {} as any,
+        stages: {},
+      });
     }
-  } catch (error) {
-    console.error('[shapeBuildAPI] Failed to upsert build session snapshot', error);
   }
 };
 
-const updateBuildSessionFromTasks = async (nodeId: NodeId, data: { 
-  status?: ShapeBuildSessionRecord['status']; 
-  stopReason?: ShapeBuildStopReason; 
-  completedAt?: number; 
-  canResume?: boolean 
+const updateBuildSessionFromTasks = async (nodeId: NodeId, data: {
+  status?: ShapeBuildSessionRecord['status'];
+  stopReason?: ShapeBuildStopReason;
+  completedAt?: number;
+  canResume?: boolean
 }): Promise<void> => {
-  try {
-    const previousSessionRecord = data.status ? await shapeQueryAPIImpl.getBuildSessionRecord(nodeId).catch(() => null) : null;
-    
-    await shapeMutationAPIImpl.updateBuildSession(nodeId, {
-      status: data.status,
-      stopReason: data.stopReason,
-      completedAt: data.completedAt,
-      canResume: data.canResume,
-    });
-    
-    // Emit session state change event
-    if (data.status) {
-      const newSessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(nodeId).catch(() => null);
-      if (newSessionRecord) {
-        emitSessionStateChange(nodeId, previousSessionRecord?.status, data.status, newSessionRecord);
-      }
+  await shapeMutationAPIImpl.updateBuildSession(nodeId, {
+    status: data.status,
+    stopReason: data.stopReason,
+    completedAt: data.completedAt,
+    canResume: data.canResume,
+  });
+
+  if (data.status) {
+    const newSessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(nodeId).catch(() => null);
+    if (newSessionRecord) {
+      emitSessionStatusUpdated(nodeId, newSessionRecord);
+    } else {
+      emitSessionStatusUpdated(nodeId, {
+        nodeId,
+        status: data.status,
+        stopReason: data.stopReason,
+        canResume: data.canResume,
+        startedAt: 0,
+        updatedAt: Date.now(),
+        completedAt: data.completedAt,
+        progress: {} as any,
+        stages: {},
+      });
     }
-  } catch (error) {
-    console.error('[shapeBuildAPI] Failed to update build session from tasks', error);
   }
 };
 
@@ -619,8 +634,10 @@ const startBuildSessionInternal = async (
     step: string,
     extra?: Record<string, unknown>,
   ): void => {
+    // stageHeartbeatAt keeps the session alive during long startup steps.
+    // stageId is NOT written here — startup:* values are not valid StageIds
+    // and must not appear in the session record per the event spec.
     void shapeMutationAPIImpl.updateBuildSession(startupNodeId, {
-      stageId: `startup:${step}:${phase}`,
       stageHeartbeatAt: Date.now(),
     }).catch(() => { });
     const payload = {
@@ -735,7 +752,7 @@ const startBuildSessionInternal = async (
       canResume: false,
       stopReason: undefined,
     });
-    await emitProgressSnapshot(nodeForSession, `${startupScope} ignored: pipeline already active`);
+    // sessionStatusUpdated is emitted inside upsertBuildSessionSnapshot
     return nodeForSession;
   }
   let sourcePlan;
@@ -745,7 +762,7 @@ const startBuildSessionInternal = async (
       selectedAdminPairCount: selectionSummary.selectedAdminPairCount,
       downloadTaskPayloadsCount: downloadTaskPayloads.length,
     });
-    
+
     sourcePlan = await executeStartupStep(
       'plan-source-total',
       async () => estimatePlannedSourceTotal({
@@ -760,7 +777,7 @@ const startBuildSessionInternal = async (
         selectedAdminPairCount: selectionSummary.selectedAdminPairCount,
       },
     );
-    
+
     console.warn('[shapeBuildAPI] plan-source-total step completed successfully', {
       nodeId: nodeForSession,
       plannedSourceTotal: sourcePlan.plannedSourceTotal,
@@ -770,66 +787,31 @@ const startBuildSessionInternal = async (
     // If auth is required, set session to paused (not failed) so the auth dialog
     // can be shown and the user can retry after authenticating (#979)
     if (error instanceof AuthRequiredError) {
-      try {
-        await upsertBuildSessionSnapshot({
-          nodeId: nodeForSession,
-          selectedArrayByCountries: draftEntity.selectedArrayByCountries,
-          tasks: [],
-          status: 'paused',
-          canResume: true,
-        });
-        await emitProgressSnapshot(nodeForSession, 'Authentication required. Build paused. Resume after sign-in.');
-      } catch (emitError) {
-        console.error('[shapeBuildAPI] Failed to emit paused snapshot for auth', {
-          nodeId: nodeForSession,
-          emitError: emitError instanceof Error ? emitError.message : String(emitError),
-        });
-      }
-      throw error;
-    }
-    // Emit empty task snapshot to notify UI of the error state
-    console.error('[shapeBuildAPI] Failed to plan source total, emitting empty task snapshot', {
-      nodeId: nodeForSession,
-      error: error instanceof Error ? error.message : String(error),
-      errorName: error instanceof Error ? error.name : 'Unknown',
-      errorStack: error instanceof Error ? error.stack : undefined,
-      selectedAdminPairCount: selectionSummary.selectedAdminPairCount,
-      downloadTaskPayloadsCount: downloadTaskPayloads.length,
-    });
-    
-    try {
-      // Send empty task snapshot to UI so it doesn't wait indefinitely
       await upsertBuildSessionSnapshot({
         nodeId: nodeForSession,
         selectedArrayByCountries: draftEntity.selectedArrayByCountries,
-        tasks: [], // Empty tasks array
-        status: 'failed',
-        canResume: false,
+        tasks: [],
+        status: 'paused',
+        canResume: true,
       });
-      
-      console.warn('[shapeBuildAPI] Empty build session snapshot upserted', {
-        nodeId: nodeForSession,
-      });
-      
-      await emitTaskSnapshot(nodeForSession);
-      
-      console.warn('[shapeBuildAPI] Empty task snapshot emitted to UI', {
-        nodeId: nodeForSession,
-      });
-      
-      // Emit progress snapshot to ensure UI receives notification
-      await emitProgressSnapshot(nodeForSession, 'Build failed during source planning.');
-      
-      console.warn('[shapeBuildAPI] Progress snapshot emitted for failed build', {
-        nodeId: nodeForSession,
-      });
-    } catch (emitError) {
-      console.error('[shapeBuildAPI] Failed to emit empty task snapshot', {
-        nodeId: nodeForSession,
-        emitError: emitError instanceof Error ? emitError.message : String(emitError),
-      });
+      // sessionStatusUpdated is emitted inside upsertBuildSessionSnapshot
+      throw error;
     }
-    
+    // Emit sessionStatusUpdated with 'failed' so the UI is not left waiting.
+    console.error('[shapeBuildAPI] Failed to plan source total', {
+      nodeId: nodeForSession,
+      error: error instanceof Error ? error.message : String(error),
+      errorName: error instanceof Error ? error.name : 'Unknown',
+      selectedAdminPairCount: selectionSummary.selectedAdminPairCount,
+      downloadTaskPayloadsCount: downloadTaskPayloads.length,
+    });
+    await upsertBuildSessionSnapshot({
+      nodeId: nodeForSession,
+      selectedArrayByCountries: draftEntity.selectedArrayByCountries,
+      tasks: [],
+      status: 'failed',
+      canResume: false,
+    });
     throw error;
   }
 
@@ -857,7 +839,7 @@ const startBuildSessionInternal = async (
 
   try {
     const taskQueue = new VtTaskQueueDb();
-    
+
     // Clean up invalid cache entries before processing any tasks (Requirements 4.1, 4.2, 4.3, 4.4)
     await executeStartupStep(
       'cleanup-invalid-cache-entries',
@@ -866,7 +848,7 @@ const startBuildSessionInternal = async (
           const cleanupResult = await cacheValidator.cleanupInvalidEntries(nodeForSession);
           console.log(
             `[shapeBuildAPI] Cache cleanup completed for node ${nodeForSession}:`,
-            { 
+            {
               geometryDeleted: cleanupResult.geometryDeleted,
               sourceDeleted: cleanupResult.sourceDeleted,
               totalDeleted: cleanupResult.geometryDeleted + cleanupResult.sourceDeleted
@@ -879,7 +861,7 @@ const startBuildSessionInternal = async (
         }
       },
     );
-    
+
     await executeStartupStep(
       'selection-diff-cleanup',
       async () => applySelectionDiffCleanup(
@@ -940,8 +922,17 @@ const startBuildSessionInternal = async (
       taskCount: number;
       source: 'created' | 'reused';
     }): Promise<void> => {
+      // Source tasks are now enqueued; emit stageSnapshotUpdated so the UI can
+      // display the task list. stageStartedAt is read from the session record.
       if (payload.stage !== 'source') return;
-      await emitProgressSnapshot(payload.nodeId, 'Source task plan prepared.');
+      const sessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(payload.nodeId).catch(() => null);
+      const stageStartedAt = sessionRecord?.stageStartedAt ?? Date.now();
+      await emitStageSnapshotUpdated(
+        payload.nodeId,
+        payload.stage,
+        stageStartedAt,
+        sessionRecord?.stageInactiveMs ?? 0,
+      );
     };
     const emitStageTaskSnapshotBarrier = async (payload: {
       nodeId: NodeId;
@@ -949,15 +940,16 @@ const startBuildSessionInternal = async (
       taskCount: number;
     }): Promise<void> => {
       void payload.taskCount;
-      await shapeMutationAPIImpl.updateBuildSession(payload.nodeId, {
-        stageId: `ui-sync:${payload.stage}:ui-initializing`,
-        stageHeartbeatAt: Date.now(),
-      });
-      await emitTaskSnapshot(payload.nodeId, { stage: payload.stage });
-      await shapeMutationAPIImpl.updateBuildSession(payload.nodeId, {
-        stageId: `ui-sync:${payload.stage}:running`,
-        stageHeartbeatAt: Date.now(),
-      });
+      // Read stageStartedAt from the session record; the pipeline has already
+      // written it before calling this callback.
+      const sessionRecord = await shapeQueryAPIImpl.getBuildSessionRecord(payload.nodeId).catch(() => null);
+      const stageStartedAt = sessionRecord?.stageStartedAt ?? Date.now();
+      await emitStageSnapshotUpdated(
+        payload.nodeId,
+        payload.stage,
+        stageStartedAt,
+        sessionRecord?.stageInactiveMs ?? 0,
+      );
     };
     emitStartupStepLog('start', 'pipeline-dispatch', {
       runId: pipelineRunId,
@@ -975,7 +967,6 @@ const startBuildSessionInternal = async (
       payloadCount: downloadTaskPayloads.length,
     });
     void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
-      stageId: 'startup:pipeline-dispatch:start',
       stageHeartbeatAt: Date.now(),
     }).catch(() => { });
     let terminalProgressMessage: string | undefined;
@@ -988,10 +979,6 @@ const startBuildSessionInternal = async (
       });
       const completedAt = Date.now();
       terminalProgressMessage = 'Empty build completed successfully (no selections).';
-      void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
-        stageId: 'startup:pipeline-dispatch:success',
-        stageHeartbeatAt: completedAt,
-      }).catch(() => { });
       await updateBuildSessionFromTasks(nodeForSession, {
         status: 'completed',
         stopReason: 'completed',
@@ -1006,7 +993,6 @@ const startBuildSessionInternal = async (
         emptyBuild: true,
       });
       clearActivePipelineRuntimeState(nodeForSession);
-      void emitProgressSnapshot(nodeForSession, terminalProgressMessage);
       return nodeForSession;
     }
 
@@ -1018,10 +1004,6 @@ const startBuildSessionInternal = async (
       });
       const completedAt = Date.now();
       terminalProgressMessage = 'Empty build completed successfully (no selections).';
-      void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
-        stageId: 'startup:pipeline-dispatch:success',
-        stageHeartbeatAt: completedAt,
-      }).catch(() => { });
       await updateBuildSessionFromTasks(nodeForSession, {
         status: 'completed',
         stopReason: 'completed',
@@ -1036,17 +1018,8 @@ const startBuildSessionInternal = async (
         emptyBuild: true,
       });
       clearActivePipelineRuntimeState(nodeForSession);
-      void emitProgressSnapshot(nodeForSession, terminalProgressMessage);
       return nodeForSession;
     }
-    console.warn('[shapeBuildAPI] Starting runShapePipeline execution', {
-      nodeId: nodeForSession,
-      runId: pipelineRunId,
-      dataSource: resolvedDataSource,
-      selectedAdminPairCount,
-      downloadTaskPayloadsCount: downloadTaskPayloads.length,
-    });
-    
     console.warn('[shapeBuildAPI] Starting runShapePipeline execution', {
       nodeId: nodeForSession,
       runId: pipelineRunId,
@@ -1078,12 +1051,6 @@ const startBuildSessionInternal = async (
       const tasks = await listTasks(taskQueue, nodeForSession);
       const terminalTaskStatus = summarizeTaskQueueStatus(tasks).status;
       const pipelineFinishedWithFailure = terminalTaskStatus === 'failed';
-      void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
-        stageId: pipelineFinishedWithFailure
-          ? 'startup:pipeline-dispatch:error'
-          : 'startup:pipeline-dispatch:success',
-        stageHeartbeatAt: completedAt,
-      }).catch(() => { });
       await updateBuildSessionFromTasks(nodeForSession, {
         status: pipelineFinishedWithFailure ? 'failed' : 'completed',
         stopReason: pipelineFinishedWithFailure ? 'failed' : 'completed',
@@ -1101,20 +1068,10 @@ const startBuildSessionInternal = async (
         errorName: error instanceof Error ? error.name : 'Unknown',
         errorStack: error instanceof Error ? error.stack : undefined,
       });
-      
-      // Emit task snapshot even when pipeline fails
-      try {
-        await emitTaskSnapshot(nodeForSession);
-        console.warn('[shapeBuildAPI] Task snapshot emitted after pipeline failure', {
-          nodeId: nodeForSession,
-        });
-      } catch (emitError) {
-        console.error('[shapeBuildAPI] Failed to emit task snapshot after pipeline failure', {
-          nodeId: nodeForSession,
-          emitError: emitError instanceof Error ? emitError.message : String(emitError),
-        });
-      }
-      
+
+      // updateBuildSessionFromTasks already emits sessionStatusUpdated.
+      // No additional snapshot emission needed here.
+
       const failedAt = Date.now();
       const diagnostics = toErrorDiagnostics(error);
       if (isAuthPendingPipelineError(error)) {
@@ -1139,10 +1096,6 @@ const startBuildSessionInternal = async (
           ...diagnostics,
         }));
         terminalProgressMessage = `Metadata error: ${diagnostics.errorMessage}`;
-        void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
-          stageId: 'startup:payload-generation:error',
-          stageHeartbeatAt: failedAt,
-        }).catch(() => { });
         await updateBuildSessionFromTasks(nodeForSession, {
           status: 'failed',
           stopReason: 'failed',
@@ -1163,10 +1116,6 @@ const startBuildSessionInternal = async (
         ...diagnostics,
       }));
       terminalProgressMessage = `Pipeline failed (${diagnostics.errorName ?? 'Error'}): ${diagnostics.errorMessage}`;
-      void shapeMutationAPIImpl.updateBuildSession(nodeForSession, {
-        stageId: 'startup:pipeline-dispatch:error',
-        stageHeartbeatAt: failedAt,
-      }).catch(() => { });
       await updateBuildSessionFromTasks(nodeForSession, {
         status: 'failed',
         stopReason: 'failed',
@@ -1175,7 +1124,6 @@ const startBuildSessionInternal = async (
       });
     }).finally(() => {
       clearActivePipelineRuntimeState(nodeForSession);
-      void emitProgressSnapshot(nodeForSession, terminalProgressMessage);
     });
     emitStartupStepLog('finish', 'pipeline-dispatch', {
       runId: pipelineRunId,
@@ -1308,14 +1256,13 @@ const invokeShapeBuildCommand = async (
       // Force reset running tasks regardless of worker termination
       await resetRunningTasks(nodeId);
 
-      // Update session state
+      // Update session state — emitSessionStatusUpdated is called inside upsertBuildSessionSnapshot
       await upsertBuildSessionSnapshot({
         nodeId,
         status: 'paused',
         stopReason,
         canResume: true,
       });
-      await emitProgressSnapshot(nodeId, 'Force termination completed.');
     }, FORCE_TERMINATION_TIMEOUT_MS);
 
     await resetRunningTasks(nodeId);
@@ -1356,7 +1303,6 @@ const invokeShapeBuildCommand = async (
             stopReason,
             canResume: true,
           });
-          await emitProgressSnapshot(nodeId, 'Pause requested.');
         }
 
         const drain = await waitForRunningTasksToDrain(nodeId);
@@ -1364,12 +1310,6 @@ const invokeShapeBuildCommand = async (
           nodeId,
           ...drain,
         });
-        if (!drain.drained && !forceTerminationExecuted) {
-          await emitProgressSnapshot(
-            nodeId,
-            `Pause requested; waiting for ${drain.running} running task(s) to reach a pause point.`
-          );
-        }
       } catch (error) {
         console.warn('[shapeBuildAPI][PauseTrace] pause-settle-monitor-failed', {
           nodeId,
@@ -1401,7 +1341,6 @@ const invokeShapeBuildCommand = async (
       stopReason,
       canResume: false,
     });
-    await emitProgressSnapshot(nodeId, 'Queued build canceled.');
     return;
   }
 

--- a/plugins/shape-plugin/src/worker/api/stateManagement.ts
+++ b/plugins/shape-plugin/src/worker/api/stateManagement.ts
@@ -10,12 +10,38 @@ import type {
     ShapeBuildSessionRecord,
 } from '@hierarchidb/shape-api';
 import type {
-    SessionStateSubscription,
-    StageSnapshotSubscription,
-    HeartbeatSubscription,
-    TaskProgressSubscription,
-    WorkerLogSubscription,
+    SessionStatusUpdatedEvent,
+    StageSnapshotUpdatedEvent,
+    HeartbeatEvent,
+    TaskProgressUpdatedEvent,
+    WorkerLogEvent,
 } from '~/common/types/session-events';
+
+// Subscription interfaces using the canonical 4-event types
+export interface SessionStateSubscription {
+    unsubscribe?: () => void;
+    callback?: (event: SessionStatusUpdatedEvent) => void;
+}
+
+export interface StageSnapshotSubscription {
+    unsubscribe?: () => void;
+    callback?: (event: StageSnapshotUpdatedEvent) => void;
+}
+
+export interface HeartbeatSubscription {
+    unsubscribe?: () => void;
+    callback?: (event: HeartbeatEvent) => void;
+}
+
+export interface TaskProgressSubscription {
+    unsubscribe?: () => void;
+    callback?: (event: TaskProgressUpdatedEvent) => void;
+}
+
+export interface WorkerLogSubscription {
+    unsubscribe?: () => void;
+    callback?: (event: WorkerLogEvent) => void;
+}
 import {
     resolveTaskActivityTimestamp,
     selectLatestTaskByProgress,
@@ -96,7 +122,7 @@ const waitIfPaused = async (nodeId: NodeId): Promise<void> => {
 
 const setPaused = async (nodeId: NodeId, paused: boolean): Promise<void> => {
     const state = getPauseState(nodeId);
-    
+
     // If pausing, verify and protect task states before setting pause
     if (paused && !state.paused) {
         try {
@@ -116,19 +142,19 @@ const setPaused = async (nodeId: NodeId, paused: boolean): Promise<void> => {
             });
         }
     }
-    
+
     state.paused = paused;
     console.warn('[shapeBuildRuntime][PauseTrace] state-update', {
         nodeId,
         paused,
         waiters: state.waiters.length,
     });
-    
+
     if (!paused && state.waiters.length > 0) {
         const pending = [...state.waiters];
         state.waiters.length = 0;
         pending.forEach((resolve) => { resolve() });
-        
+
         // Clear snapshots when resuming
         taskStateProtection.clearSnapshots(nodeId);
     }


### PR DESCRIPTION
## Summary

Closes #1074

Aligns the Worker→UI event architecture to the canonical 4-event spec defined in `docs/build-session-worker-ui-event-spec.md`.

## Changes

### Type definitions (`session-events.ts`)
- Replace old event types with canonical 4-event set:
  - `SessionStatusUpdatedEvent` (was `SessionStateChangeEvent`)
  - `StageSnapshotUpdatedEvent` (was `StageSnapshotEvent`)
  - `TaskProgressUpdatedEvent` (was `TaskProgressEvent`)
  - `HeartbeatEvent` (was `SessionHeartbeatEvent`)
- Add `SessionPhase` union type

### Worker side
- `eventEmission.ts`: new emit functions matching canonical event shapes
- `eventBuffering.ts`: updated to new types
- `shapeBuildRuntimeExecutionControl.ts`, `shapeBuildAPI.ts`, `stateManagement.ts`: updated

### UI side
- `useShapeBuildSessionStateAtomBridge.ts`: consumes canonical events directly; removes `startup:`/`ui-sync:` stageId hacks
- `buildSessionWorkerEventAdapter.ts` (shape-plugin): removes `isActivePhase`/`resolveProgressValue` from config
- `createBuildSessionWorkerEventAdapter.ts` (ui-build-sessions): `AdapterConfig` simplified
- `workerBridge.ts`: `subscribeAll` handlers typed as `unknown`

### Docs
- Fixed 5 contradictions in `build-session-worker-ui-event-spec.md` and `build-session-worker-ui-event-design.md`

### Tests
- Updated `eventBuffering.unit.test.ts`, `eventArchitectureProperties.property.test.ts`, `eventDeliveryExtendedScenarios.property.test.ts`

## Verification

```
pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin  # no errors in changed files
pnpm -w turbo run test --filter @hierarchidb/shape-plugin -- --run
# Test Files  63 passed | 2 skipped (65)
# Tests  442 passed | 3 skipped (445)
```