### PR TITLE
fix(location-plugin): rename subscribeBuildProgress → subscribeTaskProgress in test shim and README (#1149)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,7 @@
 
 ## Doing
 
+- #1149 / `fix/location-plugin/rename-subscribe-build-progress-1149` / 2026-03-18 開始
 - #1123 / `fix/app/subscribe-task-progress-1123` / 2026-03-17 開始
 - #1127 / `fix/shape-plugin/task-progress-version-gate-and-idle-fallback` / 2026-03-17 開始
 - #1020 / `refactor/shape-plugin/build-session-event-redesign-1020` / 2026-03-14 開始

--- a/plugins/location-plugin/src/common/test-shims/runtime-worker.ts
+++ b/plugins/location-plugin/src/common/test-shims/runtime-worker.ts
@@ -16,7 +16,7 @@ export const workerAPI = {
     status: 'running' as const,
   }),
   pauseBuildSession: async () => undefined,
-  subscribeBuildProgress: async () => () => undefined,
+  subscribeTaskProgress: async () => () => undefined,
 };
 
 export default {

--- a/plugins/shape-plugin/README.md
+++ b/plugins/shape-plugin/README.md
@@ -92,7 +92,7 @@ Shape ビルド機能の新アーキテクチャ概要と利用メモ。
 
 ## Build execution design (2025-12 WIP)
 - Entry (UI Build Progress): call worker API `startBuildSession(nodeId, config)`; UI keeps `sessionId` and subscribes to progress.
-- Worker API: expose `startBuildSession`, `pauseBuildSession`, `cancelQueuedBuildSession`, `subscribeBuildProgress`; bridge ProgressInfo to UI.
+- Worker API: expose `startBuildSession`, `pauseBuildSession`, `cancelQueuedBuildSession`, `subscribeTaskProgress`; bridge ProgressInfo to UI.
 - Build manager: `UnifiedShapeBuildManager` coordinates stages (download → extract1 → extract2 → vectorTiles) and emits stage-scoped progress.
 - Ephemeral DB (Dexie, `getDBName('shape-ephemeral')`):
   - `sessions` (state/config), `rawBuffers` (downloaded), `extractedBuffers` (stage1/2), `vectorTiles` (tiles), `cache` (optional).


### PR DESCRIPTION
Closes #1149

## 変更内容

- `plugins/location-plugin/src/common/test-shims/runtime-worker.ts`: `subscribeBuildProgress` → `subscribeTaskProgress`
- `plugins/shape-plugin/README.md`: 同メソッド名を修正

## 検証

- typecheck: exit 0 (119/119)
- test: 7 files / 14 tests passed, exit 0