### PR TITLE
fix(ui-treeconsole-base): correct moveNode failure mock to use CRUDResult shape (#1099)

### DIFF
--- a/packages/ui/treeconsole/base/src/hooks/treeViewController.mutations.test.tsx
+++ b/packages/ui/treeconsole/base/src/hooks/treeViewController.mutations.test.tsx
@@ -85,13 +85,13 @@ describe('useTreeViewController', () => {
 
     it('should handle move failure gracefully', async () => {
       mockStateManager.moveNode = vi.fn().mockResolvedValue({
-        success: false,
+        result: false,
         error: 'Cannot move node',
       });
 
       const { result } = renderHook(() => useTreeViewController(mockProps));
 
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
 
       await act(async () => {
         await result.current.moveNode('$1' as NodeId, '$2' as NodeId, 0);


### PR DESCRIPTION
Closes #1099

## 変更内容
`treeViewController.mutations.test.tsx` の moveNode 失敗テストで、モックが `{ success: false }` を返していたが、`CRUDResult` 型は `{ result: boolean }` であり実装も `res.result === false` をチェックしている。`success` フィールドは存在しないため条件が一致せず `console.error` が呼ばれなかった。

モック戻り値を `{ result: false, error: 'Cannot move node' }` に修正。

## 検証
- `pnpm vitest run`: 73/73 passed (22 skipped), exit 0