### PR TITLE
chore(naming-audit): implement Audit Tool and extend .tsx naming guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@
 
 - 破壊的変更を避ける目的でも、契約違反の吸収はしない。
 - 必須値（例: `nodeId`）は型で必須化し、`null/undefined` を黙認しない。
-- 新規 `*.ts/*.tsx` は `docs/ts-file-naming-guideline.md` に従う。
+- 新規 `*.ts/*.tsx` は `docs/ts-file-naming-guideline.md` に従う（`.tsx` の Container/Presentational 分離・View サフィックス規約を含む）。
 - 再エクスポート禁止（例外: `src/index.ts` と export エントリ対応のトップ `index.ts`）。
 - テスト（`__tests__`）は原則相対 import を使い、`~/*` を避ける。
 

--- a/docs/ts-file-naming-guideline.md
+++ b/docs/ts-file-naming-guideline.md
@@ -1,16 +1,15 @@
-# `src/**/*.ts` ファイル命名指針
+# `src/**/*.ts` / `src/**/*.tsx` ファイル命名指針
 
-本ドキュメントは、リポジトリ全体の `src` 配下にある `*.ts` ファイル名を、役割から一意に推測できる状態へ揃えるための指針です。
+本ドキュメントは、リポジトリ全体の `src` 配下にある `*.ts` / `*.tsx` ファイル名を、役割から一意に推測できる状態へ揃えるための指針です。
 
 ## 対象範囲
 
-- `app/src/**/*.ts`
-- `packages/*/src/**/*.ts`
-- `plugins/*-plugin/src/**/*.ts`
+- `app/src/**/*.ts`, `app/src/**/*.tsx`
+- `packages/*/src/**/*.ts`, `packages/*/src/**/*.tsx`
+- `plugins/*-plugin/src/**/*.ts`, `plugins/*-plugin/src/**/*.tsx`
 
 除外:
 
-- `*.tsx`（別ガイドの対象）
 - `dist/**` など生成物
 - `*.d.ts`（型宣言ポリシーは `docs/developer-guidelines.md` を参照）
 
@@ -124,6 +123,47 @@
 4. `pnpm lint && pnpm typecheck && pnpm test`（必要フィルタ付き）で回帰確認する。
 5. PR には「命名理由」と「ロールバック方法（rename 戻し）」を明記する。
 
+## `.tsx` ファイル命名規約
+
+### コンポーネントファイル
+
+- コンポーネントファイルは PascalCase: `ComponentName.tsx`
+- ファイル名と主エクスポートのコンポーネント名を一致させる。
+
+### View サフィックス（Presentational コンポーネント）
+
+- Presentational コンポーネント（props のみに依存し、hooks を使用しない）には `*View.tsx` サフィックスを付与する。
+- 例: `CacheManagementSectionView.tsx`
+
+### Container/Presentational 分離パターン
+
+分離が必要なコンポーネントは以下の3ファイル構成（パターン A）を標準とする:
+
+```
+ComponentName/
+  ComponentName.tsx              → Container（hook 呼び出し + View 組み立て）
+  ComponentNameView.tsx          → Presentational（React.memo 適用、hooks なし）
+  useComponentNameState.ts       → State hook（Container ロジック抽出）
+```
+
+- Container は State hook を呼び出し、戻り値を View の props として渡す。
+- Presentational には `React.memo` を適用し、`displayName` を設定する。
+- re-export のみのラッパーファイル（パターン B）は禁止。実体ファイルを直接参照する。
+
+### 分離判断基準
+
+以下のいずれかを満たすコンポーネントは分離を推奨する:
+
+- JSX 行数 > 50
+- hooks 呼び出し数 > 2
+
+上記を満たさない小規模コンポーネントは分離せず、`React.memo` のみ適用する。分離しない場合はコードコメントで理由を明記する。
+
+### `.tsx` の禁止パターン
+
+- `use*.tsx`: Hook に JSX を持ち込まない（`use*.ts` を使用する）。
+- re-export のみの `.tsx` ラッパーファイル: 実体ファイルを直接参照する。
+
 ## レビュー観点（チェックリスト）
 
 - [ ] ファイル名と主エクスポート名は一致しているか
@@ -131,3 +171,6 @@
 - [ ] `index.ts` に実装ロジックが入っていないか
 - [ ] `use*.ts` 以外の hook 命名違反がないか
 - [ ] `internal/impl/core` の使用理由が説明可能か
+- [ ] Presentational コンポーネント（hooks なし）に `*View.tsx` サフィックスが付いているか
+- [ ] 分離閾値（JSX > 50行 or hooks > 2）を超えるコンポーネントが Container/Presentational 分離されているか
+- [ ] re-export のみの `.tsx` ラッパーファイルが残っていないか

--- a/scripts/__tests__/primaryExportRule.test.ts
+++ b/scripts/__tests__/primaryExportRule.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import { primaryExportRule } from '../naming-audit/rules/primaryExportRule.js';
+import type { FileAnalysis, FileEntry } from '../naming-audit/types.js';
+
+/** Helper to build a minimal FileEntry. */
+function makeFile(relativePath: string, ext: '.ts' | '.tsx'): FileEntry {
+    return {
+        absolutePath: `/repo/${relativePath}`,
+        relativePath,
+        subPackage: 'test-pkg',
+        extension: ext,
+    };
+}
+
+/** Helper to build a minimal FileAnalysis. */
+function makeAnalysis(overrides: Partial<FileAnalysis> & { file: FileEntry }): FileAnalysis {
+    return {
+        primaryExport: null,
+        exports: [],
+        isReExportOnly: false,
+        componentMetrics: null,
+        ...overrides,
+    };
+}
+
+describe('PrimaryExportRule', () => {
+    // ---------------------------------------------------------------
+    // Skip conditions
+    // ---------------------------------------------------------------
+
+    it('skips files with no exports', () => {
+        const file = makeFile('src/Empty.ts', '.ts');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({ file, exports: [], primaryExport: null }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it('skips index.ts files', () => {
+        const file = makeFile('src/index.ts', '.ts');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: 'Foo', kind: 'const', isDefault: false }],
+                primaryExport: { name: 'Foo', kind: 'const', isDefault: false },
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it('skips re-export-only files', () => {
+        const file = makeFile('src/Wrapper.tsx', '.tsx');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                isReExportOnly: true,
+                exports: [{ name: 'Actual', kind: 'reExport', isDefault: false }],
+                primaryExport: { name: 'Actual', kind: 'reExport', isDefault: false },
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it('skips wildcard re-exports', () => {
+        const file = makeFile('src/barrel.ts', '.ts');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: '*', kind: 'reExport', isDefault: false }],
+                primaryExport: { name: '*', kind: 'reExport', isDefault: false },
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    // ---------------------------------------------------------------
+    // .tsx — exact (PascalCase) match
+    // ---------------------------------------------------------------
+
+    it('no violation when .tsx file stem matches primary export exactly', () => {
+        const file = makeFile('src/ShapePreviewStep.tsx', '.tsx');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: 'ShapePreviewStep', kind: 'function', isDefault: false }],
+                primaryExport: { name: 'ShapePreviewStep', kind: 'function', isDefault: false },
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it('violation when .tsx file stem differs from primary export', () => {
+        const file = makeFile('src/ShapePreviewStep.tsx', '.tsx');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: 'ShapePreviewStepView', kind: 'function', isDefault: false }],
+                primaryExport: { name: 'ShapePreviewStepView', kind: 'function', isDefault: false },
+            }),
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0].pattern).toBe(1);
+        expect(violations[0].severity).toBe('error');
+        expect(violations[0].suggestedRename).toBe('ShapePreviewStepView.tsx');
+    });
+
+    it('.tsx is case-sensitive — different casing is a violation', () => {
+        const file = makeFile('src/shapepreviewstep.tsx', '.tsx');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: 'ShapePreviewStep', kind: 'function', isDefault: false }],
+                primaryExport: { name: 'ShapePreviewStep', kind: 'function', isDefault: false },
+            }),
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0].suggestedRename).toBe('ShapePreviewStep.tsx');
+    });
+
+    // ---------------------------------------------------------------
+    // .ts — case-insensitive match (camelCase hooks)
+    // ---------------------------------------------------------------
+
+    it('no violation when .ts hook file matches primary export (same case)', () => {
+        const file = makeFile('src/useShapePreviewStep.ts', '.ts');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: 'useShapePreviewStep', kind: 'function', isDefault: false }],
+                primaryExport: { name: 'useShapePreviewStep', kind: 'function', isDefault: false },
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it('no violation when .ts file matches primary export case-insensitively', () => {
+        const file = makeFile('src/MyModule.ts', '.ts');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: 'myModule', kind: 'const', isDefault: false }],
+                primaryExport: { name: 'myModule', kind: 'const', isDefault: false },
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it('violation when .ts file does not match primary export even case-insensitively', () => {
+        const file = makeFile('src/helpers.ts', '.ts');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: 'formatDate', kind: 'function', isDefault: false }],
+                primaryExport: { name: 'formatDate', kind: 'function', isDefault: false },
+            }),
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0].pattern).toBe(1);
+        expect(violations[0].severity).toBe('error');
+        expect(violations[0].suggestedRename).toBe('formatDate.ts');
+    });
+
+    // ---------------------------------------------------------------
+    // Violation shape
+    // ---------------------------------------------------------------
+
+    it('violation includes correct file, pattern, severity, message, and suggestedRename', () => {
+        const file = makeFile('src/OldName.tsx', '.tsx');
+        const violations = primaryExportRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [{ name: 'NewName', kind: 'function', isDefault: false }],
+                primaryExport: { name: 'NewName', kind: 'function', isDefault: false },
+            }),
+        );
+        expect(violations).toHaveLength(1);
+        const v = violations[0];
+        expect(v.file).toBe(file);
+        expect(v.pattern).toBe(1);
+        expect(v.severity).toBe('error');
+        expect(v.message).toContain('OldName.tsx');
+        expect(v.message).toContain('NewName');
+        expect(v.suggestedRename).toBe('NewName.tsx');
+    });
+});

