### PR TITLE
chore(ci): add naming-audit workflow

### DIFF
--- a/.github/workflows/naming-audit.yml
+++ b/.github/workflows/naming-audit.yml
@@ -1,0 +1,44 @@
+name: Naming Audit
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "app/src/**/*.ts"
+      - "app/src/**/*.tsx"
+      - "packages/*/src/**/*.ts"
+      - "packages/*/src/**/*.tsx"
+      - "plugins/*-plugin/src/**/*.ts"
+      - "plugins/*-plugin/src/**/*.tsx"
+      - "scripts/naming-audit/**"
+      - "scripts/naming-audit.ts"
+
+concurrency:
+  group: naming-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  naming-audit:
+    name: Naming Convention Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_path: ./package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install deps
+        run: pnpm install --no-frozen-lockfile --force
+
+      - name: Run naming audit
+        run: pnpm tsx scripts/naming-audit.ts --ci


### PR DESCRIPTION
Closes #1221

PR で `*.ts`/`*.tsx` ファイルが変更された場合に Audit Tool を自動実行。error レベルの違反があれば PR をブロック。