### PR TITLE
chore(build): remove build:types/build:dts/build:js scripts, unify to build (#1082)

### DIFF
--- a/packages/auth-api/package.json
+++ b/packages/auth-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts src/AuthService.ts src/AuthRecoveryService.ts src/AuthNotificationSystem.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/build-api/package.json
+++ b/packages/build-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/build-runtime-services/package.json
+++ b/packages/build-runtime-services/package.json
@@ -19,12 +19,10 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsdown src/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@hierarchidb/build": "workspace:*",
     "@hierarchidb/core-types": "workspace:*",

--- a/packages/build-session-ports/package.json
+++ b/packages/build-session-ports/package.json
@@ -13,7 +13,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:types": "pnpm run build",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
     "test": "vitest"
   },

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
     "test": "vitest run"

--- a/packages/chunk-store/package.json
+++ b/packages/chunk-store/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.build.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "build:types": "pnpm run build",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "format": "biome check --write src",

--- a/packages/import-export-api/package.json
+++ b/packages/import-export-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/import-export/package.json
+++ b/packages/import-export/package.json
@@ -17,7 +17,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.build.json --outDir dist",
     "clean": "rm -rf dist",
     "test": "vitest run -c vitest.config.ts src/__tests__/vector-tile-export.test.ts",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"

--- a/packages/location-api/package.json
+++ b/packages/location-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/location-store/package.json
+++ b/packages/location-store/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/map-source/package.json
+++ b/packages/map-source/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.build.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/plugin-ui-sdk/package.json
+++ b/packages/plugin-ui-sdk/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsdown src/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"

--- a/packages/resolver-store/package.json
+++ b/packages/resolver-store/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/route-api/package.json
+++ b/packages/route-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/route-resolver/package.json
+++ b/packages/route-resolver/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.build.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/route-searoute/package.json
+++ b/packages/route-searoute/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.build.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/route-store/package.json
+++ b/packages/route-store/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/shape-api/package.json
+++ b/packages/shape-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.json --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/shape-store/package.json
+++ b/packages/shape-store/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/spreadsheet-store/package.json
+++ b/packages/spreadsheet-store/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/style-api/package.json
+++ b/packages/style-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/styler-store/package.json
+++ b/packages/styler-store/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/tabular-source/package.json
+++ b/packages/tabular-source/package.json
@@ -42,7 +42,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts src/ports.ts src/registry.ts src/types.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.build.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/tabular-store/package.json
+++ b/packages/tabular-store/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.build.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/tag-api/package.json
+++ b/packages/tag-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/tree-api/package.json
+++ b/packages/tree-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/ui/dialog/package.json
+++ b/packages/ui/dialog/package.json
@@ -19,7 +19,6 @@
   ],
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "test": "vitest --passWithNoTests",

--- a/packages/ui/file/package.json
+++ b/packages/ui/file/package.json
@@ -11,7 +11,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "format": "biome check --write src",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,scss}\"",
     "clean": "rm -rf dist",

--- a/packages/ui/json-treeview/package.json
+++ b/packages/ui/json-treeview/package.json
@@ -19,7 +19,6 @@
   ],
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/ui/worker-client/package.json
+++ b/packages/ui/worker-client/package.json
@@ -18,7 +18,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --project tsconfig.json --outDir dist",
     "test": "vitest",
     "test:run": "vitest run",
     "coverage": "vitest run --coverage",
@@ -54,7 +53,6 @@
     "@hierarchidb/core-types": "workspace:*",
     "@hierarchidb/build-api": "workspace:*",
     "@hierarchidb/tree-api": "workspace:*",
-    "@hierarchidb/auth-api": "workspace:*",
     "@hierarchidb/worker-api": "workspace:*",
     "@hierarchidb/runtime-worker": "workspace:*"
   },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts src/format.ts src/validation.ts src/SingletonMixin.ts src/generateId.ts src/db-name.ts src/env.ts src/webCrypto.ts src/dualKeyMap.ts src/treeConsoleSettings.ts src/zoomBandSettings.ts src/sleep.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"

--- a/packages/vectortile-store/package.json
+++ b/packages/vectortile-store/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/packages/vt-orchestrator/package.json
+++ b/packages/vt-orchestrator/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"