--- a/scripts/__tests__/roleSuffixRule.test.ts
+++ b/scripts/__tests__/roleSuffixRule.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest';
+
+import { roleSuffixRule, detectSingleRole, hasCorrectSuffix, buildSuggestedRename } from '../naming-audit/rules/roleSuffixRule.js';
+import type { ExportInfo, FileAnalysis, FileEntry } from '../naming-audit/types.js';
+
+/** Helper to build a minimal FileEntry. */
+function makeFile(relativePath: string, ext: '.ts' | '.tsx'): FileEntry {
+    return {
+        absolutePath: `/repo/${relativePath}`,
+        relativePath,
+        subPackage: 'test-pkg',
+        extension: ext,
+    };
+}
+
+/** Helper to build a minimal FileAnalysis. */
+function makeAnalysis(overrides: Partial<FileAnalysis> & { file: FileEntry }): FileAnalysis {
+    return {
+        primaryExport: null,
+        exports: [],
+        isReExportOnly: false,
+        componentMetrics: null,
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------
+// Helper: type-only exports
+// ---------------------------------------------------------------
+const typeExports: ExportInfo[] = [
+    { name: 'Foo', kind: 'type', isDefault: false },
+    { name: 'Bar', kind: 'interface', isDefault: false },
+];
+
+// ---------------------------------------------------------------
+// Helper: const-only exports
+// ---------------------------------------------------------------
+const constExports: ExportInfo[] = [
+    { name: 'MAX_SIZE', kind: 'const', isDefault: false },
+    { name: 'DEFAULT_COLOR', kind: 'const', isDefault: false },
+];
+
+// ---------------------------------------------------------------
+// Helper: function-only exports (utils)
+// ---------------------------------------------------------------
+const funcExports: ExportInfo[] = [
+    { name: 'formatDate', kind: 'function', isDefault: false },
+    { name: 'parseUrl', kind: 'function', isDefault: false },
+];
+
+describe('RoleSuffixRule', () => {
+    // ---------------------------------------------------------------
+    // Types-only: wrong suffix → violation
+    // ---------------------------------------------------------------
+    it('types-only file with wrong suffix → violation', () => {
+        const file = makeFile('src/ui/components/ShapeDialogStepProps.ts', '.ts');
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: typeExports,
+                primaryExport: typeExports[0],
+            }),
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0].pattern).toBe(2);
+        expect(violations[0].severity).toBe('error');
+        expect(violations[0].suggestedRename).toMatch(/Types\.ts$/);
+    });
+
+    // ---------------------------------------------------------------
+    // Types-only: correct suffix → no violation
+    // ---------------------------------------------------------------
+    it('types-only file with *Types.ts suffix → no violation', () => {
+        const file = makeFile('src/ui/components/shapeDialogStepTypes.ts', '.ts');
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: typeExports,
+                primaryExport: typeExports[0],
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it('types-only file named types.ts → no violation', () => {
+        const file = makeFile('src/ui/components/steps/types.ts', '.ts');
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: typeExports,
+                primaryExport: typeExports[0],
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    // ---------------------------------------------------------------
+    // Constants-only: wrong suffix → violation
+    // ---------------------------------------------------------------
+    it('constants-only file with wrong suffix → violation', () => {
+        const file = makeFile('src/ui/components/shapeConsts.ts', '.ts');
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: constExports,
+                primaryExport: constExports[0],
+            }),
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0].pattern).toBe(2);
+        expect(violations[0].severity).toBe('error');
+        expect(violations[0].suggestedRename).toMatch(/Constants\.ts$/);
+    });
+
+    // ---------------------------------------------------------------
+    // Utils-only: wrong suffix → violation
+    // ---------------------------------------------------------------
+    it('utils-only file with wrong suffix → violation', () => {
+        const file = makeFile('src/ui/components/shapeHelpers.ts', '.ts');
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: funcExports,
+                primaryExport: funcExports[0],
+            }),
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0].pattern).toBe(2);
+        expect(violations[0].severity).toBe('error');
+        expect(violations[0].suggestedRename).toMatch(/Utils\.ts$/);
+    });
+
+    // ---------------------------------------------------------------
+    // Mixed-role file → no violation (skip)
+    // ---------------------------------------------------------------
+    it('mixed-role file (types + functions) → no violation', () => {
+        const file = makeFile('src/ui/components/shapeMixed.ts', '.ts');
+        const mixedExports: ExportInfo[] = [
+            { name: 'Foo', kind: 'type', isDefault: false },
+            { name: 'doSomething', kind: 'function', isDefault: false },
+        ];
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: mixedExports,
+                primaryExport: mixedExports[0],
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    // ---------------------------------------------------------------
+    // .tsx file → skip
+    // ---------------------------------------------------------------
+    it('.tsx file → skip', () => {
+        const file = makeFile('src/ui/components/ShapePreview.tsx', '.tsx');
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: typeExports,
+                primaryExport: typeExports[0],
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    // ---------------------------------------------------------------
+    // index.ts → skip
+    // ---------------------------------------------------------------
+    it('index.ts → skip', () => {
+        const file = makeFile('src/ui/components/index.ts', '.ts');
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: typeExports,
+                primaryExport: typeExports[0],
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    // ---------------------------------------------------------------
+    // Hook file → skip
+    // ---------------------------------------------------------------
+    it('hook file (primary export starts with "use") → skip', () => {
+        const file = makeFile('src/ui/hooks/useShapeState.ts', '.ts');
+        const hookExports: ExportInfo[] = [
+            { name: 'useShapeState', kind: 'function', isDefault: false },
+        ];
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: hookExports,
+                primaryExport: hookExports[0],
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    // ---------------------------------------------------------------
+    // Re-export-only → skip
+    // ---------------------------------------------------------------
+    it('re-export-only file → skip', () => {
+        const file = makeFile('src/ui/components/shapeTypes.ts', '.ts');
+        const reExports: ExportInfo[] = [
+            { name: 'Foo', kind: 'reExport', isDefault: false },
+        ];
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: reExports,
+                isReExportOnly: true,
+                primaryExport: reExports[0],
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+
+    // ---------------------------------------------------------------
+    // No exports → skip
+    // ---------------------------------------------------------------
+    it('file with no exports → skip', () => {
+        const file = makeFile('src/ui/components/empty.ts', '.ts');
+        const violations = roleSuffixRule.evaluate(
+            makeAnalysis({
+                file,
+                exports: [],
+                primaryExport: null,
+            }),
+        );
+        expect(violations).toEqual([]);
+    });
+});
+
+describe('detectSingleRole', () => {
+    it('returns "types" for type/interface-only exports', () => {
+        expect(detectSingleRole(typeExports)).toBe('types');
+    });
+
+    it('returns "constants" for const-only exports', () => {
+        expect(detectSingleRole(constExports)).toBe('constants');
+    });
+
+    it('returns "utils" for function-only exports', () => {
+        expect(detectSingleRole(funcExports)).toBe('utils');
+    });
+
+    it('returns null for mixed exports', () => {
+        const mixed: ExportInfo[] = [
+            { name: 'Foo', kind: 'type', isDefault: false },
+            { name: 'bar', kind: 'const', isDefault: false },
+        ];
+        expect(detectSingleRole(mixed)).toBeNull();
+    });
+
+    it('ignores reExport entries when detecting role', () => {
+        const withReExport: ExportInfo[] = [
+            { name: 'Foo', kind: 'type', isDefault: false },
+            { name: 'Bar', kind: 'reExport', isDefault: false },
+        ];
+        expect(detectSingleRole(withReExport)).toBe('types');
+    });
+
+    it('returns null for empty exports', () => {
+        expect(detectSingleRole([])).toBeNull();
+    });
+});
+
+describe('hasCorrectSuffix', () => {
+    it('recognises *Types suffix', () => {
+        expect(hasCorrectSuffix('shapeDialogStepTypes', 'types')).toBe(true);
+    });
+
+    it('recognises standalone "types"', () => {
+        expect(hasCorrectSuffix('types', 'types')).toBe(true);
+    });
+
+    it('rejects wrong suffix for types', () => {
+        expect(hasCorrectSuffix('shapeDialogStepProps', 'types')).toBe(false);
+    });
+
+    it('recognises *Constants suffix', () => {
+        expect(hasCorrectSuffix('locationMapPreviewConstants', 'constants')).toBe(true);
+    });
+
+    it('recognises standalone "constants"', () => {
+        expect(hasCorrectSuffix('constants', 'constants')).toBe(true);
+    });
+
+    it('recognises *Utils suffix', () => {
+        expect(hasCorrectSuffix('shapeUtils', 'utils')).toBe(true);
+    });
+
+    it('recognises standalone "utils"', () => {
+        expect(hasCorrectSuffix('utils', 'utils')).toBe(true);
+    });
+});
+
+describe('buildSuggestedRename', () => {
+    it('strips Props suffix and appends Types', () => {
+        const result = buildSuggestedRename('ShapeDialogStepProps', 'types', 'components');
+        expect(result).toBe('shapeDialogStepTypes.ts');
+    });
+
+    it('strips Helpers suffix and appends Utils', () => {
+        const result = buildSuggestedRename('ShapeHelpers', 'utils', 'components');
+        expect(result).toBe('shapeUtils.ts');
+    });
+
+    it('strips Consts suffix and appends Constants', () => {
+        const result = buildSuggestedRename('ShapeConsts', 'constants', 'components');
+        expect(result).toBe('shapeConstants.ts');
+    });
+
+    it('uses standalone form for banned generic name "helper"', () => {
+        const result = buildSuggestedRename('helper', 'utils', 'components');
+        expect(result).toBe('utils.ts');
+    });
+});

--- a/scripts/naming-audit.ts
+++ b/scripts/naming-audit.ts
@@ -1,0 +1,183 @@
+// ============================================================
+// CLI entry point for the naming-audit tool.
+//
+// Usage:
+//   pnpm tsx scripts/naming-audit.ts [options]
+//
+// Options:
+//   --ci              CI mode (same behaviour, explicit intent flag)
+//   --format <fmt>    Output format: "json" | "table" (default: "table")
+//   --target <dir>    Override target directories (repeatable)
+// ============================================================
+
+import { createExportAnalyzer } from './naming-audit/exportAnalyzer.js';
+import { scanFiles } from './naming-audit/fileScanner.js';
+import { evaluateRules } from './naming-audit/ruleEngine.js';
+import { implSuffixRule } from './naming-audit/rules/implSuffixRule.js';
+import { primaryExportRule } from './naming-audit/rules/primaryExportRule.js';
+import { roleSuffixRule } from './naming-audit/rules/roleSuffixRule.js';
+import { separationThresholdRule } from './naming-audit/rules/separationThresholdRule.js';
+import { viewPatternRule } from './naming-audit/rules/viewPatternRule.js';
+import type {
+  FileAnalysis,
+  FileScannerOptions,
+  Rule,
+  RuleEngineConfig,
+} from './naming-audit/types.js';
+import { reportViolations } from './naming-audit/violationReporter.js';
+
+// ---------------------------------------------------------------------------
+// Default configuration
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TARGET_DIRS: readonly string[] = [
+  'app/src/',
+  'packages/*/src/',
+  'plugins/*-plugin/src/',
+];
+
+const DEFAULT_EXCLUDE_PATTERNS: readonly string[] = ['dist/', '*.d.ts', '__tests__/'];
+
+const ROUTER_EXCEPTION_PATHS: readonly string[] = ['app/src/router/**'];
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+interface CliOptions {
+  readonly ci: boolean;
+  readonly format: 'json' | 'table';
+  readonly targets: readonly string[];
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  let ci = false;
+  let format: 'json' | 'table' = 'table';
+  const targets: string[] = [];
+
+  // Skip first two entries (node binary + script path)
+  const args = argv.slice(2);
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--ci':
+        ci = true;
+        break;
+      case '--format': {
+        const value = args[++i];
+        if (value !== 'json' && value !== 'table') {
+          console.error(`Invalid format: "${value}". Expected "json" or "table".`);
+          process.exit(2);
+        }
+        format = value;
+        break;
+      }
+      case '--target': {
+        const value = args[++i];
+        if (!value) {
+          console.error('Missing value for --target');
+          process.exit(2);
+        }
+        targets.push(value);
+        break;
+      }
+      default:
+        console.error(`Unknown option: "${arg}"`);
+        process.exit(2);
+    }
+  }
+
+  return {
+    ci,
+    format,
+    targets: targets.length > 0 ? targets : DEFAULT_TARGET_DIRS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// All rules
+// ---------------------------------------------------------------------------
+
+const ALL_RULES: readonly Rule[] = [
+  primaryExportRule,
+  roleSuffixRule,
+  implSuffixRule,
+  viewPatternRule,
+  separationThresholdRule,
+];
+
+// ExportAnalyzer — reusable ts-morph Project instance
+const exportAnalyzer = createExportAnalyzer();
+
+// ---------------------------------------------------------------------------
+// Main pipeline
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Progress helpers (write to stderr so stdout stays clean for JSON output)
+// ---------------------------------------------------------------------------
+
+const isTTY = process.stderr.isTTY ?? false;
+
+function clearLine(): void {
+  if (isTTY) {
+    process.stderr.write('\r\x1b[K');
+  }
+}
+
+function progress(msg: string): void {
+  if (isTTY) {
+    clearLine();
+    process.stderr.write(msg);
+  } else {
+    process.stderr.write(`${msg}\n`);
+  }
+}
+
+function progressDone(msg: string): void {
+  clearLine();
+  process.stderr.write(`${msg}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Main pipeline
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const options = parseArgs(process.argv);
+
+  const scannerOptions: FileScannerOptions = {
+    targetDirs: options.targets,
+    excludePatterns: DEFAULT_EXCLUDE_PATTERNS,
+  };
+
+  const ruleConfig: RuleEngineConfig = {
+    routerExceptionPaths: ROUTER_EXCEPTION_PATHS,
+  };
+
+  // Step 1: Scan files
+  progress('Scanning files…');
+  const files = scanFiles(scannerOptions);
+  progressDone(`✔ Scanned ${files.length} files`);
+
+  // Step 2: Analyse exports for each file
+  const analyses: FileAnalysis[] = [];
+  for (let i = 0; i < files.length; i++) {
+    progress(`Analysing exports… (${i + 1}/${files.length}) ${files[i].relativePath}`);
+    analyses.push(exportAnalyzer.analyze(files[i]));
+  }
+  progressDone(`✔ Analysed ${analyses.length} files`);
+
+  // Step 3: Evaluate rules
+  progress('Evaluating rules…');
+  const violations = evaluateRules(analyses, ALL_RULES, ruleConfig);
+  progressDone(`✔ Evaluated ${ALL_RULES.length} rules — ${violations.length} violation(s) found`);
+
+  // Step 4: Report violations and determine exit code
+  const exitCode = reportViolations(violations, options.format);
+
+  process.exit(exitCode);
+}
+
+main();

--- a/scripts/naming-audit/exportAnalyzer.ts
+++ b/scripts/naming-audit/exportAnalyzer.ts
@@ -1,0 +1,456 @@
+// ============================================================
+// ExportAnalyzer -- uses ts-morph to extract export information
+// from TypeScript / TSX source files.
+//
+// Provides:
+//   analyzeFile(file, project)   – analyse a single file
+//   createExportAnalyzer(tsConfigPath?) – factory with reusable Project
+// ============================================================
+
+import path from 'node:path';
+import fs from 'node:fs';
+
+import {
+    type ExportAssignment,
+    type ExportDeclaration,
+    Project,
+    type SourceFile,
+    SyntaxKind,
+} from 'ts-morph';
+
+import type {
+    ComponentMetrics,
+    ExportInfo,
+    FileAnalysis,
+    FileEntry,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Derive the "stem" of a file (name without extension). */
+function fileStem(filePath: string): string {
+    const base = path.basename(filePath);
+    // Handle double extensions like .core.ts, .internal.ts
+    const match = base.match(/^(.+?)\.(?:core|internal|impl)?\.[^.]+$/);
+    if (match) return match[1];
+    return path.parse(base).name;
+}
+
+/**
+ * Check if a function name looks like a React hook call.
+ * Hooks start with "use" followed by an uppercase letter.
+ */
+function isHookName(name: string): boolean {
+    return name.length > 3 && name.startsWith('use') && name[3] === name[3].toUpperCase() && name[3] !== name[3].toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Export extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all exports from a source file.
+ * Returns { exports, hasOwnDeclarations } where hasOwnDeclarations is false
+ * when the file only contains re-exports.
+ */
+function collectExports(sourceFile: SourceFile): {
+    exports: ExportInfo[];
+    hasOwnDeclarations: boolean;
+} {
+    const exports: ExportInfo[] = [];
+    let hasOwnDeclarations = false;
+
+    // --- Named export declarations (export function X, export class X, etc.) ---
+    for (const stmt of sourceFile.getStatements()) {
+        const kind = stmt.getKind();
+
+        // export function foo() {}
+        if (kind === SyntaxKind.FunctionDeclaration) {
+            const fn = stmt.asKindOrThrow(SyntaxKind.FunctionDeclaration);
+            if (fn.isExported()) {
+                hasOwnDeclarations = true;
+                exports.push({
+                    name: fn.getName() ?? 'default',
+                    kind: 'function',
+                    isDefault: fn.isDefaultExport(),
+                });
+            }
+            continue;
+        }
+
+        // export class Foo {}
+        if (kind === SyntaxKind.ClassDeclaration) {
+            const cls = stmt.asKindOrThrow(SyntaxKind.ClassDeclaration);
+            if (cls.isExported()) {
+                hasOwnDeclarations = true;
+                exports.push({
+                    name: cls.getName() ?? 'default',
+                    kind: 'class',
+                    isDefault: cls.isDefaultExport(),
+                });
+            }
+            continue;
+        }
+
+        // export interface Foo {}
+        if (kind === SyntaxKind.InterfaceDeclaration) {
+            const iface = stmt.asKindOrThrow(SyntaxKind.InterfaceDeclaration);
+            if (iface.isExported()) {
+                hasOwnDeclarations = true;
+                exports.push({
+                    name: iface.getName(),
+                    kind: 'interface',
+                    isDefault: iface.isDefaultExport(),
+                });
+            }
+            continue;
+        }
+
+        // export type Foo = ...
+        if (kind === SyntaxKind.TypeAliasDeclaration) {
+            const alias = stmt.asKindOrThrow(SyntaxKind.TypeAliasDeclaration);
+            if (alias.isExported()) {
+                hasOwnDeclarations = true;
+                exports.push({
+                    name: alias.getName(),
+                    kind: 'type',
+                    isDefault: alias.isDefaultExport(),
+                });
+            }
+            continue;
+        }
+
+        // export enum Foo {}
+        if (kind === SyntaxKind.EnumDeclaration) {
+            const en = stmt.asKindOrThrow(SyntaxKind.EnumDeclaration);
+            if (en.isExported()) {
+                hasOwnDeclarations = true;
+                exports.push({
+                    name: en.getName(),
+                    kind: 'enum',
+                    isDefault: en.isDefaultExport(),
+                });
+            }
+            continue;
+        }
+
+        // export const / export let / export var
+        if (kind === SyntaxKind.VariableStatement) {
+            const varStmt = stmt.asKindOrThrow(SyntaxKind.VariableStatement);
+            if (varStmt.isExported()) {
+                hasOwnDeclarations = true;
+                for (const decl of varStmt.getDeclarations()) {
+                    exports.push({
+                        name: decl.getName(),
+                        kind: 'const',
+                        isDefault: varStmt.isDefaultExport(),
+                    });
+                }
+            }
+            continue;
+        }
+
+        // export default expression (export default X)
+        if (kind === SyntaxKind.ExportAssignment) {
+            const assignment = stmt as ExportAssignment;
+            if (!assignment.isExportEquals()) {
+                hasOwnDeclarations = true;
+                const expr = assignment.getExpression();
+                const name = expr.getKind() === SyntaxKind.Identifier
+                    ? expr.getText()
+                    : 'default';
+                exports.push({
+                    name,
+                    kind: 'const',
+                    isDefault: true,
+                });
+            }
+            continue;
+        }
+
+        // export { X, Y } from '...' or export { X, Y }
+        if (kind === SyntaxKind.ExportDeclaration) {
+            const exportDecl = stmt as ExportDeclaration;
+            const moduleSpecifier = exportDecl.getModuleSpecifierValue();
+
+            if (moduleSpecifier) {
+                // Re-export from another module
+                const namedExports = exportDecl.getNamedExports();
+                if (namedExports.length > 0) {
+                    for (const named of namedExports) {
+                        exports.push({
+                            name: named.getAliasNode()?.getText() ?? named.getName(),
+                            kind: 'reExport',
+                            isDefault: false,
+                        });
+                    }
+                }
+                // export * from '...' has no named exports but is still a re-export
+                if (namedExports.length === 0) {
+                    exports.push({
+                        name: '*',
+                        kind: 'reExport',
+                        isDefault: false,
+                    });
+                }
+            } else {
+                // export { X, Y } (local re-export, still counts as own declaration)
+                hasOwnDeclarations = true;
+                for (const named of exportDecl.getNamedExports()) {
+                    exports.push({
+                        name: named.getAliasNode()?.getText() ?? named.getName(),
+                        kind: 'const', // best guess for local re-exports
+                        isDefault: false,
+                    });
+                }
+            }
+            continue;
+        }
+    }
+
+    return { exports, hasOwnDeclarations };
+}
+
+// ---------------------------------------------------------------------------
+// Primary export heuristic
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the primary export of a file.
+ *
+ * Heuristic (in priority order):
+ *   1. If there's a default export, that's the primary.
+ *   2. Otherwise, the named export whose name matches the file stem.
+ *   3. Otherwise, the first named export.
+ */
+function determinePrimaryExport(
+    exports: readonly ExportInfo[],
+    stem: string,
+): ExportInfo | null {
+    if (exports.length === 0) return null;
+
+    // 1. Default export
+    const defaultExport = exports.find((e) => e.isDefault);
+    if (defaultExport) return defaultExport;
+
+    // 2. Named export matching file stem (case-insensitive comparison)
+    const stemLower = stem.toLowerCase();
+    const matchingStem = exports.find(
+        (e) => e.name.toLowerCase() === stemLower,
+    );
+    if (matchingStem) return matchingStem;
+
+    // 3. First named export (skip wildcard re-exports)
+    const firstNamed = exports.find((e) => e.name !== '*');
+    return firstNamed ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Component metrics (for .tsx files)
+// ---------------------------------------------------------------------------
+
+/**
+ * Count lines that contain JSX elements.
+ * Simple heuristic: lines containing `<` followed by an uppercase letter
+ * or `</` or `/>` are considered JSX lines.
+ */
+function countJsxLines(sourceFile: SourceFile): number {
+    const text = sourceFile.getFullText();
+    const lines = text.split('\n');
+    let count = 0;
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        // Skip empty lines, comments, and import statements
+        if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('import ')) {
+            continue;
+        }
+        // Check for JSX patterns
+        if (
+            // Opening JSX tag: <Component or <div
+            /\<[A-Za-z]/.test(trimmed) ||
+            // Closing JSX tag: </Component> or />
+            /\<\/[A-Za-z]/.test(trimmed) ||
+            // Self-closing: />
+            /\/\>/.test(trimmed)
+        ) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+/**
+ * Collect hook call information from a source file.
+ * Hooks are call expressions where the function name starts with "use"
+ * and the next character is uppercase.
+ */
+function collectHookCalls(sourceFile: SourceFile): {
+    hookCallCount: number;
+    hookNames: string[];
+} {
+    const hookNames = new Set<string>();
+
+    const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
+
+    for (const call of callExpressions) {
+        const expr = call.getExpression();
+        let name: string | undefined;
+
+        // Direct call: useState(...)
+        if (expr.getKind() === SyntaxKind.Identifier) {
+            name = expr.getText();
+        }
+        // Property access: React.useState(...)
+        else if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
+            const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+            name = propAccess.getName();
+        }
+
+        if (name && isHookName(name)) {
+            hookNames.add(name);
+        }
+    }
+
+    const names = [...hookNames].sort();
+    return {
+        hookCallCount: names.length,
+        hookNames: names,
+    };
+}
+
+/**
+ * Check whether the file uses React.memo.
+ */
+function detectReactMemo(sourceFile: SourceFile): boolean {
+    const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
+
+    for (const call of callExpressions) {
+        const expr = call.getExpression();
+
+        // React.memo(...)
+        if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
+            const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+            if (
+                propAccess.getName() === 'memo' &&
+                propAccess.getExpression().getText() === 'React'
+            ) {
+                return true;
+            }
+        }
+
+        // memo(...) — imported directly
+        if (expr.getKind() === SyntaxKind.Identifier && expr.getText() === 'memo') {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Compute component metrics for a .tsx file.
+ */
+function computeComponentMetrics(sourceFile: SourceFile): ComponentMetrics {
+    const jsxLineCount = countJsxLines(sourceFile);
+    const { hookCallCount, hookNames } = collectHookCalls(sourceFile);
+    const usesReactMemo = detectReactMemo(sourceFile);
+
+    return {
+        jsxLineCount,
+        hookCallCount,
+        usesReactMemo,
+        hookNames,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyse a single file's export information using a ts-morph Project.
+ *
+ * @param file    - The FileEntry to analyse
+ * @param project - A ts-morph Project instance (reuse for performance)
+ * @returns FileAnalysis with primary export, all exports, re-export status, and component metrics
+ */
+export function analyzeFile(file: FileEntry, project: Project): FileAnalysis {
+    let sourceFile: SourceFile | undefined = project.getSourceFile(file.absolutePath);
+
+    if (!sourceFile) {
+        sourceFile = project.addSourceFileAtPath(file.absolutePath);
+    }
+
+    const { exports, hasOwnDeclarations } = collectExports(sourceFile);
+
+    // A file is re-export-only if it has exports but no own declarations
+    const isReExportOnly = exports.length > 0 && !hasOwnDeclarations;
+
+    const stem = fileStem(file.absolutePath);
+    const primaryExport = determinePrimaryExport(exports, stem);
+
+    // Component metrics only for .tsx files
+    const componentMetrics = file.extension === '.tsx'
+        ? computeComponentMetrics(sourceFile)
+        : null;
+
+    return {
+        file,
+        primaryExport,
+        exports,
+        isReExportOnly,
+        componentMetrics,
+    };
+}
+
+/**
+ * Find the nearest tsconfig.json by walking up from the current directory.
+ */
+function findNearestTsConfig(): string | undefined {
+    let dir = process.cwd();
+    const root = path.parse(dir).root;
+
+    while (dir !== root) {
+        const candidate = path.join(dir, 'tsconfig.json');
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+        dir = path.dirname(dir);
+    }
+
+    return undefined;
+}
+
+/**
+ * Factory that creates an ExportAnalyzer with a reusable ts-morph Project.
+ *
+ * @param tsConfigPath - Optional path to tsconfig.json. If omitted, searches
+ *                       for the nearest tsconfig.json or uses a minimal config.
+ * @returns An object with an `analyze` method that accepts a FileEntry.
+ */
+export function createExportAnalyzer(tsConfigPath?: string): {
+    analyze: (file: FileEntry) => FileAnalysis;
+} {
+    const resolvedTsConfig = tsConfigPath ?? findNearestTsConfig();
+
+    const project = resolvedTsConfig
+        ? new Project({ tsConfigFilePath: resolvedTsConfig, skipAddingFilesFromTsConfig: true })
+        : new Project({
+            compilerOptions: {
+                target: 99, // ESNext
+                module: 99, // ESNext
+                jsx: 4,     // react-jsx
+                strict: true,
+                esModuleInterop: true,
+                skipLibCheck: true,
+            },
+        });
+
+    return {
+        analyze: (file: FileEntry): FileAnalysis => analyzeFile(file, project),
+    };
+}

--- a/scripts/naming-audit/exportAnalyzer.ts
+++ b/scripts/naming-audit/exportAnalyzer.ts
@@ -7,23 +7,18 @@
 //   createExportAnalyzer(tsConfigPath?) – factory with reusable Project
 // ============================================================
 
-import path from 'node:path';
 import fs from 'node:fs';
+import path from 'node:path';
 
 import {
-    type ExportAssignment,
-    type ExportDeclaration,
-    Project,
-    type SourceFile,
-    SyntaxKind,
+  type ExportAssignment,
+  type ExportDeclaration,
+  Project,
+  type SourceFile,
+  SyntaxKind,
 } from 'ts-morph';
 
-import type {
-    ComponentMetrics,
-    ExportInfo,
-    FileAnalysis,
-    FileEntry,
-} from './types.js';
+import type { ComponentMetrics, ExportInfo, FileAnalysis, FileEntry } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -31,11 +26,11 @@ import type {
 
 /** Derive the "stem" of a file (name without extension). */
 function fileStem(filePath: string): string {
-    const base = path.basename(filePath);
-    // Handle double extensions like .core.ts, .internal.ts
-    const match = base.match(/^(.+?)\.(?:core|internal|impl)?\.[^.]+$/);
-    if (match) return match[1];
-    return path.parse(base).name;
+  const base = path.basename(filePath);
+  // Handle double extensions like .core.ts, .internal.ts
+  const match = base.match(/^(.+?)\.(?:core|internal|impl)?\.[^.]+$/);
+  if (match) return match[1];
+  return path.parse(base).name;
 }
 
 /**
@@ -43,7 +38,12 @@ function fileStem(filePath: string): string {
  * Hooks start with "use" followed by an uppercase letter.
  */
 function isHookName(name: string): boolean {
-    return name.length > 3 && name.startsWith('use') && name[3] === name[3].toUpperCase() && name[3] !== name[3].toLowerCase();
+  return (
+    name.length > 3 &&
+    name.startsWith('use') &&
+    name[3] === name[3].toUpperCase() &&
+    name[3] !== name[3].toLowerCase()
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -56,161 +56,163 @@ function isHookName(name: string): boolean {
  * when the file only contains re-exports.
  */
 function collectExports(sourceFile: SourceFile): {
-    exports: ExportInfo[];
-    hasOwnDeclarations: boolean;
+  exports: ExportInfo[];
+  hasOwnDeclarations: boolean;
 } {
-    const exports: ExportInfo[] = [];
-    let hasOwnDeclarations = false;
+  const exports: ExportInfo[] = [];
+  let hasOwnDeclarations = false;
 
-    // --- Named export declarations (export function X, export class X, etc.) ---
-    for (const stmt of sourceFile.getStatements()) {
-        const kind = stmt.getKind();
+  // --- Named export declarations (export function X, export class X, etc.) ---
+  for (const stmt of sourceFile.getStatements()) {
+    const kind = stmt.getKind();
 
-        // export function foo() {}
-        if (kind === SyntaxKind.FunctionDeclaration) {
-            const fn = stmt.asKindOrThrow(SyntaxKind.FunctionDeclaration);
-            if (fn.isExported()) {
-                hasOwnDeclarations = true;
-                exports.push({
-                    name: fn.getName() ?? 'default',
-                    kind: 'function',
-                    isDefault: fn.isDefaultExport(),
-                });
-            }
-            continue;
-        }
-
-        // export class Foo {}
-        if (kind === SyntaxKind.ClassDeclaration) {
-            const cls = stmt.asKindOrThrow(SyntaxKind.ClassDeclaration);
-            if (cls.isExported()) {
-                hasOwnDeclarations = true;
-                exports.push({
-                    name: cls.getName() ?? 'default',
-                    kind: 'class',
-                    isDefault: cls.isDefaultExport(),
-                });
-            }
-            continue;
-        }
-
-        // export interface Foo {}
-        if (kind === SyntaxKind.InterfaceDeclaration) {
-            const iface = stmt.asKindOrThrow(SyntaxKind.InterfaceDeclaration);
-            if (iface.isExported()) {
-                hasOwnDeclarations = true;
-                exports.push({
-                    name: iface.getName(),
-                    kind: 'interface',
-                    isDefault: iface.isDefaultExport(),
-                });
-            }
-            continue;
-        }
-
-        // export type Foo = ...
-        if (kind === SyntaxKind.TypeAliasDeclaration) {
-            const alias = stmt.asKindOrThrow(SyntaxKind.TypeAliasDeclaration);
-            if (alias.isExported()) {
-                hasOwnDeclarations = true;
-                exports.push({
-                    name: alias.getName(),
-                    kind: 'type',
-                    isDefault: alias.isDefaultExport(),
-                });
-            }
-            continue;
-        }
-
-        // export enum Foo {}
-        if (kind === SyntaxKind.EnumDeclaration) {
-            const en = stmt.asKindOrThrow(SyntaxKind.EnumDeclaration);
-            if (en.isExported()) {
-                hasOwnDeclarations = true;
-                exports.push({
-                    name: en.getName(),
-                    kind: 'enum',
-                    isDefault: en.isDefaultExport(),
-                });
-            }
-            continue;
-        }
-
-        // export const / export let / export var
-        if (kind === SyntaxKind.VariableStatement) {
-            const varStmt = stmt.asKindOrThrow(SyntaxKind.VariableStatement);
-            if (varStmt.isExported()) {
-                hasOwnDeclarations = true;
-                for (const decl of varStmt.getDeclarations()) {
-                    exports.push({
-                        name: decl.getName(),
-                        kind: 'const',
-                        isDefault: varStmt.isDefaultExport(),
-                    });
-                }
-            }
-            continue;
-        }
-
-        // export default expression (export default X)
-        if (kind === SyntaxKind.ExportAssignment) {
-            const assignment = stmt as ExportAssignment;
-            if (!assignment.isExportEquals()) {
-                hasOwnDeclarations = true;
-                const expr = assignment.getExpression();
-                const name = expr.getKind() === SyntaxKind.Identifier
-                    ? expr.getText()
-                    : 'default';
-                exports.push({
-                    name,
-                    kind: 'const',
-                    isDefault: true,
-                });
-            }
-            continue;
-        }
-
-        // export { X, Y } from '...' or export { X, Y }
-        if (kind === SyntaxKind.ExportDeclaration) {
-            const exportDecl = stmt as ExportDeclaration;
-            const moduleSpecifier = exportDecl.getModuleSpecifierValue();
-
-            if (moduleSpecifier) {
-                // Re-export from another module
-                const namedExports = exportDecl.getNamedExports();
-                if (namedExports.length > 0) {
-                    for (const named of namedExports) {
-                        exports.push({
-                            name: named.getAliasNode()?.getText() ?? named.getName(),
-                            kind: 'reExport',
-                            isDefault: false,
-                        });
-                    }
-                }
-                // export * from '...' has no named exports but is still a re-export
-                if (namedExports.length === 0) {
-                    exports.push({
-                        name: '*',
-                        kind: 'reExport',
-                        isDefault: false,
-                    });
-                }
-            } else {
-                // export { X, Y } (local re-export, still counts as own declaration)
-                hasOwnDeclarations = true;
-                for (const named of exportDecl.getNamedExports()) {
-                    exports.push({
-                        name: named.getAliasNode()?.getText() ?? named.getName(),
-                        kind: 'const', // best guess for local re-exports
-                        isDefault: false,
-                    });
-                }
-            }
-            continue;
-        }
+    // export function foo() {}
+    if (kind === SyntaxKind.FunctionDeclaration) {
+      const fn = stmt.asKindOrThrow(SyntaxKind.FunctionDeclaration);
+      if (fn.isExported()) {
+        hasOwnDeclarations = true;
+        exports.push({
+          name: fn.getName() ?? 'default',
+          kind: 'function',
+          isDefault: fn.isDefaultExport(),
+        });
+      }
+      continue;
     }
 
-    return { exports, hasOwnDeclarations };
+    // export class Foo {}
+    if (kind === SyntaxKind.ClassDeclaration) {
+      const cls = stmt.asKindOrThrow(SyntaxKind.ClassDeclaration);
+      if (cls.isExported()) {
+        hasOwnDeclarations = true;
+        exports.push({
+          name: cls.getName() ?? 'default',
+          kind: 'class',
+          isDefault: cls.isDefaultExport(),
+        });
+      }
+      continue;
+    }
+
+    // export interface Foo {}
+    if (kind === SyntaxKind.InterfaceDeclaration) {
+      const iface = stmt.asKindOrThrow(SyntaxKind.InterfaceDeclaration);
+      if (iface.isExported()) {
+        hasOwnDeclarations = true;
+        exports.push({
+          name: iface.getName(),
+          kind: 'interface',
+          isDefault: iface.isDefaultExport(),
+        });
+      }
+      continue;
+    }
+
+    // export type Foo = ...
+    if (kind === SyntaxKind.TypeAliasDeclaration) {
+      const alias = stmt.asKindOrThrow(SyntaxKind.TypeAliasDeclaration);
+      if (alias.isExported()) {
+        hasOwnDeclarations = true;
+        exports.push({
+          name: alias.getName(),
+          kind: 'type',
+          isDefault: alias.isDefaultExport(),
+        });
+      }
+      continue;
+    }
+
+    // export enum Foo {}
+    if (kind === SyntaxKind.EnumDeclaration) {
+      const en = stmt.asKindOrThrow(SyntaxKind.EnumDeclaration);
+      if (en.isExported()) {
+        hasOwnDeclarations = true;
+        exports.push({
+          name: en.getName(),
+          kind: 'enum',
+          isDefault: en.isDefaultExport(),
+        });
+      }
+      continue;
+    }
+
+    // export const / export let / export var
+    if (kind === SyntaxKind.VariableStatement) {
+      const varStmt = stmt.asKindOrThrow(SyntaxKind.VariableStatement);
+      if (varStmt.isExported()) {
+        hasOwnDeclarations = true;
+        for (const decl of varStmt.getDeclarations()) {
+          const initializer = decl.getInitializer();
+          const isFunction =
+            initializer &&
+            (initializer.getKind() === SyntaxKind.ArrowFunction ||
+              initializer.getKind() === SyntaxKind.FunctionExpression);
+          exports.push({
+            name: decl.getName(),
+            kind: isFunction ? 'function' : 'const',
+            isDefault: varStmt.isDefaultExport(),
+          });
+        }
+      }
+      continue;
+    }
+
+    // export default expression (export default X)
+    if (kind === SyntaxKind.ExportAssignment) {
+      const assignment = stmt as ExportAssignment;
+      if (!assignment.isExportEquals()) {
+        hasOwnDeclarations = true;
+        const expr = assignment.getExpression();
+        const name = expr.getKind() === SyntaxKind.Identifier ? expr.getText() : 'default';
+        exports.push({
+          name,
+          kind: 'const',
+          isDefault: true,
+        });
+      }
+      continue;
+    }
+
+    // export { X, Y } from '...' or export { X, Y }
+    if (kind === SyntaxKind.ExportDeclaration) {
+      const exportDecl = stmt as ExportDeclaration;
+      const moduleSpecifier = exportDecl.getModuleSpecifierValue();
+
+      if (moduleSpecifier) {
+        // Re-export from another module
+        const namedExports = exportDecl.getNamedExports();
+        if (namedExports.length > 0) {
+          for (const named of namedExports) {
+            exports.push({
+              name: named.getAliasNode()?.getText() ?? named.getName(),
+              kind: 'reExport',
+              isDefault: false,
+            });
+          }
+        }
+        // export * from '...' has no named exports but is still a re-export
+        if (namedExports.length === 0) {
+          exports.push({
+            name: '*',
+            kind: 'reExport',
+            isDefault: false,
+          });
+        }
+      } else {
+        // export { X, Y } (local re-export, still counts as own declaration)
+        hasOwnDeclarations = true;
+        for (const named of exportDecl.getNamedExports()) {
+          exports.push({
+            name: named.getAliasNode()?.getText() ?? named.getName(),
+            kind: 'const', // best guess for local re-exports
+            isDefault: false,
+          });
+        }
+      }
+    }
+  }
+
+  return { exports, hasOwnDeclarations };
 }
 
 // ---------------------------------------------------------------------------
@@ -225,26 +227,21 @@ function collectExports(sourceFile: SourceFile): {
  *   2. Otherwise, the named export whose name matches the file stem.
  *   3. Otherwise, the first named export.
  */
-function determinePrimaryExport(
-    exports: readonly ExportInfo[],
-    stem: string,
-): ExportInfo | null {
-    if (exports.length === 0) return null;
+function determinePrimaryExport(exports: readonly ExportInfo[], stem: string): ExportInfo | null {
+  if (exports.length === 0) return null;
 
-    // 1. Default export
-    const defaultExport = exports.find((e) => e.isDefault);
-    if (defaultExport) return defaultExport;
+  // 1. Default export
+  const defaultExport = exports.find((e) => e.isDefault);
+  if (defaultExport) return defaultExport;
 
-    // 2. Named export matching file stem (case-insensitive comparison)
-    const stemLower = stem.toLowerCase();
-    const matchingStem = exports.find(
-        (e) => e.name.toLowerCase() === stemLower,
-    );
-    if (matchingStem) return matchingStem;
+  // 2. Named export matching file stem (case-insensitive comparison)
+  const stemLower = stem.toLowerCase();
+  const matchingStem = exports.find((e) => e.name.toLowerCase() === stemLower);
+  if (matchingStem) return matchingStem;
 
-    // 3. First named export (skip wildcard re-exports)
-    const firstNamed = exports.find((e) => e.name !== '*');
-    return firstNamed ?? null;
+  // 3. First named export (skip wildcard re-exports)
+  const firstNamed = exports.find((e) => e.name !== '*');
+  return firstNamed ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -257,30 +254,37 @@ function determinePrimaryExport(
  * or `</` or `/>` are considered JSX lines.
  */
 function countJsxLines(sourceFile: SourceFile): number {
-    const text = sourceFile.getFullText();
-    const lines = text.split('\n');
-    let count = 0;
+  const text = sourceFile.getFullText();
+  const lines = text.split('\n');
+  let count = 0;
 
-    for (const line of lines) {
-        const trimmed = line.trim();
-        // Skip empty lines, comments, and import statements
-        if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('import ')) {
-            continue;
-        }
-        // Check for JSX patterns
-        if (
-            // Opening JSX tag: <Component or <div
-            /\<[A-Za-z]/.test(trimmed) ||
-            // Closing JSX tag: </Component> or />
-            /\<\/[A-Za-z]/.test(trimmed) ||
-            // Self-closing: />
-            /\/\>/.test(trimmed)
-        ) {
-            count++;
-        }
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Skip empty lines, comments, and import statements
+    if (
+      !trimmed ||
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('import ')
+    ) {
+      continue;
     }
+    // Check for JSX patterns
+    if (
+      // Opening tag (Component or html element)
+      /<[A-Za-z0-9]/.test(trimmed) ||
+      // React fragment opening: <>
+      /<>/.test(trimmed) ||
+      // Closing tag: </Component> or </>
+      /<\//.test(trimmed) ||
+      // Self-closing: />
+      /\/>/.test(trimmed)
+    ) {
+      count++;
+    }
+  }
 
-    return count;
+  return count;
 }
 
 /**
@@ -289,82 +293,81 @@ function countJsxLines(sourceFile: SourceFile): number {
  * and the next character is uppercase.
  */
 function collectHookCalls(sourceFile: SourceFile): {
-    hookCallCount: number;
-    hookNames: string[];
+  hookCallCount: number;
+  hookNames: string[];
 } {
-    const hookNames = new Set<string>();
+  const hookNames = new Set<string>();
+  let hookCallCount = 0;
 
-    const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
+  const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
 
-    for (const call of callExpressions) {
-        const expr = call.getExpression();
-        let name: string | undefined;
+  for (const call of callExpressions) {
+    const expr = call.getExpression();
+    let name: string | undefined;
 
-        // Direct call: useState(...)
-        if (expr.getKind() === SyntaxKind.Identifier) {
-            name = expr.getText();
-        }
-        // Property access: React.useState(...)
-        else if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
-            const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
-            name = propAccess.getName();
-        }
-
-        if (name && isHookName(name)) {
-            hookNames.add(name);
-        }
+    // Direct call: useState(...)
+    if (expr.getKind() === SyntaxKind.Identifier) {
+      name = expr.getText();
+    }
+    // Property access: React.useState(...)
+    else if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+      name = propAccess.getName();
     }
 
-    const names = [...hookNames].sort();
-    return {
-        hookCallCount: names.length,
-        hookNames: names,
-    };
+    if (name && isHookName(name)) {
+      hookNames.add(name);
+      hookCallCount++;
+    }
+  }
+
+  const names = [...hookNames].sort();
+  return {
+    hookCallCount,
+    hookNames: names,
+  };
 }
 
 /**
  * Check whether the file uses React.memo.
  */
 function detectReactMemo(sourceFile: SourceFile): boolean {
-    const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
+  const callExpressions = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
 
-    for (const call of callExpressions) {
-        const expr = call.getExpression();
+  for (const call of callExpressions) {
+    const expr = call.getExpression();
 
-        // React.memo(...)
-        if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
-            const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
-            if (
-                propAccess.getName() === 'memo' &&
-                propAccess.getExpression().getText() === 'React'
-            ) {
-                return true;
-            }
-        }
-
-        // memo(...) — imported directly
-        if (expr.getKind() === SyntaxKind.Identifier && expr.getText() === 'memo') {
-            return true;
-        }
+    // React.memo(...)
+    if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+      if (propAccess.getName() === 'memo' && propAccess.getExpression().getText() === 'React') {
+        return true;
+      }
     }
 
-    return false;
+    // memo(...) — imported directly
+    if (expr.getKind() === SyntaxKind.Identifier && expr.getText() === 'memo') {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**
  * Compute component metrics for a .tsx file.
  */
 function computeComponentMetrics(sourceFile: SourceFile): ComponentMetrics {
-    const jsxLineCount = countJsxLines(sourceFile);
-    const { hookCallCount, hookNames } = collectHookCalls(sourceFile);
-    const usesReactMemo = detectReactMemo(sourceFile);
+  const jsxLineCount = countJsxLines(sourceFile);
+  const { hookCallCount, hookNames } = collectHookCalls(sourceFile);
+  const usesReactMemo = detectReactMemo(sourceFile);
 
-    return {
-        jsxLineCount,
-        hookCallCount,
-        usesReactMemo,
-        hookNames,
-    };
+  return {
+    jsxLineCount,
+    hookCallCount,
+    usesReactMemo,
+    hookNames,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -379,50 +382,48 @@ function computeComponentMetrics(sourceFile: SourceFile): ComponentMetrics {
  * @returns FileAnalysis with primary export, all exports, re-export status, and component metrics
  */
 export function analyzeFile(file: FileEntry, project: Project): FileAnalysis {
-    let sourceFile: SourceFile | undefined = project.getSourceFile(file.absolutePath);
+  let sourceFile: SourceFile | undefined = project.getSourceFile(file.absolutePath);
 
-    if (!sourceFile) {
-        sourceFile = project.addSourceFileAtPath(file.absolutePath);
-    }
+  if (!sourceFile) {
+    sourceFile = project.addSourceFileAtPath(file.absolutePath);
+  }
 
-    const { exports, hasOwnDeclarations } = collectExports(sourceFile);
+  const { exports, hasOwnDeclarations } = collectExports(sourceFile);
 
-    // A file is re-export-only if it has exports but no own declarations
-    const isReExportOnly = exports.length > 0 && !hasOwnDeclarations;
+  // A file is re-export-only if it has exports but no own declarations
+  const isReExportOnly = exports.length > 0 && !hasOwnDeclarations;
 
-    const stem = fileStem(file.absolutePath);
-    const primaryExport = determinePrimaryExport(exports, stem);
+  const stem = fileStem(file.absolutePath);
+  const primaryExport = determinePrimaryExport(exports, stem);
 
-    // Component metrics only for .tsx files
-    const componentMetrics = file.extension === '.tsx'
-        ? computeComponentMetrics(sourceFile)
-        : null;
+  // Component metrics only for .tsx files
+  const componentMetrics = file.extension === '.tsx' ? computeComponentMetrics(sourceFile) : null;
 
-    return {
-        file,
-        primaryExport,
-        exports,
-        isReExportOnly,
-        componentMetrics,
-    };
+  return {
+    file,
+    primaryExport,
+    exports,
+    isReExportOnly,
+    componentMetrics,
+  };
 }
 
 /**
  * Find the nearest tsconfig.json by walking up from the current directory.
  */
 function findNearestTsConfig(): string | undefined {
-    let dir = process.cwd();
-    const root = path.parse(dir).root;
+  let dir = process.cwd();
+  const root = path.parse(dir).root;
 
-    while (dir !== root) {
-        const candidate = path.join(dir, 'tsconfig.json');
-        if (fs.existsSync(candidate)) {
-            return candidate;
-        }
-        dir = path.dirname(dir);
+  while (dir !== root) {
+    const candidate = path.join(dir, 'tsconfig.json');
+    if (fs.existsSync(candidate)) {
+      return candidate;
     }
+    dir = path.dirname(dir);
+  }
 
-    return undefined;
+  return undefined;
 }
 
 /**
@@ -433,24 +434,24 @@ function findNearestTsConfig(): string | undefined {
  * @returns An object with an `analyze` method that accepts a FileEntry.
  */
 export function createExportAnalyzer(tsConfigPath?: string): {
-    analyze: (file: FileEntry) => FileAnalysis;
+  analyze: (file: FileEntry) => FileAnalysis;
 } {
-    const resolvedTsConfig = tsConfigPath ?? findNearestTsConfig();
+  const resolvedTsConfig = tsConfigPath ?? findNearestTsConfig();
 
-    const project = resolvedTsConfig
-        ? new Project({ tsConfigFilePath: resolvedTsConfig, skipAddingFilesFromTsConfig: true })
-        : new Project({
-            compilerOptions: {
-                target: 99, // ESNext
-                module: 99, // ESNext
-                jsx: 4,     // react-jsx
-                strict: true,
-                esModuleInterop: true,
-                skipLibCheck: true,
-            },
-        });
+  const project = resolvedTsConfig
+    ? new Project({ tsConfigFilePath: resolvedTsConfig, skipAddingFilesFromTsConfig: true })
+    : new Project({
+        compilerOptions: {
+          target: 99, // ESNext
+          module: 99, // ESNext
+          jsx: 4, // react-jsx
+          strict: true,
+          esModuleInterop: true,
+          skipLibCheck: true,
+        },
+      });
 
-    return {
-        analyze: (file: FileEntry): FileAnalysis => analyzeFile(file, project),
-    };
+  return {
+    analyze: (file: FileEntry): FileAnalysis => analyzeFile(file, project),
+  };
 }

--- a/scripts/naming-audit/fileScanner.ts
+++ b/scripts/naming-audit/fileScanner.ts
@@ -1,0 +1,196 @@
+// ============================================================
+// FileScanner -- walks the file system and collects FileEntry[].
+//
+// Resolves glob patterns in targetDirs (e.g. "packages/*/src/")
+// and returns one FileEntry per .ts / .tsx file found, excluding
+// dist/, *.d.ts, and __tests__/ by default.
+// ============================================================
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { FileEntry, FileScannerOptions } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a single target-dir pattern (which may contain `*` wildcards)
+ * into concrete directory paths that exist on disk.
+ */
+function resolveTargetDirs(pattern: string): string[] {
+    const normalized = pattern.replace(/\/+$/, '');
+
+    if (!normalized.includes('*')) {
+        const abs = path.resolve(normalized);
+        return fs.existsSync(abs) ? [abs] : [];
+    }
+
+    const segments = normalized.split('/');
+    const wildcardIdx = segments.findIndex((s) => s.includes('*'));
+
+    const baseDir = path.resolve(segments.slice(0, wildcardIdx).join('/'));
+    if (!fs.existsSync(baseDir)) return [];
+
+    const wildcardSegment = segments[wildcardIdx];
+    const rest = segments.slice(wildcardIdx + 1).join('/');
+
+    // Convert the wildcard segment into a simple regex.
+    const escaped = wildcardSegment.replace(/[.+?^{}()|[\]\\]/g, '\\$&');
+    const regexStr = '^' + escaped.replace(/\*/g, '[^/]+') + '$';
+    const regex = new RegExp(regexStr);
+
+    const entries = fs.readdirSync(baseDir, { withFileTypes: true });
+    const matched: string[] = [];
+
+    for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (!regex.test(entry.name)) continue;
+
+        const candidate = rest
+            ? path.join(baseDir, entry.name, rest)
+            : path.join(baseDir, entry.name);
+
+        if (fs.existsSync(candidate)) {
+            matched.push(candidate);
+        }
+    }
+
+    return matched;
+}
+
+/**
+ * Derive the sub-package identifier from a resolved directory path.
+ *
+ * Heuristic (in order):
+ *   plugins/name/src  -> "name"   (e.g. "shape-plugin")
+ *   packages/name/src -> "name"   (e.g. "core-types")
+ *   app/src           -> "app"
+ *   fallback          -> last meaningful segment
+ */
+function deriveSubPackage(resolvedDir: string): string {
+    const rel = path.relative(process.cwd(), resolvedDir).replace(/\\/g, '/');
+    const parts = rel.split('/');
+
+    // plugins/<name>/src or packages/<name>/src
+    if (
+        parts.length >= 3 &&
+        (parts[0] === 'plugins' || parts[0] === 'packages') &&
+        parts[parts.length - 1] === 'src'
+    ) {
+        return parts[1];
+    }
+
+    // app/src
+    if (parts.length >= 2 && parts[0] === 'app' && parts[1] === 'src') {
+        return 'app';
+    }
+
+    // Fallback: use the parent of "src" if present, otherwise the last segment.
+    const srcIdx = parts.lastIndexOf('src');
+    if (srcIdx > 0) return parts[srcIdx - 1];
+    return parts[parts.length - 1] || 'unknown';
+}
+
+/**
+ * Check whether a file path should be excluded based on the exclude patterns.
+ *
+ * Supported pattern styles:
+ *   "dist/"      -> exclude any path segment named "dist"
+ *   "*.d.ts"     -> exclude files ending with ".d.ts"
+ *   "__tests__/" -> exclude any path segment named "__tests__"
+ */
+function isExcluded(
+    relativePath: string,
+    excludePatterns: readonly string[],
+): boolean {
+    for (const pattern of excludePatterns) {
+        // Directory-style pattern (e.g. "dist/", "__tests__/")
+        if (pattern.endsWith('/')) {
+            const dirName = pattern.slice(0, -1);
+            const segments = relativePath.split('/');
+            if (segments.some((s) => s === dirName)) return true;
+            continue;
+        }
+
+        // Wildcard extension pattern (e.g. "*.d.ts")
+        if (pattern.startsWith('*.')) {
+            const suffix = pattern.slice(1); // ".d.ts"
+            if (relativePath.endsWith(suffix)) return true;
+            continue;
+        }
+
+        // Exact match fallback
+        if (relativePath.includes(pattern)) return true;
+    }
+
+    return false;
+}
+
+/**
+ * Recursively collect all .ts / .tsx files under `dir`.
+ */
+function walkDir(dir: string): string[] {
+    const results: string[] = [];
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            results.push(...walkDir(fullPath));
+        } else if (entry.isFile()) {
+            const ext = path.extname(entry.name);
+            if (ext === '.ts' || ext === '.tsx') {
+                results.push(fullPath);
+            }
+        }
+    }
+
+    return results;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan the file system for .ts / .tsx files matching the given options.
+ *
+ * @param options - target directories (may contain globs) and exclude patterns
+ * @returns an array of FileEntry objects
+ */
+export function scanFiles(options: FileScannerOptions): FileEntry[] {
+    const { targetDirs, excludePatterns } = options;
+    const entries: FileEntry[] = [];
+
+    for (const targetDir of targetDirs) {
+        const resolvedDirs = resolveTargetDirs(targetDir);
+
+        for (const resolvedDir of resolvedDirs) {
+            const subPackage = deriveSubPackage(resolvedDir);
+            const allFiles = walkDir(resolvedDir);
+
+            for (const absPath of allFiles) {
+                const relPath = path
+                    .relative(resolvedDir, absPath)
+                    .replace(/\\/g, '/');
+
+                if (isExcluded(relPath, excludePatterns)) continue;
+
+                const ext = path.extname(absPath);
+                if (ext !== '.ts' && ext !== '.tsx') continue;
+
+                entries.push({
+                    absolutePath: absPath,
+                    relativePath: relPath,
+                    subPackage,
+                    extension: ext as '.ts' | '.tsx',
+                });
+            }
+        }
+    }
+
+    return entries;
+}

--- a/scripts/naming-audit/ruleEngine.ts
+++ b/scripts/naming-audit/ruleEngine.ts
@@ -1,0 +1,76 @@
+// ============================================================
+// RuleEngine — orchestrates all naming-audit rules and applies
+// the RouterExceptionFilter to downgrade violations in router-
+// convention paths from 'error' to 'warning'.
+//
+// Requirements: 1.1, 1.4
+// ============================================================
+
+import type { FileAnalysis, Rule, RuleEngineConfig, Violation } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Router exception filter
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a file path falls under one of the router exception
+ * paths. Uses a simple prefix match against the file's relativePath
+ * (which is relative to the sub-package root, e.g. "src/router/...").
+ *
+ * The config paths are normalised to strip trailing slashes and use
+ * forward slashes for consistent matching.
+ */
+function isRouterException(relativePath: string, exceptionPaths: readonly string[]): boolean {
+  const normalised = relativePath.replace(/\\/g, '/');
+  return exceptionPaths.some((exPath) => {
+    const normEx = exPath
+      .replace(/\\/g, '/')
+      .replace(/\/\*\*$/, '')
+      .replace(/\/$/, '');
+    return normalised.startsWith(`${normEx}/`) || normalised === normEx;
+  });
+}
+
+/**
+ * Downgrade a violation's severity from 'error' to 'warning' when
+ * the file is inside a router exception path.
+ */
+function applyRouterException(violation: Violation, exceptionPaths: readonly string[]): Violation {
+  if (violation.severity !== 'error') return violation;
+  if (!isRouterException(violation.file.relativePath, exceptionPaths)) return violation;
+
+  return {
+    ...violation,
+    severity: 'warning',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate all rules against a set of file analyses.
+ *
+ * 1. Each rule is applied to each analysis.
+ * 2. Router exception paths downgrade 'error' → 'warning'.
+ * 3. Results are returned as a flat array of violations.
+ */
+export function evaluateRules(
+  analyses: readonly FileAnalysis[],
+  rules: readonly Rule[],
+  config: RuleEngineConfig
+): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const analysis of analyses) {
+    for (const rule of rules) {
+      const ruleViolations = rule.evaluate(analysis);
+      for (const v of ruleViolations) {
+        violations.push(applyRouterException(v, config.routerExceptionPaths));
+      }
+    }
+  }
+
+  return violations;
+}

--- a/scripts/naming-audit/rules/implSuffixRule.ts
+++ b/scripts/naming-audit/rules/implSuffixRule.ts
@@ -1,0 +1,193 @@
+// ============================================================
+// ImplSuffixRule — Pattern 4: Inappropriate .core.ts / .internal.ts / .impl.ts usage
+//
+// Detects implementation-detail suffixes (.core.ts, .internal.ts,
+// .impl.ts) that are used without proper justification:
+//   - .core.ts must only be used for algorithm-core extraction
+//   - .internal.ts must only be used for same-directory private impl
+//   - .impl.ts must only be used for interface implementation swap points
+//
+// When a suffix is used inappropriately (e.g. a hook internal
+// implementation labelled as .core.ts), suggests a domain-specific
+// rename or relocation into a sub-directory.
+//
+// Requirements: 1.2, 4.1, 4.4
+// ============================================================
+
+import path from 'node:path';
+
+import type { FileAnalysis, Rule, Violation } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Suffix detection
+// ---------------------------------------------------------------------------
+
+type ImplSuffix = 'core' | 'internal' | 'impl';
+
+const IMPL_SUFFIX_REGEX = /^(.+)\.(core|internal|impl)\.[^.]+$/;
+
+/**
+ * Parse the implementation-detail suffix from a file basename.
+ * Returns the stem (without the suffix) and the suffix kind, or
+ * `null` when the file does not use an impl suffix.
+ */
+export function parseImplSuffix(baseName: string): { stem: string; suffix: ImplSuffix } | null {
+    const match = baseName.match(IMPL_SUFFIX_REGEX);
+    if (!match) return null;
+    return { stem: match[1], suffix: match[2] as ImplSuffix };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic: is the file likely an algorithm core?
+// ---------------------------------------------------------------------------
+
+/**
+ * A `.core.ts` file is considered legitimate when it contains
+ * pure algorithmic logic — i.e. it exports only functions (no
+ * hooks, no React, no side-effects) and is NOT a re-export wrapper.
+ *
+ * Hook files (stem starts with "use") are never legitimate .core.ts
+ * because the guideline says hook internals should live in a
+ * sub-directory, not use the .core.ts suffix.
+ */
+export function isLegitimateCoreSuffix(analysis: FileAnalysis, stem: string): boolean {
+    // Re-export wrappers are never legitimate .core.ts
+    if (analysis.isReExportOnly) return false;
+
+    // Hook files should use sub-directory, not .core.ts
+    if (stem.startsWith('use')) return false;
+
+    // Must have own (non-reExport) exports
+    const ownExports = analysis.exports.filter((e) => e.kind !== 'reExport');
+    if (ownExports.length === 0) return false;
+
+    // All own exports must be pure functions — no types, classes, consts
+    // (types are fine alongside functions, but the primary must be functions)
+    const hasFunctions = ownExports.some((e) => e.kind === 'function');
+    const hasNonFunctionValues = ownExports.some(
+        (e) => e.kind !== 'function' && e.kind !== 'type' && e.kind !== 'interface',
+    );
+
+    return hasFunctions && !hasNonFunctionValues;
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic: is the file a legitimate .internal.ts?
+// ---------------------------------------------------------------------------
+
+/**
+ * A `.internal.ts` file is legitimate when it is NOT a re-export
+ * wrapper and actually contains own exports (private implementation
+ * within the same directory).
+ */
+export function isLegitimateInternalSuffix(analysis: FileAnalysis): boolean {
+    if (analysis.isReExportOnly) return false;
+    const ownExports = analysis.exports.filter((e) => e.kind !== 'reExport');
+    return ownExports.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic: is the file a legitimate .impl.ts?
+// ---------------------------------------------------------------------------
+
+/**
+ * A `.impl.ts` file is legitimate when it is NOT a re-export
+ * wrapper and contains own exports (interface implementation).
+ */
+export function isLegitimateImplSuffix(analysis: FileAnalysis): boolean {
+    if (analysis.isReExportOnly) return false;
+    const ownExports = analysis.exports.filter((e) => e.kind !== 'reExport');
+    return ownExports.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Suggested rename generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a suggested rename for a file with an inappropriate impl suffix.
+ *
+ * Strategy:
+ *   - Hook .core.ts → move to sub-directory: `<stem>/<stem>.ts`
+ *   - Re-export .core.ts → delete wrapper, rename target
+ *   - Other .core.ts / .internal.ts / .impl.ts → drop suffix: `<stem>.ts`
+ */
+export function buildSuggestedRename(
+    stem: string,
+    suffix: ImplSuffix,
+    extension: string,
+    isReExportOnly: boolean,
+): string {
+    if (suffix === 'core' && stem.startsWith('use')) {
+        // Hook internal implementation → sub-directory
+        return `${stem}/${stem}${extension}`;
+    }
+
+    if (isReExportOnly) {
+        // Re-export wrapper → delete this file, rename the target
+        return `(delete wrapper, rename target to ${stem}${extension})`;
+    }
+
+    // Default: drop the suffix
+    return `${stem}${extension}`;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+export const implSuffixRule: Rule = {
+    name: 'ImplSuffixRule',
+
+    evaluate(analysis: FileAnalysis): Violation[] {
+        const { file } = analysis;
+        const baseName = path.basename(file.absolutePath);
+
+        const parsed = parseImplSuffix(baseName);
+        if (!parsed) return [];
+
+        const { stem, suffix } = parsed;
+
+        // --- Evaluate legitimacy per suffix kind ---
+
+        switch (suffix) {
+            case 'core': {
+                if (isLegitimateCoreSuffix(analysis, stem)) return [];
+                break;
+            }
+            case 'internal': {
+                if (isLegitimateInternalSuffix(analysis)) return [];
+                break;
+            }
+            case 'impl': {
+                if (isLegitimateImplSuffix(analysis)) return [];
+                break;
+            }
+        }
+
+        // --- Build violation ---
+
+        const suggestedRename = buildSuggestedRename(
+            stem,
+            suffix,
+            file.extension,
+            analysis.isReExportOnly,
+        );
+
+        const reason = analysis.isReExportOnly
+            ? `is a re-export wrapper with .${suffix}.ts suffix`
+            : stem.startsWith('use')
+                ? `is a hook internal implementation using .${suffix}.ts (move to sub-directory instead)`
+                : `uses .${suffix}.ts without clear justification`;
+
+        return [
+            {
+                file,
+                pattern: 4,
+                severity: 'error',
+                message: `File "${baseName}" ${reason}. Suggested: "${suggestedRename}".`,
+                suggestedRename,
+            },
+        ];
+    },
+};

--- a/scripts/naming-audit/rules/primaryExportRule.ts
+++ b/scripts/naming-audit/rules/primaryExportRule.ts
@@ -1,0 +1,84 @@
+// ============================================================
+// PrimaryExportRule — Pattern 1: Primary_Export mismatch
+//
+// Checks whether the file stem matches the primary export
+// symbol name. When they don't match, suggests renaming the
+// file to match the primary export.
+// ============================================================
+
+import path from 'node:path';
+
+import type { FileAnalysis, Rule, Violation } from '../types.js';
+
+/**
+ * Extract the stem (name without extension) from a file path.
+ * Handles double extensions like .core.ts, .internal.ts, .impl.ts.
+ */
+function fileStem(filePath: string): string {
+    const base = path.basename(filePath);
+    const match = base.match(/^(.+?)\.(?:core|internal|impl)?\.[^.]+$/);
+    if (match) return match[1];
+    return path.parse(base).name;
+}
+
+/**
+ * Determine the expected file name based on the primary export name
+ * and the original file extension.
+ */
+function buildExpectedFileName(primaryExportName: string, extension: string): string {
+    return `${primaryExportName}${extension}`;
+}
+
+export const primaryExportRule: Rule = {
+    name: 'PrimaryExportRule',
+
+    evaluate(analysis: FileAnalysis): Violation[] {
+        const { file, primaryExport, exports, isReExportOnly } = analysis;
+
+        // Skip index.ts files — they are re-export entry points
+        const baseName = path.basename(file.absolutePath);
+        if (baseName === 'index.ts' || baseName === 'index.tsx') {
+            return [];
+        }
+
+        // Skip re-export-only files — handled by ViewPatternRule
+        if (isReExportOnly) {
+            return [];
+        }
+
+        // Skip files with no exports
+        if (exports.length === 0 || primaryExport === null) {
+            return [];
+        }
+
+        const stem = fileStem(file.absolutePath);
+        const primaryName = primaryExport.name;
+
+        // Skip wildcard re-exports that resolved as primary
+        if (primaryName === '*') {
+            return [];
+        }
+
+        // For .tsx files: exact (PascalCase) match required
+        // For .ts files: case-insensitive match (hooks are camelCase, e.g. useXxx.ts)
+        const matches = file.extension === '.tsx'
+            ? stem === primaryName
+            : stem.toLowerCase() === primaryName.toLowerCase();
+
+        if (matches) {
+            return [];
+        }
+
+        const suggestedRename = buildExpectedFileName(primaryName, file.extension);
+
+        return [
+            {
+                file,
+                pattern: 1,
+                severity: 'error',
+                message: `File "${baseName}" does not match primary export "${primaryName}". Expected "${suggestedRename}".`,
+                suggestedRename,
+            },
+        ];
+    },
+};

--- a/scripts/naming-audit/rules/roleSuffixRule.ts
+++ b/scripts/naming-audit/rules/roleSuffixRule.ts
@@ -1,0 +1,224 @@
+// ============================================================
+// RoleSuffixRule — Pattern 2: Role suffix inconsistency
+//
+// Checks whether single-role files (types-only, constants-only,
+// utils-only) use the correct normalised suffix. Also flags
+// banned generic file names (helper.ts, common.ts, etc.).
+// ============================================================
+
+import path from 'node:path';
+
+import type { ExportInfo, FileAnalysis, Rule, Violation } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Banned generic names → suggested replacement
+// ---------------------------------------------------------------------------
+
+const BANNED_GENERIC_NAMES: ReadonlyMap<string, string> = new Map([
+    ['helper', 'utils'],
+    ['helpers', 'utils'],
+    ['common', null!],   // needs domain prefix — handled below
+    ['shared', null!],
+    ['misc', null!],
+    ['temp', null!],
+]);
+
+// ---------------------------------------------------------------------------
+// Role detection helpers
+// ---------------------------------------------------------------------------
+
+type SingleRole = 'types' | 'constants' | 'utils';
+
+/**
+ * Determine whether a file is a "single-role" file based on its
+ * non-reExport exports. Returns the detected role or `null` when
+ * the file has mixed roles or no qualifying exports.
+ */
+export function detectSingleRole(exports: readonly ExportInfo[]): SingleRole | null {
+    // Filter out re-exports — only look at "own" exports
+    const own = exports.filter((e) => e.kind !== 'reExport');
+
+    if (own.length === 0) return null;
+
+    // Types-only: every export is 'type' or 'interface'
+    const allTypes = own.every((e) => e.kind === 'type' || e.kind === 'interface');
+    if (allTypes) return 'types';
+
+    // Constants-only: every export is 'const' AND none are functions
+    const allConsts = own.every((e) => e.kind === 'const');
+    const anyFunction = own.some((e) => e.kind === 'function');
+    if (allConsts && !anyFunction) return 'constants';
+
+    // Utils-only: every export is 'function' (pure functions)
+    const allFunctions = own.every((e) => e.kind === 'function');
+    if (allFunctions) return 'utils';
+
+    return null; // mixed roles
+}
+
+// ---------------------------------------------------------------------------
+// Suffix validation helpers
+// ---------------------------------------------------------------------------
+
+const ROLE_SUFFIX_MAP: Record<SingleRole, { suffix: string; standalone: string }> = {
+    types: { suffix: 'Types', standalone: 'types' },
+    constants: { suffix: 'Constants', standalone: 'constants' },
+    utils: { suffix: 'Utils', standalone: 'utils' },
+};
+
+/**
+ * Check whether the file stem already has the correct suffix for
+ * the given role.
+ *
+ * Valid patterns:
+ *   - stem ends with the PascalCase suffix (e.g. "shapeDialogStepTypes")
+ *   - stem is exactly the standalone name (e.g. "types")
+ */
+export function hasCorrectSuffix(stem: string, role: SingleRole): boolean {
+    const { suffix, standalone } = ROLE_SUFFIX_MAP[role];
+    return stem.endsWith(suffix) || stem === standalone;
+}
+
+// ---------------------------------------------------------------------------
+// Suggested rename generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a suggested file name for a file that should have a role suffix.
+ *
+ * Strategy:
+ *   - Strip known wrong suffixes (Props, Defs, Helpers, etc.)
+ *   - Append the correct role suffix in camelCase
+ *   - If the stem is a banned generic name, replace entirely
+ */
+export function buildSuggestedRename(
+    stem: string,
+    role: SingleRole,
+    dirName: string,
+): string {
+    const { suffix, standalone } = ROLE_SUFFIX_MAP[role];
+
+    // If the stem is a banned generic name, try to use the standalone form
+    // or prefix with directory name as domain
+    const lowerStem = stem.toLowerCase();
+    if (BANNED_GENERIC_NAMES.has(lowerStem)) {
+        // helper/helpers → utils; common/shared/misc/temp → <domain>Suffix
+        if (lowerStem === 'helper' || lowerStem === 'helpers') {
+            return `${standalone}.ts`;
+        }
+        // For other banned names, use directory name as domain prefix
+        const domain = sanitiseDomain(dirName);
+        if (domain) {
+            return `${domain}${suffix}.ts`;
+        }
+        return `${standalone}.ts`;
+    }
+
+    // Strip known wrong suffixes to extract the domain prefix
+    const domain = stripWrongSuffix(stem);
+
+    if (domain) {
+        // Ensure camelCase: first char lowercase
+        const camelDomain = domain.charAt(0).toLowerCase() + domain.slice(1);
+        return `${camelDomain}${suffix}.ts`;
+    }
+
+    // Fallback: just append the suffix
+    const camelStem = stem.charAt(0).toLowerCase() + stem.slice(1);
+    return `${camelStem}${suffix}.ts`;
+}
+
+/** Known wrong suffixes that indicate a role but don't match the convention. */
+const WRONG_SUFFIXES = [
+    'Props', 'Defs', 'Definitions', 'Interfaces',
+    'Helpers', 'Helper',
+    'Consts', 'Config',
+];
+
+function stripWrongSuffix(stem: string): string | null {
+    for (const wrong of WRONG_SUFFIXES) {
+        if (stem.endsWith(wrong) && stem.length > wrong.length) {
+            return stem.slice(0, -wrong.length);
+        }
+    }
+    return null;
+}
+
+function sanitiseDomain(dirName: string): string {
+    // Convert kebab-case directory name to camelCase domain prefix
+    return dirName
+        .split('-')
+        .map((part, i) => (i === 0 ? part.toLowerCase() : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()))
+        .join('');
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+export const roleSuffixRule: Rule = {
+    name: 'RoleSuffixRule',
+
+    evaluate(analysis: FileAnalysis): Violation[] {
+        const { file, exports, primaryExport, isReExportOnly } = analysis;
+        const baseName = path.basename(file.absolutePath);
+        const stem = path.parse(baseName).name;
+        const dirName = path.basename(path.dirname(file.absolutePath));
+
+        // --- Skip conditions ---
+
+        // Skip .tsx files (components, not role files)
+        if (file.extension === '.tsx') return [];
+
+        // Skip index.ts files
+        if (stem === 'index') return [];
+
+        // Skip files with no exports or only re-exports
+        if (exports.length === 0 || isReExportOnly) return [];
+
+        // Skip hook files (primary export starts with "use")
+        if (primaryExport && primaryExport.name.startsWith('use')) return [];
+
+        const violations: Violation[] = [];
+
+        // --- Check banned generic names first ---
+        const lowerStem = stem.toLowerCase();
+        if (BANNED_GENERIC_NAMES.has(lowerStem)) {
+            const role = detectSingleRole(exports);
+            const suggestedRename = role
+                ? buildSuggestedRename(stem, role, dirName)
+                : `${sanitiseDomain(dirName) || stem}Utils.ts`;
+
+            violations.push({
+                file,
+                pattern: 2,
+                severity: 'error',
+                message: `Banned generic file name "${baseName}". Rename to "${suggestedRename}" or a more descriptive domain-specific name.`,
+                suggestedRename,
+            });
+            return violations;
+        }
+
+        // --- Detect single role and validate suffix ---
+        const role = detectSingleRole(exports);
+
+        // Skip files with mixed roles or no detectable single role
+        if (role === null) return [];
+
+        // Skip files that already have the correct suffix
+        if (hasCorrectSuffix(stem, role)) return [];
+
+        const suggestedRename = buildSuggestedRename(stem, role, dirName);
+        const { suffix, standalone } = ROLE_SUFFIX_MAP[role];
+
+        violations.push({
+            file,
+            pattern: 2,
+            severity: 'error',
+            message: `File "${baseName}" contains only ${role} but does not use the "*${suffix}.ts" or "${standalone}.ts" suffix. Rename to "${suggestedRename}".`,
+            suggestedRename,
+        });
+
+        return violations;
+    },
+};

--- a/scripts/naming-audit/rules/roleSuffixRule.ts
+++ b/scripts/naming-audit/rules/roleSuffixRule.ts
@@ -14,14 +14,7 @@ import type { ExportInfo, FileAnalysis, Rule, Violation } from '../types.js';
 // Banned generic names → suggested replacement
 // ---------------------------------------------------------------------------
 
-const BANNED_GENERIC_NAMES = new Set([
-    'helper',
-    'helpers',
-    'common',
-    'shared',
-    'misc',
-    'temp',
-]);
+const BANNED_GENERIC_NAMES = new Set(['helper', 'helpers', 'common', 'shared', 'misc', 'temp']);
 
 // ---------------------------------------------------------------------------
 // Role detection helpers
@@ -91,11 +84,7 @@ export function hasCorrectSuffix(stem: string, role: SingleRole): boolean {
  *   - Append the correct role suffix in camelCase
  *   - If the stem is a banned generic name, replace entirely
  */
-export function buildSuggestedRename(
-    stem: string,
-    role: SingleRole,
-    dirName: string,
-): string {
+export function buildSuggestedRename(stem: string, role: SingleRole, dirName: string): string {
     const { suffix, standalone } = ROLE_SUFFIX_MAP[role];
 
     // If the stem is a banned generic name, try to use the standalone form
@@ -130,9 +119,14 @@ export function buildSuggestedRename(
 
 /** Known wrong suffixes that indicate a role but don't match the convention. */
 const WRONG_SUFFIXES = [
-    'Props', 'Defs', 'Definitions', 'Interfaces',
-    'Helpers', 'Helper',
-    'Consts', 'Config',
+    'Props',
+    'Defs',
+    'Definitions',
+    'Interfaces',
+    'Helpers',
+    'Helper',
+    'Consts',
+    'Config',
 ];
 
 function stripWrongSuffix(stem: string): string | null {
@@ -148,7 +142,9 @@ function sanitiseDomain(dirName: string): string {
     // Convert kebab-case directory name to camelCase domain prefix
     return dirName
         .split('-')
-        .map((part, i) => (i === 0 ? part.toLowerCase() : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()))
+        .map((part, i) =>
+            i === 0 ? part.toLowerCase() : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+        )
         .join('');
 }
 

--- a/scripts/naming-audit/rules/roleSuffixRule.ts
+++ b/scripts/naming-audit/rules/roleSuffixRule.ts
@@ -14,13 +14,13 @@ import type { ExportInfo, FileAnalysis, Rule, Violation } from '../types.js';
 // Banned generic names → suggested replacement
 // ---------------------------------------------------------------------------
 
-const BANNED_GENERIC_NAMES: ReadonlyMap<string, string> = new Map([
-    ['helper', 'utils'],
-    ['helpers', 'utils'],
-    ['common', null!],   // needs domain prefix — handled below
-    ['shared', null!],
-    ['misc', null!],
-    ['temp', null!],
+const BANNED_GENERIC_NAMES = new Set([
+    'helper',
+    'helpers',
+    'common',
+    'shared',
+    'misc',
+    'temp',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/scripts/naming-audit/rules/separationThresholdRule.ts
+++ b/scripts/naming-audit/rules/separationThresholdRule.ts
@@ -90,7 +90,8 @@ export const separationThresholdRule: Rule = {
     if (componentMetrics === null) return [];
 
     // --- Skip files that already use React.memo (likely already separated) ---
-    if (componentMetrics.usesReactMemo) return [];
+    // Only skip if it uses React.memo AND does not exceed thresholds
+    if (componentMetrics.usesReactMemo && !exceedsThreshold(componentMetrics)) return [];
 
     // --- Skip *View.tsx files (already presentational) ---
     const stem = fileStem(file.absolutePath);

--- a/scripts/naming-audit/rules/separationThresholdRule.ts
+++ b/scripts/naming-audit/rules/separationThresholdRule.ts
@@ -1,0 +1,119 @@
+// ============================================================
+// SeparationThresholdRule — Container/Presentational separation threshold
+//
+// Reports .tsx components that exceed the separation threshold:
+//   - JSX line count > 50, OR
+//   - Hook call count > 2
+//
+// These components are candidates for splitting into:
+//   ComponentName.tsx (Container)
+//   ComponentNameView.tsx (Presentational)
+//   useComponentNameState.ts (State hook)
+//
+// Requirements: 1.2, 7.4
+// ============================================================
+
+import path from 'node:path';
+
+import type { ComponentMetrics, FileAnalysis, Rule, Violation } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Thresholds (from design doc / requirements 7.4)
+// ---------------------------------------------------------------------------
+
+/** Maximum JSX lines before separation is recommended. */
+export const JSX_LINE_THRESHOLD = 50;
+
+/** Maximum hook calls before separation is recommended. */
+export const HOOK_CALL_THRESHOLD = 2;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fileStem(filePath: string): string {
+  return path.parse(path.basename(filePath)).name;
+}
+
+/**
+ * Determine whether a component exceeds the separation threshold.
+ *
+ * Returns true when:
+ *   - jsxLineCount > JSX_LINE_THRESHOLD, OR
+ *   - hookCallCount > HOOK_CALL_THRESHOLD
+ */
+export function exceedsThreshold(metrics: ComponentMetrics): boolean {
+  return metrics.jsxLineCount > JSX_LINE_THRESHOLD || metrics.hookCallCount > HOOK_CALL_THRESHOLD;
+}
+
+/**
+ * Build a human-readable reason string describing which thresholds
+ * were exceeded.
+ */
+function buildReason(metrics: ComponentMetrics): string {
+  const parts: string[] = [];
+
+  if (metrics.jsxLineCount > JSX_LINE_THRESHOLD) {
+    parts.push(`JSX lines: ${metrics.jsxLineCount} (threshold: ${JSX_LINE_THRESHOLD})`);
+  }
+  if (metrics.hookCallCount > HOOK_CALL_THRESHOLD) {
+    parts.push(`hook calls: ${metrics.hookCallCount} (threshold: ${HOOK_CALL_THRESHOLD})`);
+  }
+
+  return parts.join(', ');
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+export const separationThresholdRule: Rule = {
+  name: 'SeparationThresholdRule',
+
+  evaluate(analysis: FileAnalysis): Violation[] {
+    const { file, componentMetrics, isReExportOnly, exports } = analysis;
+
+    // --- Only applies to .tsx files ---
+    if (file.extension !== '.tsx') return [];
+
+    // --- Skip index.tsx ---
+    const baseName = path.basename(file.absolutePath);
+    if (baseName === 'index.tsx') return [];
+
+    // --- Skip re-export wrappers (handled by ViewPatternRule) ---
+    if (isReExportOnly) return [];
+
+    // --- Skip files with no exports ---
+    if (exports.length === 0) return [];
+
+    // --- Skip files without component metrics ---
+    if (componentMetrics === null) return [];
+
+    // --- Skip files that already use React.memo (likely already separated) ---
+    if (componentMetrics.usesReactMemo) return [];
+
+    // --- Skip *View.tsx files (already presentational) ---
+    const stem = fileStem(file.absolutePath);
+    if (stem.endsWith('View')) return [];
+
+    // --- Check threshold ---
+    if (!exceedsThreshold(componentMetrics)) return [];
+
+    const reason = buildReason(componentMetrics);
+    const suggestedContainer = `${stem}.tsx`;
+    const suggestedView = `${stem}View.tsx`;
+    const suggestedHook = `use${stem.charAt(0).toUpperCase()}${stem.slice(1)}State.ts`;
+
+    return [
+      {
+        file,
+        pattern: 5,
+        severity: 'warning',
+        message:
+          `Component "${baseName}" exceeds separation threshold (${reason}). ` +
+          `Consider splitting into ${suggestedContainer} + ${suggestedView} + ${suggestedHook}.`,
+        suggestedRename: `${suggestedContainer} + ${suggestedView} + ${suggestedHook}`,
+      },
+    ];
+  },
+};

--- a/scripts/naming-audit/rules/separationThresholdRule.ts
+++ b/scripts/naming-audit/rules/separationThresholdRule.ts
@@ -89,8 +89,7 @@ export const separationThresholdRule: Rule = {
     // --- Skip files without component metrics ---
     if (componentMetrics === null) return [];
 
-    // --- Skip files that already use React.memo (likely already separated) ---
-    // Only skip if it uses React.memo AND does not exceed thresholds
+    // --- Skip files that already use React.memo AND are below thresholds ---
     if (componentMetrics.usesReactMemo && !exceedsThreshold(componentMetrics)) return [];
 
     // --- Skip *View.tsx files (already presentational) ---

--- a/scripts/naming-audit/rules/viewPatternRule.ts
+++ b/scripts/naming-audit/rules/viewPatternRule.ts
@@ -1,0 +1,166 @@
+// ============================================================
+// ViewPatternRule — Patterns 5 & 6:
+//   Pattern 5: Container/Presentational mixed component
+//   Pattern 6: View suffix missing on presentational component
+//
+// Also detects re-export-only wrapper .tsx files (Pattern B)
+// that should be deleted in favour of the real implementation.
+//
+// Requirements: 1.2, 5.3, 7.1
+// ============================================================
+
+import path from 'node:path';
+
+import type { FileAnalysis, Rule, Violation } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VIEW_SUFFIX_REGEX = /View$/;
+
+/**
+ * Extract the stem (name without extension) from a file path.
+ */
+function fileStem(filePath: string): string {
+  return path.parse(path.basename(filePath)).name;
+}
+
+/**
+ * Check whether a .tsx file is a hook file (primary export starts with "use").
+ * Hook .tsx files are excluded from View pattern checks.
+ */
+function isHookFile(analysis: FileAnalysis): boolean {
+  if (analysis.primaryExport === null) return false;
+  return analysis.primaryExport.name.startsWith('use');
+}
+
+/**
+ * Check whether a .tsx file is an index file.
+ */
+function isIndexFile(filePath: string): boolean {
+  const base = path.basename(filePath);
+  return base === 'index.tsx';
+}
+
+// ---------------------------------------------------------------------------
+// Re-export wrapper detection (Pattern B)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect a re-export-only .tsx wrapper file.
+ *
+ * Pattern B: A .tsx file whose only purpose is to re-export from
+ * another file (typically a *View.tsx). These wrappers should be
+ * deleted and the target file renamed.
+ *
+ * Returns a Violation when the file is a re-export wrapper, or
+ * null when it is not.
+ */
+function detectReExportWrapper(analysis: FileAnalysis): Violation | null {
+  const { file, isReExportOnly, primaryExport } = analysis;
+
+  if (!isReExportOnly) return null;
+
+  const stem = fileStem(file.absolutePath);
+  const baseName = path.basename(file.absolutePath);
+
+  // Build a suggested action: delete this wrapper, rename the target
+  const suggestedRename = primaryExport
+    ? `(delete ${baseName}, rename target to ${primaryExport.name}${file.extension})`
+    : `(delete re-export wrapper ${baseName})`;
+
+  return {
+    file,
+    pattern: 5,
+    severity: 'error',
+    message:
+      `File "${baseName}" is a re-export-only wrapper (Pattern B). ` +
+      `Delete this file and rename the implementation file to "${stem}${file.extension}".`,
+    suggestedRename,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// View suffix detection (Pattern 6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect a presentational .tsx component that is missing the *View.tsx suffix.
+ *
+ * A component is considered presentational when:
+ *   - It is a .tsx file
+ *   - It has componentMetrics (i.e. it contains JSX)
+ *   - It has zero hook calls (hookCallCount === 0)
+ *   - It does NOT already have the *View.tsx suffix
+ *
+ * Returns a Violation when the suffix is missing, or null otherwise.
+ */
+function detectMissingViewSuffix(analysis: FileAnalysis): Violation | null {
+  const { file, componentMetrics } = analysis;
+
+  if (componentMetrics === null) return null;
+
+  // Only flag files with zero hooks — they are purely presentational
+  if (componentMetrics.hookCallCount !== 0) return null;
+
+  const stem = fileStem(file.absolutePath);
+  const baseName = path.basename(file.absolutePath);
+
+  // Already has the View suffix — compliant
+  if (VIEW_SUFFIX_REGEX.test(stem)) return null;
+
+  const suggestedRename = `${stem}View${file.extension}`;
+
+  return {
+    file,
+    pattern: 6,
+    severity: 'error',
+    message:
+      `File "${baseName}" is a presentational component (0 hook calls) ` +
+      `but does not use the "*View.tsx" suffix. Rename to "${suggestedRename}".`,
+    suggestedRename,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+export const viewPatternRule: Rule = {
+  name: 'ViewPatternRule',
+
+  evaluate(analysis: FileAnalysis): Violation[] {
+    const { file, exports } = analysis;
+
+    // --- Only applies to .tsx files ---
+    if (file.extension !== '.tsx') return [];
+
+    // --- Skip index.tsx files ---
+    if (isIndexFile(file.absolutePath)) return [];
+
+    // --- Skip hook files (use*.tsx — though discouraged, they exist) ---
+    if (isHookFile(analysis)) return [];
+
+    // --- Skip files with no exports ---
+    if (exports.length === 0) return [];
+
+    const violations: Violation[] = [];
+
+    // --- Check for re-export wrapper (Pattern B → Pattern 5) ---
+    const wrapperViolation = detectReExportWrapper(analysis);
+    if (wrapperViolation !== null) {
+      violations.push(wrapperViolation);
+      // Re-export wrappers don't need further checks
+      return violations;
+    }
+
+    // --- Check for missing View suffix (Pattern 6) ---
+    const viewSuffixViolation = detectMissingViewSuffix(analysis);
+    if (viewSuffixViolation !== null) {
+      violations.push(viewSuffixViolation);
+    }
+
+    return violations;
+  },
+};

--- a/scripts/naming-audit/types.ts
+++ b/scripts/naming-audit/types.ts
@@ -1,0 +1,141 @@
+// ============================================================
+// Core type definitions for the naming-audit tool.
+// ============================================================
+
+// ---------------------------------------------------------------------------
+// FileScanner types
+// ---------------------------------------------------------------------------
+
+/** A single file discovered by the scanner. */
+export interface FileEntry {
+    /** Absolute path to the file */
+    readonly absolutePath: string;
+    /** Path relative to the sub-package root (e.g., "src/ui/components/Foo.tsx") */
+    readonly relativePath: string;
+    /** Sub-package identifier (e.g., "shape-plugin", "app") */
+    readonly subPackage: string;
+    /** File extension: ".ts" | ".tsx" */
+    readonly extension: '.ts' | '.tsx';
+}
+
+/** Options passed to the file scanner. */
+export interface FileScannerOptions {
+    /** Target directories to scan */
+    readonly targetDirs: readonly string[];
+    /** Glob patterns to exclude */
+    readonly excludePatterns: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// ExportAnalyzer types
+// ---------------------------------------------------------------------------
+
+/** The syntactic kind of an exported symbol. */
+export type ExportKind = 'function' | 'class' | 'const' | 'type' | 'interface' | 'enum' | 'reExport';
+
+/** Metadata for a single export from a file. */
+export interface ExportInfo {
+    readonly name: string;
+    readonly kind: ExportKind;
+    readonly isDefault: boolean;
+}
+
+/** Metrics collected from a .tsx component file. */
+export interface ComponentMetrics {
+    readonly jsxLineCount: number;
+    readonly hookCallCount: number;
+    readonly usesReactMemo: boolean;
+    readonly hookNames: readonly string[];
+}
+
+/** Full analysis result for a single file. */
+export interface FileAnalysis {
+    readonly file: FileEntry;
+    /** Primary export: the main symbol exported from this file */
+    readonly primaryExport: ExportInfo | null;
+    /** All exports from this file */
+    readonly exports: readonly ExportInfo[];
+    /** Whether this file is a re-export-only wrapper */
+    readonly isReExportOnly: boolean;
+    /** For .tsx files: number of JSX lines, hook call count */
+    readonly componentMetrics: ComponentMetrics | null;
+}
+
+// ---------------------------------------------------------------------------
+// RuleEngine types
+// ---------------------------------------------------------------------------
+
+/** Severity level of a detected violation. */
+export type Severity = 'error' | 'warning';
+
+/**
+ * Inconsistency pattern identifier.
+ *
+ * 1 – Primary export name ≠ file name
+ * 2 – Role suffix not normalised
+ * 3 – (reserved)
+ * 4 – Inappropriate .core.ts / .internal.ts / .impl.ts usage
+ * 5 – Container/Presentational mixed
+ * 6 – View suffix missing on presentational component
+ */
+export type InconsistencyPattern = 1 | 2 | 3 | 4 | 5 | 6;
+
+/** A single naming-convention violation detected by a rule. */
+export interface Violation {
+    readonly file: FileEntry;
+    readonly pattern: InconsistencyPattern;
+    readonly severity: Severity;
+    readonly message: string;
+    readonly suggestedRename: string;
+}
+
+/** A rule that can evaluate a file analysis and produce violations. */
+export interface Rule {
+    readonly name: string;
+    evaluate(analysis: FileAnalysis): Violation[];
+}
+
+/** Configuration for the rule engine. */
+export interface RuleEngineConfig {
+    /** Paths to treat as router-convention exceptions (warning instead of error) */
+    readonly routerExceptionPaths: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Data-model types
+// ---------------------------------------------------------------------------
+
+/** Classification of a file's role based on its content and naming. */
+export type FileRole =
+    | 'component'
+    | 'view'
+    | 'container'
+    | 'hook'
+    | 'stateHook'
+    | 'types'
+    | 'constants'
+    | 'utils'
+    | 'validators'
+    | 'index'
+    | 'internal'
+    | 'impl'
+    | 'core'
+    | 'other';
+
+/** Result of classifying a single file. */
+export interface FileClassification {
+    readonly file: FileEntry;
+    readonly detectedRole: FileRole;
+    readonly expectedRole: FileRole;
+    readonly primaryExportName: string | null;
+    readonly expectedFileName: string | null;
+}
+
+/** Audit summary for a sub-package. */
+export interface AuditSummary {
+    readonly subPackage: string;
+    readonly totalFiles: number;
+    readonly violations: readonly Violation[];
+    readonly warnings: readonly Violation[];
+    readonly compliant: number;
+}

--- a/scripts/naming-audit/violationReporter.ts
+++ b/scripts/naming-audit/violationReporter.ts
@@ -1,0 +1,100 @@
+// ============================================================
+// ViolationReporter — formats and outputs detected violations.
+//
+// Supports two output formats:
+//   - "table": human-readable console table
+//   - "json":  machine-readable JSON array
+//
+// Exit codes:
+//   0 — no error-level violations (warnings are allowed)
+//   1 — at least one error-level violation detected
+//
+// Requirements: 1.1, 1.2, 1.3
+// ============================================================
+
+import type { Violation } from './types.js';
+
+// ---------------------------------------------------------------------------
+// JSON reporter
+// ---------------------------------------------------------------------------
+
+function reportJson(violations: readonly Violation[]): void {
+  const output = violations.map((v) => ({
+    file: v.file.relativePath,
+    subPackage: v.file.subPackage,
+    pattern: v.pattern,
+    severity: v.severity,
+    message: v.message,
+    suggestedRename: v.suggestedRename,
+  }));
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Table reporter
+// ---------------------------------------------------------------------------
+
+function severityIcon(severity: 'error' | 'warning'): string {
+  return severity === 'error' ? '✖' : '⚠';
+}
+
+function reportTable(violations: readonly Violation[]): void {
+  if (violations.length === 0) {
+    console.log('✔ No naming violations found.');
+    return;
+  }
+
+  // Group by sub-package for readability
+  const grouped = new Map<string, Violation[]>();
+  for (const v of violations) {
+    const key = v.file.subPackage;
+    const list = grouped.get(key);
+    if (list) {
+      list.push(v);
+    } else {
+      grouped.set(key, [v]);
+    }
+  }
+
+  for (const [subPackage, items] of grouped) {
+    console.log(`\n── ${subPackage} ──`);
+    for (const v of items) {
+      const icon = severityIcon(v.severity);
+      console.log(`  ${icon} [P${v.pattern}] ${v.file.relativePath}`);
+      console.log(`    ${v.message}`);
+      console.log(`    → ${v.suggestedRename}`);
+    }
+  }
+
+  // Summary
+  const errors = violations.filter((v) => v.severity === 'error').length;
+  const warnings = violations.filter((v) => v.severity === 'warning').length;
+  console.log(`\n── Summary ──`);
+  console.log(`  Total: ${violations.length}  Errors: ${errors}  Warnings: ${warnings}`);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Report violations to stdout and return the appropriate exit code.
+ *
+ * @param violations - All detected violations
+ * @param format     - Output format: "json" or "table"
+ * @returns Exit code: 0 if no errors, 1 if error-level violations exist
+ */
+export function reportViolations(
+  violations: readonly Violation[],
+  format: 'json' | 'table'
+): number {
+  if (format === 'json') {
+    reportJson(violations);
+  } else {
+    reportTable(violations);
+  }
+
+  const hasErrors = violations.some((v) => v.severity === 'error');
+  return hasErrors ? 1 : 0;
+}


### PR DESCRIPTION
Closes #1181

## 概要

命名規約違反を検出する Audit Tool の実装と、`.tsx` ファイル命名規約のガイドライン拡張。

## 変更内容

### Audit Tool (`scripts/naming-audit.ts`)
- **FileScanner**: `app/src/`, `packages/*/src/`, `plugins/*-plugin/src/` 配下の `*.ts` / `*.tsx` を走査
- **ExportAnalyzer**: `ts-morph` AST 解析で export 情報・ComponentMetrics を抽出
- **RuleEngine**: 5ルールを統合、RouterExceptionFilter で `app/src/router/**` を warning に降格
- **ViolationReporter**: table / JSON 出力、CI 用 exit code (0=pass, 1=error)
- **進捗表示**: stderr にリアルタイム進捗を出力（TTY 対応）

### 実装済みルール
| パターン | ルール | 検出内容 |
|---|---|---|
| P1 | PrimaryExportRule | ファイル名と主エクスポートの不一致 |
| P2 | RoleSuffixRule | 役割サフィックス不統一 (types/constants/utils) |
| P4 | ImplSuffixRule | .core.ts/.internal.ts/.impl.ts の不適切使用 |
| P5 | ViewPatternRule | re-export ラッパー (Pattern B) |
| P6 | ViewPatternRule | View サフィックス欠落 |
| — | SeparationThresholdRule | 分離閾値超過 (JSX>50 or hooks>2) |

### ガイドライン拡張
- `docs/ts-file-naming-guideline.md`: 対象範囲に `.tsx` 追加、Container/Presentational 分離パターン・View サフィックス・分離閾値を規定
- `AGENTS.md`: 参照更新

## 使い方
```bash
# 全体実行
pnpm tsx scripts/naming-audit.ts

# パッケージ指定
pnpm tsx scripts/naming-audit.ts --target packages/build-session-ports/src

# JSON 出力
pnpm tsx scripts/naming-audit.ts --target plugins/shape-plugin/src --format json

# CI モード
pnpm tsx scripts/naming-audit.ts --ci
```

## ロールバック
```bash
git revert <commit-hash> --no-edit
```