### PR TITLE
fix(shape-plugin): restore disableHoverLift prop in GeometryConfigSectionView

### DIFF
--- a/plugins/shape-plugin/src/ui/components/build-config/GeometryConfigSectionView.tsx
+++ b/plugins/shape-plugin/src/ui/components/build-config/GeometryConfigSectionView.tsx
@@ -27,6 +27,7 @@ export const GeometryConfigSectionView = React.memo<GeometryConfigSectionViewPro
   ({
     t,
     disabled,
+    disableHoverLift,
     hoverCardSx,
     baseGeometryConfig,
     simplifyAlgorithm,
@@ -111,7 +112,7 @@ export const GeometryConfigSectionView = React.memo<GeometryConfigSectionViewPro
             <SimplifyToleranceByAdminLevelCard
               geometryConfig={baseGeometryConfig}
               disabled={disabled}
-              disableHoverLift={disabled}
+              disableHoverLift={disableHoverLift}
               onChange={onGeometryUpdate}
             />
           </Stack>

--- a/plugins/shape-plugin/src/ui/components/build-config/useGeometryConfigSectionState.ts
+++ b/plugins/shape-plugin/src/ui/components/build-config/useGeometryConfigSectionState.ts
@@ -21,6 +21,7 @@ interface GeometryConfigSectionStateProps {
 export interface GeometryConfigSectionViewProps {
     readonly t: TFunction;
     readonly disabled: boolean;
+    readonly disableHoverLift: boolean;
     readonly hoverCardSx: SxProps<Theme>;
     readonly baseGeometryConfig: ShapeBuildGeometryConfig;
     readonly simplifyAlgorithm: 'topojson' | 'geojson';
@@ -59,6 +60,7 @@ export function useGeometryConfigSectionState(
     return {
         t,
         disabled,
+        disableHoverLift,
         hoverCardSx,
         baseGeometryConfig,
         simplifyAlgorithm,


### PR DESCRIPTION
Closes #1232

PR #1225 の Container/Presentational 分離で `disableHoverLift` prop が欠落していたリグレッションを修正。

- `GeometryConfigSectionViewProps` に `disableHoverLift` を追加
- `useGeometryConfigSectionState` の return に `disableHoverLift` を追加
- `SimplifyToleranceByAdminLevelCard` で `disableHoverLift={disableHoverLift}` に修正（`disabled` ではなく）

typecheck: pass