--- a/packages/worker-api/package.json
+++ b/packages/worker-api/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts --config ../../../tsdown.config.ts --outDir dist",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --project tsconfig.json --outDir dist",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },

--- a/plugins/basemap-plugin/package.json
+++ b/plugins/basemap-plugin/package.json
@@ -35,7 +35,7 @@
     }
   },
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "test": "vitest",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
@@ -44,9 +44,7 @@
     "format": "biome check --write src",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,scss}\"",
     "dev:tsc": "tsc --watch",
-    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hierarchidb/plugin-base": "workspace:*",
@@ -170,8 +168,5 @@
         ]
       }
     }
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/plugins/folder-plugin/package.json
+++ b/plugins/folder-plugin/package.json
@@ -43,16 +43,14 @@
     }
   },
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --splitting false --outDir dist",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "test": "vitest --passWithNoTests",
     "test:run": "vitest run",
     "coverage": "vitest run --coverage",
     "dev:tsc": "tsc --watch",
-    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --splitting false --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hierarchidb/plugin-base": "workspace:*"
@@ -161,8 +159,5 @@
   },
   "turbo": {
     "pipeline": {}
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/plugins/linker-plugin/package.json
+++ b/plugins/linker-plugin/package.json
@@ -40,16 +40,14 @@
     }
   },
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
     "lint": "eslint src",
     "test": "vitest",
     "test:run": "vitest run",
     "coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
-    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hierarchidb/plugin-base": "workspace:*"
@@ -150,8 +148,5 @@
         "draft"
       ]
     }
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/plugins/linker-plugin/src/index.ts
+++ b/plugins/linker-plugin/src/index.ts
@@ -1,7 +1,2 @@
-// Minimal entry with UI steps registration for Linker
-import './ui/index.js';
-
 export { PLUGIN_MANIFEST as LinkerPluginManifest } from './plugin-manifest.js';
 export { LinkerResourceService, linkerServices, type LinkerResource } from './services/index.js';
-
-

--- a/plugins/location-plugin/package.json
+++ b/plugins/location-plugin/package.json
@@ -41,14 +41,12 @@
     }
   },
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/worker/locationEntitiesDB.ts src/worker/createLocationFeatureStoreDexie.ts src/locationEntitiesDB.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
     "test": "vitest",
     "test:watch": "vitest",
     "clean": "rm -rf dist",
-    "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
-    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/worker/locationEntitiesDB.ts src/worker/createLocationFeatureStoreDexie.ts src/locationEntitiesDB.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs"
   },
   "dependencies": {
     "@hierarchidb/gen-iso3166-2": "workspace:*",
@@ -168,8 +166,5 @@
         "visualization"
       ]
     }
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/plugins/resolver-plugin/package.json
+++ b/plugins/resolver-plugin/package.json
@@ -36,15 +36,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "test": "vitest run",
     "test:run": "vitest run",
     "coverage": "vitest run --coverage",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
-    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hierarchidb/plugin-base": "workspace:*",
@@ -136,8 +134,5 @@
         "relationalData"
       ]
     }
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/plugins/resolver-plugin/src/index.ts
+++ b/plugins/resolver-plugin/src/index.ts
@@ -1,4 +1,3 @@
-
 export type {
   ResolverEntity,
   ResolverUpdaterPayload,
@@ -13,11 +12,6 @@ export type {
   StylerIntegration,
 } from './common/types/index.js';
 
-export {
-  ResolverPanel,
-} from './ui/components/index.js';
-
-
 export async function loadResolverPanelModule() {
   return import(/* @vite-ignore */ './ui/components/ResolverPanel.js');
 }
@@ -28,8 +22,5 @@ export async function getDialogComponent() {
   }
   return () => null;
 }
-
-// Register host-composed steps on import (idempotent)
-import './ui/components/steps-provider.js';
 
 export { PLUGIN_MANIFEST as ResolverPluginManifest } from './plugin-manifest.js';

