### PR TITLE
fix(shape-plugin): add metadata to TaskSummary so task titles resolve correctly

### DIFF
--- a/plugins/shape-plugin/src/common/types/session-events.ts
+++ b/plugins/shape-plugin/src/common/types/session-events.ts
@@ -79,6 +79,8 @@ export interface HeartbeatEvent {
 
 /**
  * Minimal task summary carried inside StageSnapshotUpdatedEvent.
+ * metadata is included so UI-side title resolution (resolveShapeTaskTitle)
+ * can access metadata.preview without requiring title/inputData fields.
  */
 export interface TaskSummary {
     taskId: string;
@@ -87,6 +89,7 @@ export interface TaskSummary {
     progress: number;
     version: number;
     errorMessage?: string;
+    metadata?: Record<string, unknown>;
 }
 
 /**

--- a/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildSessionStateAtomBridge.ts
+++ b/plugins/shape-plugin/src/ui/components/build-progress/useShapeBuildSessionStateAtomBridge.ts
@@ -165,6 +165,7 @@ export const useShapeBuildSessionStateAtomBridge = (nodeId: NodeId | undefined):
                     status: resolveProgressPhase(task.status),
                     progress: task.progress,
                     errorMessage: task.errorMessage,
+                    metadata: task.metadata,
                 };
             });
             return {


### PR DESCRIPTION
## 概要

タスクが「Title unavailable」と表示される不具合を修正する。

## 原因

TaskSummary 型に metadata フィールドが存在しなかったため、Worker から送信された metadata.preview が UI 側に届かず、resolveShapeTaskTitle がタイトルを解決できなかった。

## 変更内容

- session-events.ts: TaskSummary に metadata フィールドを追加
- useShapeBuildSessionStateAtomBridge.ts: toAdapterStageSnapshotEvent 内で task.metadata を BuildTaskSummary に渡すよう修正

## 検証

- typecheck: exit 0 (pnpm -w turbo run typecheck --filter @hierarchidb/shape-plugin)

Closes #1121
