### PR TITLE
fix(plugin-registry): update exports from '' to 'common' for location/route/shape-plugin (#1105)

### DIFF
--- a/packages/plugin-registry/generated/registry.ts
+++ b/packages/plugin-registry/generated/registry.ts
@@ -390,7 +390,7 @@ export const pluginRegistry: PluginRegistryEntry[] = [
         "react-dom",
         "react-virtuoso"
       ],
-    exports: ["","worker","icon","ui"],
+    exports: ["common","worker","icon","ui"],
     manifest: {
         "id": "@hierarchidb/location-plugin",
         "name": "Location Plugin",
@@ -704,7 +704,7 @@ export const pluginRegistry: PluginRegistryEntry[] = [
         "@hierarchidb/ui-tabular",
         "@hierarchidb/ui-accordion-config"
       ],
-    exports: ["","worker","icon","ui"],
+    exports: ["common","worker","icon","ui"],
     manifest: {
         "id": "@hierarchidb/route-plugin",
         "name": "Route Plugin",
@@ -928,7 +928,7 @@ export const pluginRegistry: PluginRegistryEntry[] = [
         "topojson-server",
         "topojson-simplify"
       ],
-    exports: ["","worker","icon","ui"],
+    exports: ["common","worker","icon","ui"],
     manifest: {
         "id": "@hierarchidb/shape-plugin",
         "name": "Shape Plugin",


### PR DESCRIPTION
Closes #1105

## 変更内容
#1089 (#1090) で location/route/shape-plugin の `src/index.ts` を廃止し `./common` エントリに移行したが、`packages/plugin-registry/generated/registry.ts` の `exports` フィールドが `["", "worker", "icon", "ui"]` のまま残っていた。

`exports: ["", ...]` → `exports: ["common", ...]` に修正（3箇所）。