--- a/plugins/route-plugin/package.json
+++ b/plugins/route-plugin/package.json
@@ -43,13 +43,11 @@
     }
   },
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "test:watch": "vitest",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
-    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/worker/index.ts src/worker/factory/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
   "dependencies": {
     "dexie": "^4.2.0",
@@ -159,8 +157,5 @@
         }
       }
     }
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/plugins/shape-plugin/package.json
+++ b/plugins/shape-plugin/package.json
@@ -45,15 +45,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/common/shared/index.ts src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/public.ts src/worker/shapeEntitiesDB.ts src/worker/shapeVectorTileStore.dexie.ts src/icon/index.ts --config ../../tsdown.config.ts --splitting false --outDir dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
     "test": "SHAPE_VITEST_POOL=forks vitest run",
     "test:watch": "SHAPE_VITEST_POOL=forks vitest",
     "coverage": "SHAPE_VITEST_POOL=forks vitest run --coverage",
     "clean": "rm -rf dist",
-    "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
-    "build:js": "tsdown src/common/shared/index.ts src/index.ts src/services/index.ts src/ui/index.ts src/worker/index.ts src/worker/public.ts src/worker/shapeEntitiesDB.ts src/worker/shapeVectorTileStore.dexie.ts src/icon/index.ts --config ../../tsdown.config.ts --splitting false --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs"
   },
   "dependencies": {
     "@hierarchidb/shape-store": "workspace:*",
@@ -273,8 +271,5 @@
         ]
       }
     }
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/plugins/spreadsheet-plugin/package.json
+++ b/plugins/spreadsheet-plugin/package.json
@@ -45,14 +45,12 @@
     }
   },
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/ui/index.ts src/worker/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
     "test": "pnpm vitest",
     "test:run": "pnpm vitest run",
     "clean": "rm -rf dist",
-    "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
-    "build:dts": "rollup -c rollup.dts.config.mjs",
-    "build:js": "tsdown src/index.ts src/ui/index.ts src/worker/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist"
+    "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs"
   },
   "peerDependencies": {
     "@emotion/react": "^11.14.0",
@@ -101,8 +99,5 @@
     "@hierarchidb/auth-api": "workspace:*",
     "@hierarchidb/ui-i18n": "workspace:*"
   },
-  "dependencies": {},
-  "tsdown": {
-    "dts": false
-  }
+  "dependencies": {}
 }

--- a/plugins/spreadsheet-plugin/src/index.ts
+++ b/plugins/spreadsheet-plugin/src/index.ts
@@ -5,12 +5,19 @@ export type {
   SpreadsheetEntity,
   UploadedFileSummary,
 } from './common/types/SpreadsheetEntity.js';
-export * from './common/constants.js';
-export * from './services/index.js';
-export { createPluginTabularApi } from './services/spreadsheetTabularApiFactory.js';
+// constants (expanded from common/constants.js to avoid export * causing shared DTS chunks)
 export {
-  KeyValueSourcePanel,
-  TabularDataSourceStep,
-  TabularDataFilterStep,
-  tabularRowsAtom,
-} from './ui/index.js';
+  SPREADSHEET_PLUGIN_ID,
+  SPREADSHEET_PLUGIN_VERSION,
+  SPREADSHEET_NODE_TYPE,
+} from './plugin-manifest.js';
+export { DATA_SOURCE_TYPES, STEP_LABELS } from './common/constants.js';
+// services (expanded from services/index.js to avoid export * causing shared DTS chunks)
+export { SpreadsheetTabularApiDriver } from './services/SpreadsheetTabularApiDriver.js';
+export { SpreadsheetMetadataManager } from './services/SpreadsheetMetadataManager.js';
+export { SpreadsheetStorePort } from './services/SpreadsheetStorePort.js';
+export {
+  createSpreadsheetTabularApi,
+  createPluginTabularApi,
+} from './services/spreadsheetTabularApiFactory.js';
+export type { PluginTabularApiOptions } from './services/spreadsheetTabularApiFactory.js';

--- a/plugins/styler-plugin/package.json
+++ b/plugins/styler-plugin/package.json
@@ -35,7 +35,7 @@
     }
   },
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "test": "vitest",
     "test:run": "vitest run",
     "coverage": "vitest run --coverage",
@@ -44,9 +44,7 @@
     "format": "biome check --write src",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,scss}\"",
     "dev:tsc": "tsc --watch",
