### PR TITLE
fix(yaml-plugin): remove duplicate YamlPluginManifest type export

### DIFF
--- a/plugins/yaml-plugin/src/index.ts
+++ b/plugins/yaml-plugin/src/index.ts
@@ -1,3 +1,2 @@
 export { PLUGIN_MANIFEST as YamlPluginManifest } from './plugin-manifest.js';
-export type { YamlPluginManifest } from './plugin-manifest.js';
 export { YAML_PLUGIN_ID, YAML_PLUGIN_VERSION, YAML_NODE_TYPE } from './plugin-manifest.js';


### PR DESCRIPTION
Closes #1209

値と型の export が重複して typecheck エラーになっていた。型 export を削除。