### PR TITLE
chore(ci): add turbo cache, concurrency, paths-ignore, unify Node 24

### DIFF
--- a/.github/workflows/biome-ci.yml
+++ b/.github/workflows/biome-ci.yml
@@ -2,9 +2,9 @@ name: Biome + Deprecations (core)
 
 on:
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
   push:
-    branches: [ main, master ]
+    branches: [main, master]
 
 concurrency:
   group: biome-deprecations-${{ github.ref }}
@@ -28,8 +28,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: 24
+          cache: "pnpm"
 
       - name: Install deps
         run: pnpm install --no-frozen-lockfile --force
@@ -54,8 +54,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: 24
+          cache: "pnpm"
 
       - name: Install deps
         run: pnpm install --no-frozen-lockfile --force

--- a/.github/workflows/dep-fence-guards.yml
+++ b/.github/workflows/dep-fence-guards.yml
@@ -2,11 +2,22 @@ name: dep-fence Guards
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "plans/**"
+      - "reports/**"
+      - "LICENSE"
+      - ".kiro/**"
   push:
     branches:
       - chore/folder-plugin/unused-sweep-v1
   workflow_dispatch: {}
+
+concurrency:
+  group: dep-fence-guards-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   guards:
@@ -25,7 +36,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: 'pnpm'
+          cache: "pnpm"
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: Install dependencies (workspace)
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/policy-checks.yml
+++ b/.github/workflows/policy-checks.yml
@@ -3,7 +3,7 @@ name: Policy Checks (warn-only)
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -28,10 +28,10 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
-      
+
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: 24
+          cache: "pnpm"
 
       - name: Install dependencies (non-strict)
         run: pnpm install --no-frozen-lockfile
@@ -48,5 +48,5 @@ jobs:
       - name: publint (package publish sanity)
         run: pnpm -w pkg:publint || true
 
-      - name: '@arethetypeswrong/cli (types sanity)'
+      - name: "@arethetypeswrong/cli (types sanity)"
         run: pnpm -w pkg:attw || true


### PR DESCRIPTION
## 概要
CI ビルド時間短縮のための4施策を適用。

## 変更内容
1. **Turbo Cache 永続化**: `dep-fence-guards.yml` に `actions/cache@v4` を追加し `.turbo/cache/` を CI 間で再利用
2. **Concurrency 制御**: `dep-fence-guards.yml` に `concurrency` ブロックを追加し、同一 ref の重複実行をキャンセル
3. **Docs-only スキップ**: `pull_request` トリガーに `paths-ignore` を追加し、ドキュメントのみの変更で CI をスキップ
4. **Node.js 24 統一**: `policy-checks.yml` と `biome-ci.yml` を Node 24 に統一

## 対象ファイル
- `.github/workflows/dep-fence-guards.yml` — cache, concurrency, paths-ignore
- `.github/workflows/policy-checks.yml` — Node 24
- `.github/workflows/biome-ci.yml` — Node 24 (disabled jobs)

Closes #1172
Spec: `.kiro/specs/ci-turbo-cache-optimization/`