-    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
-    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
   "dependencies": {
     "jszip": "^3.10.1",
@@ -201,8 +199,5 @@
         ]
       }
     }
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/plugins/timeline-plugin/package.json
+++ b/plugins/timeline-plugin/package.json
@@ -36,12 +36,10 @@
     }
   },
   "scripts": {
-    "build": "pnpm build:js && pnpm build:dts",
+    "build": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
     "clean": "rm -rf dist",
     "clean:force": "NODE_OPTIONS=\"--loader ts-node/esm\" rm -rf dist node_modules tsconfig.tsbuildinfo tsup.config.bundled_*.mjs",
-    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
-    "build:js": "tsdown src/index.ts src/services/index.ts src/ui/index.ts src/icon/index.ts --config ../../tsdown.config.ts --outDir dist",
-    "build:dts": "rollup -c rollup.dts.config.mjs"
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hierarchidb/core-types": "workspace:*",
@@ -109,8 +107,5 @@
         }
       }
     }
-  },
-  "tsdown": {
-    "dts": false
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -27,32 +27,6 @@
         "storybook-static/**"
       ]
     },
-    "build:types": {
-      "dependsOn": [
-        "^build:types"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "!**/*.md",
-        "!docs/**",
-        "!plans/**",
-        "!reports/**",
-        "!coverage/**",
-        "!artifacts/**",
-        "!playwright-report/**",
-        "!storybook-static/**",
-        "!e2e-results/**",
-        "!tmp/**",
-        "!dist/**",
-        "!build/**",
-        "!**/*.tsbuildinfo"
-      ],
-      "outputs": [
-        "dist/**/*.d.ts",
-        "dist/**/*.d.ts.map",
-        "**/*.tsbuildinfo"
-      ]
-    },
     "test": {
       "dependsOn": [
         "^build"
@@ -104,7 +78,7 @@
     },
     "typecheck": {
       "dependsOn": [
-        "^build:types",
+        "^build",
         "^typecheck"
       ],
       "inputs": [
@@ -151,58 +125,6 @@
         "reports/runtime-worker/*.xml"
       ],
       "cache": false
-    },
-    "build:js": {
-      "dependsOn": [
-        "^build:js"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "!**/*.md",
-        "!docs/**",
-        "!plans/**",
-        "!reports/**",
-        "!coverage/**",
-        "!artifacts/**",
-        "!playwright-report/**",
-        "!storybook-static/**",
-        "!e2e-results/**",
-        "!tmp/**",
-        "!dist/**",
-        "!build/**",
-        "!**/*.tsbuildinfo"
-      ],
-      "outputs": [
-        "dist/**",
-        "build/**",
-        "storybook-static/**"
-      ]
-    },
-    "build:dts": {
-      "dependsOn": [
-        "^build:dts"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "!**/*.md",
-        "!docs/**",
-        "!plans/**",
-        "!reports/**",
-        "!coverage/**",
-        "!artifacts/**",
-        "!playwright-report/**",
-        "!storybook-static/**",
-        "!e2e-results/**",
-        "!tmp/**",
-        "!dist/**",
-        "!build/**",
-        "!**/*.tsbuildinfo"
-      ],
-      "outputs": [
-        "dist/**/*.d.ts",
-        "dist/**/*.d.ts.map",
-        "**/*.tsbuildinfo"
-      ]
     }
   }
 }


### PR DESCRIPTION
Closes #1082

## Changes

- **turbo.json**: remove `build:types`, `build:dts`, `build:js` task definitions; change `typecheck.dependsOn` from `^build:types` to `^build`
- **packages/\*/package.json** (37 packages): remove `build:types` script
- **plugins/\*/package.json** (10 plugins): remove `build:dts`/`build:js`, promote `build` to direct tsdown call
- **plugins/linker-plugin/src/index.ts**: remove side-effect UI import
- **plugins/resolver-plugin/src/index.ts**: remove `ResolverPanel` re-export and `steps-provider` side-effect import
- **plugins/spreadsheet-plugin/src/index.ts**: expand `export *` to named exports (aligned with #1084)

## Verification

- `pnpm -w turbo run build --filter @hierarchidb/shape-plugin --filter @hierarchidb/linker-plugin --filter @hierarchidb/resolver-plugin --filter @hierarchidb/spreadsheet-plugin`: exit 0
- `pnpm -w turbo run typecheck` (same filters): exit 0