### PR TITLE
fix(spreadsheet-plugin): replace export * with explicit exports to eliminate index2.d.ts

### DIFF
--- a/plugins/spreadsheet-plugin/src/index.ts
+++ b/plugins/spreadsheet-plugin/src/index.ts
@@ -5,12 +5,19 @@ export type {
   SpreadsheetEntity,
   UploadedFileSummary,
 } from './common/types/SpreadsheetEntity.js';
-export * from './common/constants.js';
-export * from './services/index.js';
-export { createPluginTabularApi } from './services/spreadsheetTabularApiFactory.js';
+// constants (expanded from common/constants.js to avoid export * causing shared DTS chunks)
 export {
-  KeyValueSourcePanel,
-  TabularDataSourceStep,
-  TabularDataFilterStep,
-  tabularRowsAtom,
-} from './ui/index.js';
+  SPREADSHEET_PLUGIN_ID,
+  SPREADSHEET_PLUGIN_VERSION,
+  SPREADSHEET_NODE_TYPE,
+} from './plugin-manifest.js';
+export { DATA_SOURCE_TYPES, STEP_LABELS } from './common/constants.js';
+// services (expanded from services/index.js to avoid export * causing shared DTS chunks)
+export { SpreadsheetTabularApiDriver } from './services/SpreadsheetTabularApiDriver.js';
+export { SpreadsheetMetadataManager } from './services/SpreadsheetMetadataManager.js';
+export { SpreadsheetStorePort } from './services/SpreadsheetStorePort.js';
+export {
+  createSpreadsheetTabularApi,
+  createPluginTabularApi,
+} from './services/spreadsheetTabularApiFactory.js';
+export type { PluginTabularApiOptions } from './services/spreadsheetTabularApiFactory.js';

--- a/plugins/styler-plugin/src/ui/components/StylerFilterStep.tsx
+++ b/plugins/styler-plugin/src/ui/components/StylerFilterStep.tsx
@@ -1,5 +1,5 @@
 import type { PluginStepProps } from '@hierarchidb/plugin-base';
-import { TabularDataFilterStep } from '@hierarchidb/spreadsheet-plugin';
+import { TabularDataFilterStep } from '@hierarchidb/spreadsheet-plugin/ui';
 import { AuthReadyGate } from '@hierarchidb/ui-auth';
 import { Box, CircularProgress, Typography } from '@mui/material';
 import { Suspense } from 'react';

--- a/plugins/styler-plugin/src/ui/components/StylerMappingKeysStep.tsx
+++ b/plugins/styler-plugin/src/ui/components/StylerMappingKeysStep.tsx
@@ -1,5 +1,5 @@
 import type { PluginStepProps } from '@hierarchidb/plugin-base';
-import { KeyValueSourcePanel } from '@hierarchidb/spreadsheet-plugin';
+import { KeyValueSourcePanel } from '@hierarchidb/spreadsheet-plugin/ui';
 import type { TabularTableMetadata } from '@hierarchidb/tabular-store';
 import { Box, FormControl, FormHelperText, TextField, Typography } from '@mui/material';
 import type React from 'react';

--- a/plugins/styler-plugin/src/ui/components/hooks/useStylerPreview.ts
+++ b/plugins/styler-plugin/src/ui/components/hooks/useStylerPreview.ts
@@ -1,4 +1,4 @@
-import { tabularRowsAtom } from '@hierarchidb/spreadsheet-plugin';
+import { tabularRowsAtom } from '@hierarchidb/spreadsheet-plugin/ui';
 import { i18n } from '@hierarchidb/ui-i18n';
 import type { TabularFilterRule } from '@hierarchidb/ui-tabular';
 import { useAtomValue } from 'jotai';

--- a/plugins/styler-plugin/src/ui/components/steps-provider.tsx
+++ b/plugins/styler-plugin/src/ui/components/steps-provider.tsx
@@ -3,7 +3,7 @@ import {
   type PluginStepProps,
   PluginStepRegistry,
 } from '@hierarchidb/plugin-base';
-import { TabularDataSourceStep } from '@hierarchidb/spreadsheet-plugin';
+import { TabularDataSourceStep } from '@hierarchidb/spreadsheet-plugin/ui';
 import { i18n } from '@hierarchidb/ui-i18n';
 import React from 'react';
 import type {


### PR DESCRIPTION
Closes #1083

## 変更内容
- `src/index.ts` の `export * from './services/index.js'` を個別エクスポートに展開
- `export * from './common/constants.js'` を個別エクスポートに展開
- 重複していた `export { createPluginTabularApi }` を削除
- UI コンポーネントの re-export（`KeyValueSourcePanel` 等）を削除
- `styler-plugin` の `@hierarchidb/spreadsheet-plugin` 直接 import を `/ui` サブパスに修正（4ファイル）

## 検証
- `pnpm build` 後に `dist/index2.d.ts` が生成されないことを確認
- typecheck: spreadsheet-plugin / styler-plugin / location-plugin / route-plugin 全て exit 0